### PR TITLE
Settings

### DIFF
--- a/database/factories/SettingFactory.php
+++ b/database/factories/SettingFactory.php
@@ -20,7 +20,8 @@ class SettingFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'name' => 'app_name',
+            'value' => 'Cachet',
         ];
     }
 }

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Cachet;
 
+use Cachet\Support\Settings\Setting;
 use Cachet\View\Components\Footer;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Blade;
@@ -39,6 +40,7 @@ class CachetCoreServiceProvider extends ServiceProvider
 
         $this->registerResources();
         $this->registerPublishing();
+        $this->registerSettings();
         $this->registerBladeComponents();
 
         Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
@@ -113,5 +115,10 @@ class CachetCoreServiceProvider extends ServiceProvider
         Blade::componentNamespace('Cachet\\View\\Components', 'cachet');
 
         Blade::component('footer', Footer::class);
+    }
+
+    private function registerSettings(): void
+    {
+        $this->app->singleton(Setting::class, fn ($app) => new Support\Settings\SettingManager($app));
     }
 }

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -8,4 +8,9 @@ use Illuminate\Database\Eloquent\Model;
 class Setting extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'value',
+    ];
 }

--- a/src/Support/Settings/Drivers/CacheDriver.php
+++ b/src/Support/Settings/Drivers/CacheDriver.php
@@ -20,9 +20,9 @@ class CacheDriver implements Driver
         });
     }
 
-    public function set(string $key, $value = null)
+    public function set(string $key, $value = null): mixed
     {
-        $this->eloquent->set($key, $value);
+        return $this->eloquent->set($key, $value);
     }
 
     public function has(string $key): bool

--- a/src/Support/Settings/Drivers/CacheDriver.php
+++ b/src/Support/Settings/Drivers/CacheDriver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Cachet\Support\Settings\Drivers;
+
+use Illuminate\Cache\Repository;
+
+class CacheDriver implements Driver
+{
+    public function __construct(
+        protected Repository $cache,
+        protected EloquentDriver $eloquent
+    ) {
+        //
+    }
+
+    public function get(string $key, $default = null)
+    {
+        return $this->cache->rememberForever('setting:'.$key, function () use ($key, $default) {
+            return $this->eloquent->get($key, $default);
+        });
+    }
+
+    public function set(string $key, $value = null)
+    {
+        $this->eloquent->set($key, $value);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->cache->has('setting:'.$key);
+    }
+
+    public function forget(string $key): void
+    {
+        $this->cache->forget('setting:'.$key);
+    }
+}

--- a/src/Support/Settings/Drivers/Driver.php
+++ b/src/Support/Settings/Drivers/Driver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cachet\Support\Settings\Drivers;
+
+interface Driver
+{
+    /**
+     * Get a setting.
+     */
+    public function get(string $key, $default = null);
+
+    /**
+     * Set a setting.
+     */
+    public function set(string $key, $value = null): mixed;
+
+    /**
+     * Determine if a setting exists.
+     */
+    public function has(string $key): bool;
+
+    /**
+     * Forget a setting.
+     */
+    public function forget(string $key): void;
+}

--- a/src/Support/Settings/Drivers/EloquentDriver.php
+++ b/src/Support/Settings/Drivers/EloquentDriver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cachet\Support\Settings\Drivers;
+
+use Cachet\Models\Setting;
+
+class EloquentDriver implements Driver
+{
+    public function get(string $key, $default = null)
+    {
+        return Setting::query()
+            ->where('name', $key)
+            ->first()
+            ->value ?? $default;
+    }
+
+    public function set(string $key, $value = null): mixed
+    {
+        Setting::query()
+            ->updateOrCreate(
+                ['name' => $key],
+                ['value' => $value],
+            );
+
+        return $value;
+    }
+
+    public function has(string $key): bool
+    {
+        return Setting::query()
+            ->where('name', $key)
+            ->exists();
+    }
+
+    public function forget(string $key): void
+    {
+        Setting::query()
+            ->where('name', $key)
+            ->delete();
+    }
+}

--- a/src/Support/Settings/Drivers/FileDriver.php
+++ b/src/Support/Settings/Drivers/FileDriver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cachet\Support\Settings\Drivers;
+
+class FileDriver implements Driver
+{
+    public function __construct(
+        protected EloquentDriver $eloquent
+    ) {
+        //
+    }
+
+    public function get(string $key, $default = null)
+    {
+        //
+    }
+
+    public function set(string $key, $value = null): mixed
+    {
+        return $this->eloquent->set($key, $value);
+    }
+
+    public function has(string $key): bool
+    {
+        //
+    }
+
+    public function forget(string $key): void
+    {
+        //
+    }
+}

--- a/src/Support/Settings/Setting.php
+++ b/src/Support/Settings/Setting.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Cachet\Support\Settings;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static mixed get(string $key, mixed $default = null)
+ * @method static mixed set(string $key, mixed $value)
+ * @method static void forget(string $key)
+ * @method static bool has(string $key)
+ */
+class Setting extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return SettingManager::class;
+    }
+}

--- a/src/Support/Settings/SettingManager.php
+++ b/src/Support/Settings/SettingManager.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Cachet\Support\Settings;
+
+use Cachet\Support\Settings\Drivers\CacheDriver;
+use Cachet\Support\Settings\Drivers\Driver;
+use Cachet\Support\Settings\Drivers\EloquentDriver;
+use Illuminate\Cache\Repository;
+use Illuminate\Support\Manager;
+
+class SettingManager extends Manager
+{
+    /**
+     * Get the default driver name.
+     */
+    public function getDefaultDriver(): string
+    {
+        return $this->config->get('cachet.settings.default', 'eloquent');
+    }
+
+    /**
+     * Create the eloquent driver.
+     */
+    public function createEloquentDriver()
+    {
+        return new EloquentDriver();
+    }
+
+    /**
+     * Create the cache driver.
+     */
+    public function createCacheDriver()
+    {
+        return new CacheDriver(
+            app(Repository::class),
+            $this->createEloquentDriver(),
+        );
+    }
+}

--- a/src/Support/Settings/SettingManager.php
+++ b/src/Support/Settings/SettingManager.php
@@ -3,8 +3,8 @@
 namespace Cachet\Support\Settings;
 
 use Cachet\Support\Settings\Drivers\CacheDriver;
-use Cachet\Support\Settings\Drivers\Driver;
 use Cachet\Support\Settings\Drivers\EloquentDriver;
+use Cachet\Support\Settings\Drivers\FileDriver;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Manager;
 
@@ -34,6 +34,16 @@ class SettingManager extends Manager
         return new CacheDriver(
             app(Repository::class),
             $this->createEloquentDriver(),
+        );
+    }
+
+    /**
+     * Create the file driver.
+     */
+    public function createFileDriver()
+    {
+        return new FileDriver(
+            $this->createEloquentDriver()
         );
     }
 }

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Cachet\Models\Setting;
+use Cachet\Support\Settings\Setting as SettingFacade;
+
+it('can get a setting', function () {
+    Setting::factory()->create();
+
+    $appName = SettingFacade::get('app_name');
+
+    expect($appName)->toBe('Cachet');
+});
+
+it('can determine that a setting exists', function () {
+    Setting::factory()->create();
+
+    $appName = SettingFacade::has('app_name');
+
+    expect($appName)->toBeTrue();
+});
+
+it('can forget a setting', function () {
+    Setting::factory()->create();
+
+    SettingFacade::forget('app_name');
+
+    $this->assertDatabaseMissing('settings', [
+        'name' => 'app_name',
+    ]);
+});
+
+it('can set a setting', function () {
+    Setting::factory()->create();
+
+    $setting = SettingFacade::set('app_name', 'Cachet 3.x');
+
+    expect($setting)->toBe('Cachet 3.x');
+});


### PR DESCRIPTION
Closes #32 

This PR reimplements the settings feature from Cachet 2.x. I've developed this feature to work from Laravel's `Manager` system, so we can easily add an additional driver that will read/write to the settings file that Cachet 2.x uses.

At the moment there is an `eloquent` and `cache` driver only.

To-do:

- [ ] Implement file driver
- [ ] Write tests