### PR TITLE
Add Cachet section to `about` command

### DIFF
--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Cachet;
 
 use Cachet\View\Components\Footer;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
@@ -43,6 +44,8 @@ class CachetCoreServiceProvider extends ServiceProvider
         Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
             'User-Agent', Cachet::USER_AGENT
         ));
+
+        AboutCommand::add('Cachet', fn () => ['Version' => Cachet::version()]);
     }
 
     /**


### PR DESCRIPTION
This replaces the need for the previous [`cachet:version`](https://github.com/cachethq/cachet/blob/2323e9c0e36100f561ba03f029d87e2543636e81/app/Console/Commands/VersionCommand.php) command that we had.