### PR TITLE
Beacon Telemetry

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -97,4 +97,6 @@ return [
     'major_outage' => 25.0,
 
     'beacon' => env('CACHET_BEACON', true),
+
+    'docker' => env('CACHET_DOCKER', false),
 ];

--- a/src/Jobs/SendBeaconJob.php
+++ b/src/Jobs/SendBeaconJob.php
@@ -8,6 +8,7 @@ use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Models\Metric;
 use Cachet\Models\Schedule;
+use Cachet\Settings\AppSettings;
 use Illuminate\Support\Facades\Http;
 
 class SendBeaconJob
@@ -24,7 +25,7 @@ class SendBeaconJob
         }
 
         $request = Http::asJson()->post('https://cachethq.io/beacon', [
-            'install_id' => null, // @todo Figure out this again.
+            'install_id' => app(AppSettings::class)->install_id,
             'version' => Cachet::version(),
             'docker' => config('cachet.docker'),
             'database' => config('database.default'),

--- a/src/Jobs/SendBeaconJob.php
+++ b/src/Jobs/SendBeaconJob.php
@@ -2,6 +2,14 @@
 
 namespace Cachet\Jobs;
 
+use Cachet\Cachet;
+use Cachet\Events\Beacon\BeaconSent;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\Models\Metric;
+use Cachet\Models\Schedule;
+use Illuminate\Support\Facades\Http;
+
 class SendBeaconJob
 {
     /**
@@ -11,6 +19,23 @@ class SendBeaconJob
      */
     public function handle()
     {
-        //
+        if (! config('cachet.beacon')) {
+            return;
+        }
+
+        $request = Http::asJson()->post('https://cachethq.io/beacon', [
+            'install_id' => null, // @todo Figure out this again.
+            'version' => Cachet::version(),
+            'docker' => config('cachet.docker'),
+            'database' => config('database.default'),
+            'data' => [
+                'components' => Component::query()->count(),
+                'incidents' => Incident::query()->count(),
+                'metrics' => Metric::query()->count(),
+                'schedules' => Schedule::query()->count(),
+            ],
+        ]);
+
+        BeaconSent::dispatchIf($request->successful());
     }
 }

--- a/tests/Unit/Jobs/SendBeaconJobTest.php
+++ b/tests/Unit/Jobs/SendBeaconJobTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Cachet\Cachet;
+use Cachet\Jobs\SendBeaconJob;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\Models\Metric;
+use Cachet\Models\Schedule;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+it('will not send the beacon if disabled', function () {
+    Http::fake();
+
+    config(['cachet.beacon' => false]);
+
+    dispatch(new SendBeaconJob());
+
+    Http::assertNothingSent();
+});
+
+it('sends telemetry data', function () {
+    Http::fake([
+        'https://cachethq.io/beacon' => Http::response([]),
+    ]);
+
+    config(['cachet.beacon' => true]);
+
+    Component::factory()->count(1)->create();
+    Incident::factory()->count(2)->create();
+    Metric::factory()->count(3)->create();
+    Schedule::factory()->count(4)->create();
+
+    dispatch(new SendBeaconJob());
+
+    Http::assertSent(function (Request $request) {
+        return $request['version'] === Cachet::version() &&
+            $request['docker'] === false &&
+            $request['data']['components'] === 1 &&
+            $request['data']['incidents'] === 2 &&
+            $request['data']['metrics'] === 3 &&
+            $request['data']['schedules'] === 4;
+    });
+    Http::assertSentCount(1);
+});


### PR DESCRIPTION
This PR brings back the Beacon, which sends optional and anonymous telemetry data to cachethq.io

> [!Note]
> In Cachet 2.x we would include the contact email, but we've dropped this now. 