### PR TITLE
Test Improvements

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ use function Orchestra\Testbench\workbench_path;
 
 abstract class TestCase extends Orchestra
 {
-    use RefreshDatabase, WithLaravelMigrations, WithWorkbench;
+    use RefreshDatabase, WithWorkbench;
 
     protected function setUp(): void
     {
@@ -21,11 +21,6 @@ abstract class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Cachet\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
-    }
-
-    protected function defineDatabaseMigrations()
-    {
-        $this->loadMigrationsFrom(workbench_path('database/migrations'));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,8 +8,6 @@ use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-use function Orchestra\Testbench\workbench_path;
-
 abstract class TestCase extends Orchestra
 {
     use RefreshDatabase, WithWorkbench;


### PR DESCRIPTION
`WithWorkbench` + `RefreshDatabase` combined with `testbench.yaml` configuration below should already load default migrations and run migrations from `workbench/database/migrations`:

```yaml
migrations:
  - workbench/database/migrations

workbench:
  install: true
```