### PR TITLE
API Sorts and Filters

### DIFF
--- a/database/factories/ComponentFactory.php
+++ b/database/factories/ComponentFactory.php
@@ -31,6 +31,26 @@ class ComponentFactory extends Factory
     }
 
     /**
+     * Create a component that is enabled.
+     */
+    public function enabled(): self
+    {
+        return $this->state([
+            'enabled' => true,
+        ]);
+    }
+
+    /**
+     * Create a component that is disabled
+     */
+    public function disabled(): self
+    {
+        return $this->state([
+            'enabled' => false,
+        ]);
+    }
+
+    /**
      * Provide the component with additional meta.
      */
     public function withMeta(): self

--- a/database/factories/IncidentUpdateFactory.php
+++ b/database/factories/IncidentUpdateFactory.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends Factory<IncidentUpdate>
+ *
+ * @method IncidentUpdateFactory forIncident(...$sequence)
  */
 class IncidentUpdateFactory extends Factory
 {

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -9,6 +9,7 @@ use Cachet\Http\Requests\CreateIncidentRequest;
 use Cachet\Http\Requests\UpdateIncidentRequest;
 use Cachet\Http\Resources\Incident as IncidentResource;
 use Cachet\Models\Incident;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -21,6 +22,9 @@ class IncidentController extends Controller
     public function index()
     {
         $incidents = QueryBuilder::for(Incident::class)
+            ->when(! request('sort'), function (Builder $builder) {
+                $builder->orderByDesc('created_at');
+            })
             ->allowedIncludes(['updates'])
             ->allowedFilters(['name', 'status', 'occurred_at'])
             ->allowedSorts(['name', 'status', 'id'])

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -9,6 +9,7 @@ use Cachet\Http\Requests\CreateMetricRequest;
 use Cachet\Http\Requests\UpdateMetricRequest;
 use Cachet\Http\Resources\Metric as MetricResource;
 use Cachet\Models\Metric;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -21,6 +22,9 @@ class MetricController extends Controller
     public function index()
     {
         $metrics = QueryBuilder::for(Metric::class)
+            ->when(! request('sort'), function (Builder $builder) {
+                $builder->orderByDesc('created_at');
+            })
             ->allowedIncludes(['points'])
             ->allowedFilters(['name', 'calc_type'])
             ->allowedSorts(['name', 'order', 'id'])

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -26,13 +26,14 @@ it('does not list more than 15 component groups by default', function () {
     $response->assertJsonCount(15, 'data');
 });
 
-it('can list more than 15 components', function () {
-    ComponentGroup::factory(20)->create();
+it('sorts component groups by id by default', function () {
+    $groups = ComponentGroup::factory(5)->hasComponents(2)->create();
 
-    $response = getJson('/status/api/component-groups?per_page=18');
+    $response = getJson('/status/api/component-groups');
 
-    $response->assertOk();
-    $response->assertJsonCount(18, 'data');
+    $response->assertSeeInOrder(
+        $groups->sortBy('id')->take(5)->pluck('id')->all()
+    );
 });
 
 it('can get a component group', function () {
@@ -140,7 +141,7 @@ it('can delete a component group', function () {
 it('updates components group id when a group is deleted', function () {
     $componentGroup = ComponentGroup::factory()->hasComponents(2)->create();
 
-    $response = deleteJson('/status/api/component-groups/'.$componentGroup->id);
+    $response = deleteJson('/status/api/component-groups/' . $componentGroup->id);
 
     $response->assertNoContent();
     $this->assertDatabaseMissing('component_groups', [

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -26,6 +26,15 @@ it('does not list more than 15 component groups by default', function () {
     $response->assertJsonCount(15, 'data');
 });
 
+it('can list more than 15 components', function () {
+    ComponentGroup::factory(20)->create();
+
+    $response = getJson('/status/api/component-groups?per_page=18');
+
+    $response->assertOk();
+    $response->assertJsonCount(18, 'data');
+});
+
 it('sorts component groups by id by default', function () {
     $groups = ComponentGroup::factory(5)->hasComponents(2)->create();
 

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -150,7 +150,7 @@ it('can delete a component group', function () {
 it('updates components group id when a group is deleted', function () {
     $componentGroup = ComponentGroup::factory()->hasComponents(2)->create();
 
-    $response = deleteJson('/status/api/component-groups/' . $componentGroup->id);
+    $response = deleteJson('/status/api/component-groups/'.$componentGroup->id);
 
     $response->assertNoContent();
     $this->assertDatabaseMissing('component_groups', [

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -35,6 +35,54 @@ it('can list more than 15 components', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts components by id by default', function () {
+    Component::factory(5)->create();
+
+    $response = getJson('/status/api/components');
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can sort components by name', function () {
+    Component::factory(5)->sequence(
+        ['name' => 'e'],
+        ['name' => 'b'],
+        ['name' => 'a'],
+        ['name' => 'd'],
+        ['name' => 'c'],
+    )->create();
+
+    $response = getJson('/status/api/components?sort=name');
+
+    $response->assertJsonPath('data.0.attributes.id', 3);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 5);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 1);
+});
+
+it('can sort components by order', function () {
+    Component::factory(5)->sequence(
+        ['order' => 5],
+        ['order' => 1],
+        ['order' => 3],
+        ['order' => 2],
+        ['order' => 4],
+    )->create();
+
+    $response = getJson('/status/api/components?sort=order');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 5);
+    $response->assertJsonPath('data.4.attributes.id', 1);
+});
+
 it('can get a component', function () {
     $component = Component::factory()->create();
 

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 
@@ -81,6 +82,72 @@ it('can sort components by order', function () {
     $response->assertJsonPath('data.2.attributes.id', 3);
     $response->assertJsonPath('data.3.attributes.id', 5);
     $response->assertJsonPath('data.4.attributes.id', 1);
+});
+
+it('can filter components by name', function () {
+    Component::factory(20)->create();
+    $component = Component::factory()->create([
+        'name' => 'Name to Filter by.',
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'name' => 'Name to Filter by.'
+        ],
+    ]);
+
+    $response = getJson('/status/api/components?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $component->id);
+});
+
+it('can filter components by status', function () {
+    Component::factory(19)->create([
+        'status' => ComponentStatusEnum::performance_issues,
+    ]);
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::major_outage,
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'status' => ComponentStatusEnum::major_outage->value
+        ],
+    ]);
+
+    $response = getJson('/status/api/components?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $component->id);
+});
+
+it('can filter components by enabled', function () {
+    Component::factory(20)->disabled()->create();
+    $component = Component::factory()->enabled()->create();
+
+    $query = http_build_query([
+        'filter' => ['enabled' => true],
+    ]);
+
+    $response = getJson('/status/api/components?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $component->id);
+});
+
+it('can filter components by disabled', function () {
+    Component::factory(20)->disabled()->create();
+    $component = Component::factory()->enabled()->create();
+
+    $query = http_build_query([
+        'filter' => ['enabled' => false],
+    ]);
+
+    $response = getJson('/status/api/components?per_page=25&'.$query);
+
+    $response->assertJsonCount(20, 'data');
+    $response->assertJsonMissing(['id' => $component->id]);
 });
 
 it('can get a component', function () {

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -34,6 +34,72 @@ it('can list more than 15 incidents', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts incidents by created at descending by default', function () {
+    $incidents = Incident::factory(5)->sequence(
+        ['created_at' => '2020-01-01'],
+        ['created_at' => '2021-01-01'],
+        ['created_at' => '2022-01-01'],
+        ['created_at' => '2023-01-01'],
+        ['created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/incidents');
+
+    $response->assertJsonPath('data.0.attributes.id', $incidents->last()->id);
+    $response->assertJsonPath('data.1.attributes.id', $incidents->skip(3)->first()->id);
+    $response->assertJsonPath('data.2.attributes.id', $incidents->skip(2)->first()->id);
+    $response->assertJsonPath('data.3.attributes.id', $incidents->skip(1)->first()->id);
+    $response->assertJsonPath('data.4.attributes.id', $incidents->first()->id);
+});
+
+it('can sort incidents by ID', function () {
+    Incident::factory(5)->create();
+
+    $response = getJson('/status/api/incidents?sort=id');
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can sort incidents by name', function () {
+    Incident::factory(5)->sequence(
+        ['name' => 'c', 'created_at' => '2020-01-01'],
+        ['name' => 'a', 'created_at' => '2021-01-01'],
+        ['name' => 'b', 'created_at' => '2022-01-01'],
+        ['name' => 'e', 'created_at' => '2023-01-01'],
+        ['name' => 'd', 'created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/incidents?sort=name');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 3);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 5);
+    $response->assertJsonPath('data.4.attributes.id', 4);
+});
+
+it('can sort incidents by status', function () {
+    Incident::factory(5)->sequence(
+        ['status' => 3, 'created_at' => '2020-01-01'],
+        ['status' => 1, 'created_at' => '2021-01-01'],
+        ['status' => 2, 'created_at' => '2022-01-01'],
+        ['status' => 1, 'created_at' => '2023-01-01'],
+        ['status' => 4, 'created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/incidents?sort=status');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 1);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
 it('can get an incident', function () {
     $incident = Incident::factory()->create();
 

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Incident;
 
 use function Pest\Laravel\deleteJson;
@@ -98,6 +99,64 @@ it('can sort incidents by status', function () {
     $response->assertJsonPath('data.2.attributes.id', 3);
     $response->assertJsonPath('data.3.attributes.id', 1);
     $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can filter incidents by name', function () {
+    Incident::factory(20)->create();
+    $incident = Incident::factory()->create([
+        'name' => 'Name to filter by.',
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'name' => 'Name to filter by.',
+        ],
+    ]);
+
+    $response = getJson('/status/api/incidents?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $incident->id);
+});
+
+it('can filter incidents by status', function () {
+    Incident::factory(20)->create([
+        'status' => IncidentStatusEnum::investigating
+    ]);
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::identified
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'status' => IncidentStatusEnum::identified->value,
+        ],
+    ]);
+
+    $response = getJson('/status/api/incidents?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $incident->id);
+});
+
+it('can filter incidents by occurred at date', function () {
+    Incident::factory(20)->create([
+        'occurred_at' => '2019-01-01',
+    ]);
+    $incident = Incident::factory()->create([
+        'occurred_at' => '2023-01-01',
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'occurred_at' => '2023-01-01',
+        ],
+    ]);
+
+    $response = getJson('/status/api/incidents?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $incident->id);
 });
 
 it('can get an incident', function () {

--- a/tests/Feature/Api/IncidentUpdateTest.php
+++ b/tests/Feature/Api/IncidentUpdateTest.php
@@ -34,6 +34,54 @@ it('can list more than 15 incident updates', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts incident updates by id by default', function () {
+    $incident = Incident::factory()->hasIncidentUpdates(20)->create();
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates");
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can sort incident updates by status', function () {
+    IncidentUpdate::factory(5)->sequence(
+        ['status' => 3],
+        ['status' => 1],
+        ['status' => 4],
+        ['status' => 2],
+    )->forIncident()->create();
+
+    $incident = Incident::query()->first();
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates?sort=status");
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.4.attributes.id', 3);
+});
+
+it('can sort incident updates by created date', function () {
+    IncidentUpdate::factory(4)->sequence(
+        ['created_at' => '2022-01-01'],
+        ['created_at' => '2020-01-01'],
+        ['created_at' => '2023-01-01'],
+        ['created_at' => '2021-01-01'],
+    )->forIncident()->create();
+
+    $incident = Incident::query()->first();
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates?sort=created_at");
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 3);
+});
+
 it('can get an incident update', function () {
     $incidentUpdate = IncidentUpdate::factory()->forIncident()->create();
 

--- a/tests/Feature/Api/MetricPointTest.php
+++ b/tests/Feature/Api/MetricPointTest.php
@@ -34,6 +34,18 @@ it('can list more than 15 metric points', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts metric points by id by default', function () {
+    $metric = Metric::factory()->hasMetricPoints(20)->create();
+
+    $response = getJson("/status/api/metrics/{$metric->id}/points");
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
 it('can get a metric point', function () {
     $metricPoint = MetricPoint::factory()->forMetric()->create();
 

--- a/tests/Feature/Api/MetricTest.php
+++ b/tests/Feature/Api/MetricTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\MetricTypeEnum;
 use Cachet\Models\Metric;
 
 use function Pest\Laravel\deleteJson;
@@ -98,6 +99,44 @@ it('can sort metrics by order', function () {
     $response->assertJsonPath('data.2.attributes.id', 1);
     $response->assertJsonPath('data.3.attributes.id', 4);
     $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can filter metrics by name', function () {
+    Metric::factory(20)->create();
+    $metric = Metric::factory()->create([
+        'name' => 'Name to filter by.',
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'name' => 'Name to filter by.',
+        ],
+    ]);
+
+    $response = getJson('/status/api/metrics?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $metric->id);
+});
+
+it('can filter metrics by calculation type', function () {
+    Metric::factory(20)->create([
+        'calc_type' => MetricTypeEnum::sum,
+    ]);
+    $metric = Metric::factory()->create([
+        'calc_type' => MetricTypeEnum::average,
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'calc_type' => MetricTypeEnum::average->value,
+        ],
+    ]);
+
+    $response = getJson('/status/api/metrics?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $metric->id);
 });
 
 it('can get a metric', function () {

--- a/tests/Feature/Api/MetricTest.php
+++ b/tests/Feature/Api/MetricTest.php
@@ -34,6 +34,72 @@ it('can list more than 15 metrics', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts metrics by created at descending by default', function () {
+    Metric::factory(5)->sequence(
+        ['created_at' => '2020-01-01'],
+        ['created_at' => '2021-01-01'],
+        ['created_at' => '2022-01-01'],
+        ['created_at' => '2023-01-01'],
+        ['created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/metrics');
+
+    $response->assertJsonPath('data.0.attributes.id', 5);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 2);
+    $response->assertJsonPath('data.4.attributes.id', 1);
+});
+
+it('can sort metrics by ID', function () {
+    Metric::factory(5)->create();
+
+    $response = getJson('/status/api/metrics?sort=id');
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can sort metrics by name', function () {
+    Metric::factory(5)->sequence(
+        ['name' => 'c', 'created_at' => '2020-01-01'],
+        ['name' => 'a', 'created_at' => '2021-01-01'],
+        ['name' => 'b', 'created_at' => '2022-01-01'],
+        ['name' => 'e', 'created_at' => '2023-01-01'],
+        ['name' => 'd', 'created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/metrics?sort=name');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 3);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 5);
+    $response->assertJsonPath('data.4.attributes.id', 4);
+});
+
+it('can sort metrics by order', function () {
+    Metric::factory(5)->sequence(
+        ['order' => 3, 'created_at' => '2020-01-01'],
+        ['order' => 1, 'created_at' => '2021-01-01'],
+        ['order' => 2, 'created_at' => '2022-01-01'],
+        ['order' => 4, 'created_at' => '2023-01-01'],
+        ['order' => 5, 'created_at' => '2023-02-01'],
+    )->create();
+
+    $response = getJson('/status/api/metrics?sort=order');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 3);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
 it('can get a metric', function () {
     $metric = Metric::factory()->create();
 

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -35,6 +35,82 @@ it('can list more than 15 schedules', function () {
     $response->assertJsonCount(18, 'data');
 });
 
+it('sorts schedules by id by default', function () {
+    Schedule::factory(5)->create();
+
+    $response = getJson('/status/api/schedules');
+
+    $response->assertJsonPath('data.0.attributes.id', 1);
+    $response->assertJsonPath('data.1.attributes.id', 2);
+    $response->assertJsonPath('data.2.attributes.id', 3);
+    $response->assertJsonPath('data.3.attributes.id', 4);
+    $response->assertJsonPath('data.4.attributes.id', 5);
+});
+
+it('can sort schedules by name', function () {
+    Schedule::factory(5)->sequence(
+        ['name' => 'c'],
+        ['name' => 'a'],
+        ['name' => 'b'],
+        ['name' => 'e'],
+        ['name' => 'd'],
+    )->create();
+
+    $response = getJson('/status/api/schedules?sort=name');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 3);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 5);
+    $response->assertJsonPath('data.4.attributes.id', 4);
+});
+
+it('can sort schedules by status', function () {
+    Schedule::factory(3)->sequence(
+        ['status' => 1],
+        ['status' => 2],
+        ['status' => 0],
+    )->create();
+
+    $response = getJson('/status/api/schedules?sort=status');
+
+    $response->assertJsonPath('data.0.attributes.id', 3);
+    $response->assertJsonPath('data.1.attributes.id', 1);
+    $response->assertJsonPath('data.2.attributes.id', 2);
+});
+
+it('can sort schedules by scheduled at date', function () {
+    Schedule::factory(4)->sequence(
+        ['scheduled_at' => '2022-01-01'],
+        ['scheduled_at' => '2020-01-01'],
+        ['scheduled_at' => '2023-01-01'],
+        ['scheduled_at' => '2021-01-01'],
+    )->create();
+
+    $response = getJson('/status/api/schedules?sort=scheduled_at');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 3);
+});
+
+it('can sort schedules by completed at date', function () {
+    Schedule::factory(4)->sequence(
+        ['completed_at' => '2022-01-01'],
+        ['completed_at' => '2020-01-01'],
+        ['completed_at' => '2023-01-01'],
+        ['completed_at' => '2021-01-01'],
+    )->create();
+
+    $response = getJson('/status/api/schedules?sort=completed_at');
+
+    $response->assertJsonPath('data.0.attributes.id', 2);
+    $response->assertJsonPath('data.1.attributes.id', 4);
+    $response->assertJsonPath('data.2.attributes.id', 1);
+    $response->assertJsonPath('data.3.attributes.id', 3);
+});
+
 it('can get a schedule', function () {
     $schedule = Schedule::factory()->create();
 

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Schedule;
 
@@ -109,6 +110,44 @@ it('can sort schedules by completed at date', function () {
     $response->assertJsonPath('data.1.attributes.id', 4);
     $response->assertJsonPath('data.2.attributes.id', 1);
     $response->assertJsonPath('data.3.attributes.id', 3);
+});
+
+it('can filter schedules by name', function () {
+    Schedule::factory(20)->create();
+    $schedule = Schedule::factory()->create([
+        'name' => 'Name to filter by.',
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'name' => 'Name to filter by.',
+        ],
+    ]);
+
+    $response = getJson('/status/api/schedules?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $schedule->id);
+});
+
+it('can filter schedules by status', function () {
+    Schedule::factory(20)->create([
+        'status' => ScheduleStatusEnum::upcoming
+    ]);
+    $schedule = Schedule::factory()->create([
+        'status' => ScheduleStatusEnum::complete,
+    ]);
+
+    $query = http_build_query([
+        'filter' => [
+            'status' => ScheduleStatusEnum::complete->value,
+        ],
+    ]);
+
+    $response = getJson('/status/api/schedules?'.$query);
+
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $schedule->id);
 });
 
 it('can get a schedule', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Cachet\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -18,6 +19,8 @@ abstract class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Cachet\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        $this->withoutApiRateLimiting();
     }
 
     /**
@@ -29,5 +32,13 @@ abstract class TestCase extends Orchestra
             'database.default' => 'testing',
             // 'query-builder.request_data_source' => 'body',
         ]);
+    }
+
+    /**
+     * Overrides the rate limiting defined by workbench.
+     */
+    protected function withoutApiRateLimiting(): void
+    {
+        RateLimiter::for('api', fn () => null);
     }
 }


### PR DESCRIPTION
This PR updates `MetricController::index()` and `IncidentController::index()` to default the ordering of results by the `created_at` date in descending order.

Tests have been included to check this is the case, and to check the default sorting, the ability to sort and the ability to filter various resources.

Resolves #10