### PR TITLE
Round metric point timestamp into 30 second intervals

### DIFF
--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -36,6 +36,9 @@ class MetricPoint extends Model
         );
     }
 
+    /**
+     * Override the created_at column to round the value into a 30-second interval.
+     */
     public function createdAt(): Attribute
     {
         return Attribute::make(

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -36,6 +36,26 @@ class MetricPoint extends Model
         );
     }
 
+    public function createdAt(): Attribute
+    {
+        return Attribute::make(
+            set: function ($createdAt) {
+                if (! $createdAt) {
+                    return;
+                }
+
+                if (! $createdAt instanceof DateTime) {
+                    $createdAt = Carbon::parse($createdAt);
+                }
+
+                $timestamp = $createdAt->unix();
+                $timestamp = 30 * round($timestamp / 30);
+
+                return Carbon::createFromTimestamp($timestamp);
+            }
+        );
+    }
+
     /**
      * Get the metric the point belongs to.
      */


### PR DESCRIPTION
We do this [currently](https://github.com/cachethq/cachet/blob/2323e9c0e36100f561ba03f029d87e2543636e81/app/Models/MetricPoint.php#L110-L128), and although I cannot remember _why_ we do it, I figured it's best to continue doing so. I _think_ it's so we can more easily group the points for the charts.