### PR TITLE
Add Orchestra Canvas config

### DIFF
--- a/canvas.yaml
+++ b/canvas.yaml
@@ -1,0 +1,27 @@
+preset: package
+
+namespace: Cachet
+user-auth-provider: App\Models\User
+
+paths:
+  src: src
+  resource: resources
+
+factory:
+  path: database/factories
+
+migration:
+  path: database/migrations
+  prefix: ''
+
+console:
+  namespace: Cachet\Console\Commands
+
+model:
+  namespace: Cachet\Models
+
+provider:
+  namespace: Cachet\Providers
+
+testing:
+  namespace: Cachet\Tests

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "scripts": {
         "post-autoload-dump": "@prepare",
         "test": "vendor/bin/pest",
+        "canvas": "@php vendor/bin/canvas",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "build": [


### PR DESCRIPTION
This allows us to run `composer canvas` followed by any of the `artisan` supported make commands, which makes developing this package even easier.

For example, running:

```
composer canvas make:middleware Dashboard
```

Will stub a file to `./src/Http/Middleware/Dashboard.php` 🎉 