### PR TITLE
Fix incident components relation

### DIFF
--- a/database/migrations/2023_08_23_210836_make_incident_components_table_status_id_column_null.php
+++ b/database/migrations/2023_08_23_210836_make_incident_components_table_status_id_column_null.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('incident_components', function (Blueprint $table) {
+            $table->integer('status_id')->nullable()->change();
+        });
+    }
+};

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -3,8 +3,7 @@
 use Cachet\Models\Incident;
 
 it('can have multiple components', function () {
-    // @todo fix the incident_components relationship.
     $incident = Incident::factory()->hasComponents(2)->create();
 
     expect($incident->components)->toHaveCount(2);
-})->skip('Fix the incident_components relationship.');
+});


### PR DESCRIPTION
in this PR i have noticied the **Component** model and **ComponentStatusEnum**


also i have noticed the migration change in the incidents table... which made me think that this change maybe introduced for backward compatibility when upgrading from older version of cachet

![image](https://github.com/cachethq/core/assets/17250137/94d6e4e5-7829-4ad2-b8d1-38f916111c13)


so based on the above I have modified the **status_id** column on **incident_components** and made it null

hopefully am right about my thoughts 😂 