### PR TITLE
Add ability to create metric points

### DIFF
--- a/database/factories/MetricFactory.php
+++ b/database/factories/MetricFactory.php
@@ -25,9 +25,10 @@ class MetricFactory extends Factory
             'name' => 'Cups of coffee',
             'suffix' => 'cups',
             'description' => 'How many cups of coffee consumed by the team.',
-            'default_value' => 0,
+            'default_value' => 1,
             'calc_type' => MetricTypeEnum::sum->value,
             'default_view' => MetricViewEnum::today->value,
+            'threshold' => 5, // 5 minutes.
         ];
     }
 }

--- a/src/Actions/Metric/CreateMetricPoint.php
+++ b/src/Actions/Metric/CreateMetricPoint.php
@@ -3,14 +3,27 @@
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;
+use Cachet\Models\MetricPoint;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateMetricPoint
 {
     use AsAction;
 
-    public function handle(Metric $metric, array $data = [])
+    public function handle(Metric $metric, array $data = []): MetricPoint
     {
-        // @todo create metric points within threshold of metric.
+        $lastPoint = $metric->metricPoints()->latest()->first();
+
+        // If the last point was created within the threshold, increment the counter.
+        if ($lastPoint && $lastPoint->withinThreshold($metric->threshold)) {
+            $lastPoint->increment('counter');
+
+            return $lastPoint;
+        }
+
+        return $metric->metricPoints()->create([
+            'value' => $data['value'] ?? $metric->default_value,
+            'counter' => 1,
+        ]);
     }
 }

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -33,9 +33,11 @@ class MetricPointController extends Controller
      */
     public function store(CreateMetricPointRequest $request, Metric $metric)
     {
-        CreateMetricPoint::run($metric, $request->validated());
+        $metricPoint = CreateMetricPoint::run($metric, $request->validated());
 
-        return MetricPointResource::make($metric->fresh());
+        return MetricPointResource::make($metricPoint)
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
     }
 
     /**

--- a/src/Http/Requests/CreateMetricPointRequest.php
+++ b/src/Http/Requests/CreateMetricPointRequest.php
@@ -11,7 +11,7 @@ class CreateMetricPointRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/src/Models/Metric.php
+++ b/src/Models/Metric.php
@@ -51,4 +51,12 @@ class Metric extends Model
     {
         return $this->hasMany(MetricPoint::class);
     }
+
+    /**
+     * Get the most recent metric points.
+     */
+    public function recentMetricPoints(int $points = 15): HasMany
+    {
+        return $this->metricPoints()->latest()->limit($points);
+    }
 }

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -22,6 +22,11 @@ class MetricPoint extends Model
         'deleted' => MetricPointDeleted::class,
     ];
 
+    protected $fillable = [
+        'value',
+        'counter',
+    ];
+
     public function calculatedValue(): Attribute
     {
         return Attribute::make(
@@ -35,5 +40,13 @@ class MetricPoint extends Model
     public function metric(): BelongsTo
     {
         return $this->belongsTo(Metric::class);
+    }
+
+    /**
+     * Determine if the metric point was created within the threshold.
+     */
+    public function withinThreshold(int $threshold): bool
+    {
+        return $this->created_at->diffInMinutes(now()->startOfMinute()) < $threshold;
     }
 }

--- a/tests/Feature/Api/MetricPointTest.php
+++ b/tests/Feature/Api/MetricPointTest.php
@@ -5,6 +5,7 @@ use Cachet\Models\MetricPoint;
 
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
 
 it('can list metric points', function () {
     $metric = Metric::factory()->hasMetricPoints(2)->create();
@@ -41,6 +42,21 @@ it('can get a metric point', function () {
     $response->assertOk();
     $response->assertJsonFragment([
         'id' => $metricPoint->id,
+    ]);
+});
+
+it('can create a metric point', function () {
+    $metric = Metric::factory()->create();
+
+    $response = postJson('/status/api/metrics/'.$metric->id.'/points', [
+        'value' => 10,
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonFragment([
+        'value' => 10,
+        'counter' => 1,
+        'calculated_value' => 10,
     ]);
 });
 

--- a/tests/Unit/Actions/Metric/CreateMetricPointTest.php
+++ b/tests/Unit/Actions/Metric/CreateMetricPointTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Cachet\Actions\Metric\CreateMetricPoint;
+use Cachet\Events\Metrics\MetricPointCreated;
+use Cachet\Models\Metric;
+use Cachet\Models\MetricPoint;
+use Illuminate\Support\Facades\Event;
+
+it('creates a metric point if it is the first point', function () {
+    Event::fake();
+
+    $metric = Metric::factory()->create();
+
+    $point = CreateMetricPoint::run($metric, [
+        'value' => 1,
+    ]);
+
+    expect($point)->toBeInstanceOf(MetricPoint::class);
+    $this->assertDatabaseHas('metric_points', [
+        'metric_id' => $metric->id,
+        'value' => 1,
+        'counter' => 1,
+    ]);
+    $this->assertDatabaseCount('metric_points', 1);
+    Event::assertDispatched(MetricPointCreated::class);
+});
+
+it('creates a metric point with a default value', function () {
+    Event::fake();
+    $metric = Metric::factory()->create([
+        'default_value' => 1234,
+    ]);
+
+    $point = CreateMetricPoint::run($metric);
+
+    expect($point)->toBeInstanceOf(MetricPoint::class);
+    $this->assertDatabaseHas('metric_points', [
+        'metric_id' => $metric->id,
+        'value' => 1234,
+        'counter' => 1,
+    ]);
+    $this->assertDatabaseCount('metric_points', 1);
+    Event::assertDispatched(MetricPointCreated::class);
+});
+
+it('increments the counter if within the metric\'s threshold', function () {
+    Event::fake();
+    $metric = Metric::factory()->hasMetricPoints(1, [
+        'created_at' => now()->addMinute(),
+    ])->create([
+        'threshold' => 1,
+    ]);
+
+    $point = CreateMetricPoint::run($metric, [
+        'value' => 1,
+    ]);
+
+    expect($point)->toBeInstanceOf(MetricPoint::class);
+    $this->assertDatabaseHas('metric_points', [
+        'metric_id' => $metric->id,
+        'value' => 1,
+        'counter' => 2,
+    ]);
+    $this->assertDatabaseCount('metric_points', 1);
+    Event::assertDispatched(MetricPointCreated::class);
+});
+
+it('creates a metric point if it is outside of the metric\'s threshold', function () {
+    Event::fake();
+    $metric = Metric::factory()->hasMetricPoints(1, [
+        'created_at' => now()->addMinutes(5),
+    ])->create([
+        'threshold' => 1,
+    ]);
+
+    $point = CreateMetricPoint::run($metric, [
+        'value' => 1,
+    ]);
+
+    expect($point)->toBeInstanceOf(MetricPoint::class);
+    $this->assertDatabaseHas('metric_points', [
+        'metric_id' => $metric->id,
+        'value' => 1,
+        'counter' => 1,
+    ]);
+    $this->assertDatabaseCount('metric_points', 2);
+    Event::assertDispatched(MetricPointCreated::class);
+});

--- a/tests/Unit/Actions/Metric/CreateMetricTest.php
+++ b/tests/Unit/Actions/Metric/CreateMetricTest.php
@@ -2,8 +2,11 @@
 
 use Cachet\Actions\Metric\CreateMetric;
 use Cachet\Enums\MetricTypeEnum;
+use Cachet\Events\Metrics\MetricCreated;
+use Illuminate\Support\Facades\Event;
 
 it('can create a metric', function () {
+    Event::fake();
     $data = [
         'name' => 'Foo',
         'suffix' => 'Bar',
@@ -24,4 +27,6 @@ it('can create a metric', function () {
         ->calc_type->toBe(MetricTypeEnum::sum)
         ->display_chart->toBe(true)
         ->places->toBe(1);
+
+    Event::assertDispatched(MetricCreated::class);
 });

--- a/tests/Unit/Actions/Metric/DeleteMetricPointTest.php
+++ b/tests/Unit/Actions/Metric/DeleteMetricPointTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use Cachet\Actions\Metric\DeleteMetricPoint;
+use Cachet\Events\Metrics\MetricPointDeleted;
 use Cachet\Models\MetricPoint;
+use Illuminate\Support\Facades\Event;
 
 it('can delete a metric point', function () {
+    Event::fake();
     $metricPoint = MetricPoint::factory()->create();
 
     DeleteMetricPoint::run($metricPoint);
@@ -11,4 +14,5 @@ it('can delete a metric point', function () {
     $this->assertDatabaseMissing('metric_points', [
         'id' => $metricPoint->id,
     ]);
+    Event::assertDispatched(MetricPointDeleted::class);
 });

--- a/tests/Unit/Actions/Metric/DeleteMetricTest.php
+++ b/tests/Unit/Actions/Metric/DeleteMetricTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Cachet\Actions\Metric\DeleteMetric;
+use Cachet\Events\Metrics\MetricDeleted;
+use Cachet\Models\Metric;
+use Illuminate\Support\Facades\Event;
+
+it('can delete a metric', function () {
+    Event::fake();
+    $metric = Metric::factory()->create();
+
+    DeleteMetric::run($metric);
+
+    $this->assertDatabaseMissing('metrics', [
+        'id' => $metric->id,
+    ]);
+    Event::assertDispatched(MetricDeleted::class);
+});

--- a/tests/Unit/Actions/Metric/UpdateMetricTest.php
+++ b/tests/Unit/Actions/Metric/UpdateMetricTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use Cachet\Actions\Metric\UpdateMetric;
+use Cachet\Events\Metrics\MetricUpdated;
 use Cachet\Models\Metric;
+use Illuminate\Support\Facades\Event;
 
 it('can update a metric', function () {
+    Event::fake();
     $metric = Metric::factory()->create();
 
     $data = [
@@ -14,4 +17,5 @@ it('can update a metric', function () {
 
     expect($metric)
         ->name->toBe($data['name']);
+    Event::assertDispatched(MetricUpdated::class);
 });

--- a/tests/Unit/Models/MetricTest.php
+++ b/tests/Unit/Models/MetricTest.php
@@ -8,7 +8,13 @@ it('has points', function () {
     expect($metric->metricPoints)->toHaveCount(2);
 });
 
-it('calculates value when using counter', function ($value, $counter, $expected) {
+it('can retrieve only the most recent points', function () {
+    $metric = Metric::factory()->hasMetricPoints(10)->create();
+
+    expect($metric->recentMetricPoints(5)->get())->toHaveCount(5);
+});
+
+it('calculates counted values', function ($value, $counter, $expected) {
     $metric = Metric::factory()->hasMetricPoints(1, ['value' => $value, 'counter' => $counter])->create();
 
     expect($metric->metricPoints->first()->calculated_value)->toBe($expected);


### PR DESCRIPTION
Closes https://github.com/cachethq/core/issues/9

> **Note**
> This implementation is not 100% compatible with the existing Cachet 2.x API because we don't currently allow you to send a timestamp for the metric point.

I'm not sure if we need to be able to send timestamps? Points should be logged in real-time.