### PR TITLE
feat/dev-tools: PHPStan, PHPInsights & Laravel Pint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.13",
+        "nunomaduro/larastan": "^2.6",
+        "nunomaduro/phpinsights": "^2.8",
         "orchestra/testbench": "^8.10",
         "pestphp/pest": "^2.13",
         "pestphp/pest-plugin-laravel": "^2.2",
@@ -57,6 +60,9 @@
     "scripts": {
         "post-autoload-dump": "@prepare",
         "test": "vendor/bin/pest",
+        "format": "vendor/bin/pint --dirty",
+        "analyse": "vendor/bin/phpstan",
+        "complexity": "vendor/bin/phpinsights",
         "canvas": "@php vendor/bin/canvas",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
@@ -74,7 +80,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Preset
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default preset that will be used by PHP Insights
+    | to make your code reliable, simple, and clean. However, you can always
+    | adjust the `Metrics` and `Insights` below in this configuration file.
+    |
+    | Supported: "default", "laravel", "symfony", "magento2", "drupal"
+    |
+    */
+
+    'preset' => 'laravel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | IDE
+    |--------------------------------------------------------------------------
+    |
+    | This options allow to add hyperlinks in your terminal to quickly open
+    | files in your favorite IDE while browsing your PhpInsights report.
+    |
+    | Supported: "textmate", "macvim", "emacs", "sublime", "phpstorm",
+    | "atom", "vscode".
+    |
+    | If you have another IDE that is not in this list but which provide an
+    | url-handler, you could fill this config with a pattern like this:
+    |
+    | myide://open?url=file://%f&line=%l
+    |
+    */
+
+    'ide' => 'phpstorm',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may adjust all the various `Insights` that will be used by PHP
+    | Insights. You can either add, remove or configure `Insights`. Keep in
+    | mind, that all added `Insights` must belong to a specific `Metric`.
+    |
+    */
+
+    'exclude' => [
+        'config',
+        'database',
+        'routes',
+        'workbench',
+    ],
+
+    'add' => [
+        //  ExampleMetric::class => [
+        //      ExampleInsight::class,
+        //  ]
+    ],
+
+    'remove' => [
+        //  ExampleInsight::class,
+    ],
+
+    'config' => [
+        //  ExampleInsight::class => [
+        //      'key' => 'value',
+        //  ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Requirements
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define a level you want to reach per `Insights` category.
+    | When a score is lower than the minimum level defined, then an error
+    | code will be returned. This is optional and individually defined.
+    |
+    */
+
+    'requirements' => [
+        //        'min-quality' => 0,
+        //        'min-complexity' => 0,
+        //        'min-architecture' => 0,
+        //        'min-style' => 0,
+        //        'disable-security-check' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Threads
+    |--------------------------------------------------------------------------
+    |
+    | Here you may adjust how many threads (core) PHPInsights can use to perform
+    | the analysis. This is optional, don't provide it and the tool will guess
+    | the max core number available. It accepts null value or integer > 0.
+    |
+    */
+
+    'threads' => null,
+
+];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,351 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:allowedIncludes\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Controllers/Api/IncidentController.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:allowedFilters\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Controllers/Api/IncidentUpdateController.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:allowedIncludes\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Controllers/Api/MetricController.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:allowedIncludes\\(\\)\\.$#"
+			count: 1
+			path: src/Http/Controllers/Api/MetricPointController.php
+
+		-
+			message: "#^Class App\\\\Models\\\\User not found\\.$#"
+			count: 1
+			path: src/Http/Requests/ProfileUpdateRequest.php
+
+		-
+			message: "#^Class App\\\\Models\\\\User not found\\.$#"
+			count: 1
+			path: src/Models/Incident.php
+
+		-
+			message: "#^Call to an undefined method DateTime\\:\\:unix\\(\\)\\.$#"
+			count: 1
+			path: src/Models/MetricPoint.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/ActionsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/CommandsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/EnumsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/EventsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/GlobalsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/Http/ControllersTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/Http/MiddlewareTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/Http/RequestsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/Http/ResourcesTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/JobsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/ModelsTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/RulesTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:expect\\(\\)\\.$#"
+			count: 1
+			path: tests/Architecture/ViewTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 10
+			path: tests/Feature/Api/ComponentGroupTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 7
+			path: tests/Feature/Api/ComponentTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\:\\:get\\(\\)\\.$#"
+			count: 2
+			path: tests/Feature/Api/GeneralTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 3
+			path: tests/Feature/Api/IncidentUpdateTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Feature/Api/MetricPointTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 4
+			path: tests/Feature/Api/MetricTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 3
+			path: tests/Feature/Api/ScheduleTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: tests/Feature/CachetTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\Expectation\\<Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\|null\\>\\:\\:is\\(\\)\\.$#"
+			count: 2
+			path: tests/Feature/CachetTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Feature/HealthTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Unit/Actions/Component/CreateComponentTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 3
+			path: tests/Unit/Actions/Component/DeleteComponentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Component/UpdateComponentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
+
+		-
+			message: "#^Method Pest\\\\PendingCalls\\\\TestCall\\:\\:todo\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 3
+			path: tests/Unit/Actions/ComponentGroup/DeleteComponentGroupTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 2
+			path: tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Unit/Actions/Incident/CreateIncidentTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 3
+			path: tests/Unit/Actions/Incident/DeleteIncidentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Incident/UpdateIncidentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$message\\.$#"
+			count: 2
+			path: tests/Unit/Actions/IncidentUpdate/CreateIncidentUpdateTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Unit/Actions/IncidentUpdate/DeleteIncidentUpdateTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$message\\.$#"
+			count: 1
+			path: tests/Unit/Actions/IncidentUpdate/UpdateIncidentUpdateTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Mixins\\\\Expectation\\<mixed\\>\\:\\:\\$created_at\\.$#"
+			count: 2
+			path: tests/Unit/Actions/Metric/CreateMetricPointTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\Expectation\\<mixed\\>\\:\\:toDateTimeString\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Metric/CreateMetricPointTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 8
+			path: tests/Unit/Actions/Metric/CreateMetricPointTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Metric/CreateMetricTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Unit/Actions/Metric/DeleteMetricPointTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Unit/Actions/Metric/DeleteMetricTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Metric/UpdateMetricTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Unit/Actions/Schedule/CreateScheduleTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 2
+			path: tests/Unit/Actions/Schedule/CreateScheduleTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 1
+			path: tests/Unit/Actions/Schedule/DeleteScheduleTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$components\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Schedule/UpdateScheduleTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Schedule/UpdateScheduleTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 2
+			path: tests/Unit/Actions/Schedule/UpdateScheduleTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$email\\.$#"
+			count: 4
+			path: tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$components\\.$#"
+			count: 1
+			path: tests/Unit/Actions/Subscriber/UpdateSubscriberTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$email\\.$#"
+			count: 4
+			path: tests/Unit/Actions/Subscriber/UpdateSubscriberTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$meta\\.$#"
+			count: 1
+			path: tests/Unit/Models/ComponentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Mixins\\\\Expectation\\<mixed\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: tests/Unit/Models/ComponentTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Mixins\\\\Expectation\\<mixed\\>\\:\\:\\$template\\.$#"
+			count: 1
+			path: tests/Unit/Models/IncidentTemplateTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$components\\.$#"
+			count: 1
+			path: tests/Unit/Models/ScheduleTest.php
+
+		-
+			message: "#^Call to an undefined method Pest\\\\Mixins\\\\Expectation\\<Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Cachet\\\\Models\\\\Schedule\\>\\|null\\>\\:\\:first\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Models/ScheduleTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$components\\.$#"
+			count: 1
+			path: tests/Unit/Models/SubscriberTest.php
+
+		-
+			message: "#^Access to an undefined property Pest\\\\Expectation\\<mixed\\>\\:\\:\\$verified_at\\.$#"
+			count: 3
+			path: tests/Unit/Models/SubscriberTest.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$data of method Pest\\\\PendingCalls\\\\TestCall\\:\\:with\\(\\) expects array\\<Closure\\|iterable\\<int\\|string, mixed\\>\\|string\\>\\|Closure\\|string, array\\{1, 2, 5, 10, 15, 30, 60\\} given\\.$#"
+			count: 1
+			path: tests/Unit/Rules/FactorOfSixtyTest.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$data of method Pest\\\\PendingCalls\\\\TestCall\\:\\:with\\(\\) expects array\\<Closure\\|iterable\\<int\\|string, mixed\\>\\|string\\>\\|Closure\\|string, array\\{9, 11, 13, 17, 19, 23, 29, 31, \\.\\.\\.\\} given\\.$#"
+			count: 1
+			path: tests/Unit/Rules/FactorOfSixtyTest.php

--- a/src/Actions/Component/CreateComponent.php
+++ b/src/Actions/Component/CreateComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Component;
 
 use Cachet\Models\Component;

--- a/src/Actions/Component/DeleteComponent.php
+++ b/src/Actions/Component/DeleteComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Component;
 
 use Cachet\Models\Component;

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Component;
 
 use Cachet\Events\Components\ComponentStatusWasChanged;

--- a/src/Actions/ComponentGroup/CreateComponentGroup.php
+++ b/src/Actions/ComponentGroup/CreateComponentGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\Component;

--- a/src/Actions/ComponentGroup/DeleteComponentGroup.php
+++ b/src/Actions/ComponentGroup/DeleteComponentGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\ComponentGroup;

--- a/src/Actions/ComponentGroup/UpdateComponentGroup.php
+++ b/src/Actions/ComponentGroup/UpdateComponentGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\Component;

--- a/src/Actions/Incident/CreateIncident.php
+++ b/src/Actions/Incident/CreateIncident.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;

--- a/src/Actions/Incident/DeleteIncident.php
+++ b/src/Actions/Incident/DeleteIncident.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;

--- a/src/Actions/Incident/UpdateIncident.php
+++ b/src/Actions/Incident/UpdateIncident.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;

--- a/src/Actions/IncidentTemplate/CreateIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/CreateIncidentTemplate.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentTemplate;
 
-use Cachet\Models\IncidentTemplate;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateIncidentTemplate
 {
     use AsAction;
 
-    public function handle(): IncidentTemplate
+    public function handle(): void
     {
         //
     }

--- a/src/Actions/IncidentTemplate/DeleteIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/DeleteIncidentTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentTemplate;
 
 use Cachet\Models\IncidentTemplate;
@@ -9,7 +11,7 @@ class DeleteIncidentTemplate
 {
     use AsAction;
 
-    public function handle(IncidentTemplate $incidentTemplate)
+    public function handle(IncidentTemplate $incidentTemplate): void
     {
         $incidentTemplate->delete();
     }

--- a/src/Actions/IncidentTemplate/UpdateIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/UpdateIncidentTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentTemplate;
 
 use Cachet\Models\IncidentTemplate;
@@ -9,7 +11,7 @@ class UpdateIncidentTemplate
 {
     use AsAction;
 
-    public function handle(IncidentTemplate $incidentTemplate): IncidentTemplate
+    public function handle(IncidentTemplate $incidentTemplate): void
     {
         //
     }

--- a/src/Actions/IncidentUpdate/CreateIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/CreateIncidentUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentUpdate;
 
 use Cachet\Actions\Incident\UpdateIncident;

--- a/src/Actions/IncidentUpdate/DeleteIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/DeleteIncidentUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentUpdate;
 
 use Cachet\Models\IncidentUpdate;

--- a/src/Actions/IncidentUpdate/UpdateIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/UpdateIncidentUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\IncidentUpdate;
 
 use Cachet\Models\IncidentUpdate;

--- a/src/Actions/Metric/CreateMetric.php
+++ b/src/Actions/Metric/CreateMetric.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;

--- a/src/Actions/Metric/CreateMetricPoint.php
+++ b/src/Actions/Metric/CreateMetricPoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;

--- a/src/Actions/Metric/DeleteMetric.php
+++ b/src/Actions/Metric/DeleteMetric.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;

--- a/src/Actions/Metric/DeleteMetricPoint.php
+++ b/src/Actions/Metric/DeleteMetricPoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\MetricPoint;

--- a/src/Actions/Metric/UpdateMetric.php
+++ b/src/Actions/Metric/UpdateMetric.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;

--- a/src/Actions/Schedule/CreateSchedule.php
+++ b/src/Actions/Schedule/CreateSchedule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;

--- a/src/Actions/Schedule/DeleteSchedule.php
+++ b/src/Actions/Schedule/DeleteSchedule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;

--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;

--- a/src/Actions/Subscriber/CreateSubscriber.php
+++ b/src/Actions/Subscriber/CreateSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Subscriber;
 
 use Cachet\Models\Subscriber;

--- a/src/Actions/Subscriber/UnsubscribeSubscriber.php
+++ b/src/Actions/Subscriber/UnsubscribeSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Subscriber;
 
 use Cachet\Events\Subscribers\SubscriberUnsubscribed;

--- a/src/Actions/Subscriber/UpdateSubscriber.php
+++ b/src/Actions/Subscriber/UpdateSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Actions\Subscriber;
 
 use Cachet\Models\Subscriber;

--- a/src/Cachet.php
+++ b/src/Cachet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet;
 
 use Cachet\Http\Middleware\RedirectIfAuthenticated;
@@ -13,12 +15,12 @@ class Cachet
      *
      * @var string
      */
-    const USER_AGENT = 'Cachet/1.0';
+    public const USER_AGENT = 'Cachet/1.0';
 
     /**
      * Cachet is being used to authenticate users.
      */
-    public static bool $withAuthentication = false;
+    protected static bool $withAuthentication = false;
 
     /**
      * Get the current user using `cachet.guard`.
@@ -47,11 +49,17 @@ class Cachet
     /**
      * Enable Cachet's authentication routes.
      */
-    public static function withAuthentication(): static
+    public static function withAuthentication(): void
     {
         static::$withAuthentication = true;
+    }
 
-        return new static();
+    /**
+     * Determine if Cachet is being used to authenticate users.
+     */
+    public static function hasAuthentication(): bool
+    {
+        return static::$withAuthentication;
     }
 
     /**

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet;
 
 use Cachet\View\Components\Footer;

--- a/src/CachetServiceProvider.php
+++ b/src/CachetServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet;
 
 use Illuminate\Support\ServiceProvider;

--- a/src/Console/Commands/SendBeaconCommand.php
+++ b/src/Console/Commands/SendBeaconCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Console\Commands;
 
 use Cachet\Jobs\SendBeaconJob;

--- a/src/Enums/ComponentGroupVisibilityEnum.php
+++ b/src/Enums/ComponentGroupVisibilityEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum ComponentGroupVisibilityEnum: int

--- a/src/Enums/ComponentStatusEnum.php
+++ b/src/Enums/ComponentStatusEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum ComponentStatusEnum: int
@@ -19,7 +21,6 @@ enum ComponentStatusEnum: int
             self::performance_issues->value => __('Performance Issues'),
             self::partial_outage->value => __('Partial Outage'),
             self::major_outage->value => __('Major Outage'),
-            default => __('Unknown Component Status'),
         };
     }
 }

--- a/src/Enums/IncidentStatusEnum.php
+++ b/src/Enums/IncidentStatusEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum IncidentStatusEnum: int

--- a/src/Enums/IncidentTemplateEngineEnum.php
+++ b/src/Enums/IncidentTemplateEngineEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum IncidentTemplateEngineEnum

--- a/src/Enums/MetricTypeEnum.php
+++ b/src/Enums/MetricTypeEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum MetricTypeEnum: int

--- a/src/Enums/MetricViewEnum.php
+++ b/src/Enums/MetricViewEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum MetricViewEnum: int

--- a/src/Enums/ResourceVisibilityEnum.php
+++ b/src/Enums/ResourceVisibilityEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum ResourceVisibilityEnum: int

--- a/src/Enums/ScheduleStatusEnum.php
+++ b/src/Enums/ScheduleStatusEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum ScheduleStatusEnum: int

--- a/src/Enums/UserLevelEnum.php
+++ b/src/Enums/UserLevelEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Enums;
 
 enum UserLevelEnum: int

--- a/src/Events/Beacon/BeaconSent.php
+++ b/src/Events/Beacon/BeaconSent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Beacon;
 
 use Illuminate\Foundation\Events\Dispatchable;

--- a/src/Events/Components/ComponentCreated.php
+++ b/src/Events/Components/ComponentCreated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Components;
 
 use Cachet\Models\Component;

--- a/src/Events/Components/ComponentDeleted.php
+++ b/src/Events/Components/ComponentDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Components;
 
 use Cachet\Models\Component;

--- a/src/Events/Components/ComponentStatusWasChanged.php
+++ b/src/Events/Components/ComponentStatusWasChanged.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Components;
 
 use Cachet\Enums\ComponentStatusEnum;

--- a/src/Events/Components/ComponentUpdated.php
+++ b/src/Events/Components/ComponentUpdated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Components;
 
 use Cachet\Models\Component;

--- a/src/Events/Incidents/IncidentCreated.php
+++ b/src/Events/Incidents/IncidentCreated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Incidents;
 
 use Cachet\Models\Incident;

--- a/src/Events/Incidents/IncidentDeleted.php
+++ b/src/Events/Incidents/IncidentDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Incidents;
 
 use Cachet\Models\Incident;

--- a/src/Events/Incidents/IncidentUpdated.php
+++ b/src/Events/Incidents/IncidentUpdated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Incidents;
 
 use Cachet\Models\Incident;

--- a/src/Events/Metrics/MetricCreated.php
+++ b/src/Events/Metrics/MetricCreated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Metrics;
 
 use Cachet\Models\Metric;

--- a/src/Events/Metrics/MetricDeleted.php
+++ b/src/Events/Metrics/MetricDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Metrics;
 
 use Cachet\Models\Metric;

--- a/src/Events/Metrics/MetricPointCreated.php
+++ b/src/Events/Metrics/MetricPointCreated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Metrics;
 
 use Cachet\Models\MetricPoint;

--- a/src/Events/Metrics/MetricPointDeleted.php
+++ b/src/Events/Metrics/MetricPointDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Metrics;
 
 use Cachet\Models\MetricPoint;

--- a/src/Events/Metrics/MetricUpdated.php
+++ b/src/Events/Metrics/MetricUpdated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Metrics;
 
 use Cachet\Models\Metric;

--- a/src/Events/ServingCachet.php
+++ b/src/Events/ServingCachet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;

--- a/src/Events/Subscribers/SubscriberCreated.php
+++ b/src/Events/Subscribers/SubscriberCreated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Subscribers;
 
 use Cachet\Models\Subscriber;

--- a/src/Events/Subscribers/SubscriberUnsubscribed.php
+++ b/src/Events/Subscribers/SubscriberUnsubscribed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Subscribers;
 
 use Cachet\Models\Subscriber;

--- a/src/Events/Subscribers/SubscriberVerified.php
+++ b/src/Events/Subscribers/SubscriberVerified.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Events\Subscribers;
 
 use Cachet\Models\Subscriber;

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Component\CreateComponent;

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\ComponentGroup\CreateComponentGroup;

--- a/src/Http/Controllers/Api/GeneralController.php
+++ b/src/Http/Controllers/Api/GeneralController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Cachet;

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Incident\CreateIncident;

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\IncidentUpdate\CreateIncidentUpdate;

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Metric\CreateMetric;

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Metric\CreateMetricPoint;

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Schedule\CreateSchedule;

--- a/src/Http/Controllers/Dashboard/ComponentController.php
+++ b/src/Http/Controllers/Dashboard/ComponentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Actions\Component\CreateComponent;

--- a/src/Http/Controllers/Dashboard/ComponentGroupController.php
+++ b/src/Http/Controllers/Dashboard/ComponentGroupController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\ComponentGroup;

--- a/src/Http/Controllers/Dashboard/DashboardController.php
+++ b/src/Http/Controllers/Dashboard/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\Component;

--- a/src/Http/Controllers/Dashboard/IncidentController.php
+++ b/src/Http/Controllers/Dashboard/IncidentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\Incident;

--- a/src/Http/Controllers/Dashboard/IncidentTemplateController.php
+++ b/src/Http/Controllers/Dashboard/IncidentTemplateController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\IncidentTemplate;

--- a/src/Http/Controllers/Dashboard/IncidentUpdateController.php
+++ b/src/Http/Controllers/Dashboard/IncidentUpdateController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/Dashboard/IndexController.php
+++ b/src/Http/Controllers/Dashboard/IndexController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/Dashboard/MetricController.php
+++ b/src/Http/Controllers/Dashboard/MetricController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\Metric;

--- a/src/Http/Controllers/Dashboard/ScheduleController.php
+++ b/src/Http/Controllers/Dashboard/ScheduleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Cachet\Models\Schedule;

--- a/src/Http/Controllers/Dashboard/TeamController.php
+++ b/src/Http/Controllers/Dashboard/TeamController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\Dashboard;
 
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/HealthController.php
+++ b/src/Http/Controllers/HealthController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers;
 
 class HealthController

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers;
 
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Controllers\StatusPage;
 
 use Cachet\Cachet;

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Middleware;
 
 use Cachet\Cachet;

--- a/src/Http/Middleware/RedirectIfAuthenticated.php
+++ b/src/Http/Middleware/RedirectIfAuthenticated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Middleware;
 
 use Cachet\Cachet;

--- a/src/Http/Requests/Auth/LoginRequest.php
+++ b/src/Http/Requests/Auth/LoginRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;

--- a/src/Http/Requests/CreateComponentGroupRequest.php
+++ b/src/Http/Requests/CreateComponentGroupRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/CreateComponentRequest.php
+++ b/src/Http/Requests/CreateComponentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\ComponentStatusEnum;

--- a/src/Http/Requests/CreateIncidentRequest.php
+++ b/src/Http/Requests/CreateIncidentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\IncidentStatusEnum;

--- a/src/Http/Requests/CreateIncidentTemplateRequest.php
+++ b/src/Http/Requests/CreateIncidentTemplateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/CreateIncidentUpdateRequest.php
+++ b/src/Http/Requests/CreateIncidentUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\IncidentStatusEnum;

--- a/src/Http/Requests/CreateMetricPointRequest.php
+++ b/src/Http/Requests/CreateMetricPointRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/CreateMetricRequest.php
+++ b/src/Http/Requests/CreateMetricRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Rules\FactorOfSixty;

--- a/src/Http/Requests/CreateScheduleRequest.php
+++ b/src/Http/Requests/CreateScheduleRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\ComponentStatusEnum;

--- a/src/Http/Requests/DeleteComponentRequest.php
+++ b/src/Http/Requests/DeleteComponentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/DeleteIncidentRequest.php
+++ b/src/Http/Requests/DeleteIncidentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/DeleteIncidentTemplateRequest.php
+++ b/src/Http/Requests/DeleteIncidentTemplateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/DeleteMetricRequest.php
+++ b/src/Http/Requests/DeleteMetricRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/ProfileUpdateRequest.php
+++ b/src/Http/Requests/ProfileUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use App\Models\User;

--- a/src/Http/Requests/UpdateComponentGroupRequest.php
+++ b/src/Http/Requests/UpdateComponentGroupRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/UpdateComponentRequest.php
+++ b/src/Http/Requests/UpdateComponentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\ComponentStatusEnum;

--- a/src/Http/Requests/UpdateIncidentRequest.php
+++ b/src/Http/Requests/UpdateIncidentRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\IncidentStatusEnum;

--- a/src/Http/Requests/UpdateIncidentTemplateRequest.php
+++ b/src/Http/Requests/UpdateIncidentTemplateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Http/Requests/UpdateIncidentUpdateRequest.php
+++ b/src/Http/Requests/UpdateIncidentUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\IncidentStatusEnum;

--- a/src/Http/Requests/UpdateMetricRequest.php
+++ b/src/Http/Requests/UpdateMetricRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Rules\FactorOfSixty;

--- a/src/Http/Requests/UpdateScheduleRequest.php
+++ b/src/Http/Requests/UpdateScheduleRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Requests;
 
 use Cachet\Enums\ComponentStatusEnum;

--- a/src/Http/Resources/Component.php
+++ b/src/Http/Resources/Component.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
 
+/**
+ * @mixin \Cachet\Models\Component
+ */
 class Component extends JsonApiResource
 {
     public function toAttributes(Request $request): array

--- a/src/Http/Resources/ComponentGroup.php
+++ b/src/Http/Resources/ComponentGroup.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
+/**
+ * @mixin \Cachet\Models\ComponentGroup
+ */
 class ComponentGroup extends JsonApiResource
 {
     public function toAttributes(Request $request): array
@@ -25,6 +31,9 @@ class ComponentGroup extends JsonApiResource
         ];
     }
 
+    /**
+     * @return array<string, (callable(): JsonApiResourceCollection)>
+     */
     public function toRelationships(Request $request): array
     {
         return [

--- a/src/Http/Resources/Incident.php
+++ b/src/Http/Resources/Incident.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
+/**
+ * @mixin \Cachet\Models\Incident
+ */
 class Incident extends JsonApiResource
 {
     public function toAttributes(Request $request): array
@@ -37,11 +43,14 @@ class Incident extends JsonApiResource
         ];
     }
 
-    public function toRelationships(Request $request)
+    /**
+     * @return array<string, (callable(): JsonApiResourceCollection)>
+     */
+    public function toRelationships(Request $request): array
     {
         return [
             'component' => fn () => Component::make($this->component),
-            'updates' => fn () => IncidentUpdate::collection($this->updates),
+            'updates' => fn () => IncidentUpdate::collection($this->incidentUpdates),
             'user' => fn () => Component::make($this->user),
         ];
     }

--- a/src/Http/Resources/IncidentUpdate.php
+++ b/src/Http/Resources/IncidentUpdate.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
 
+/**
+ * @mixin \Cachet\Models\IncidentUpdate
+ */
 class IncidentUpdate extends JsonApiResource
 {
     public function toAttributes(Request $request): array

--- a/src/Http/Resources/Metric.php
+++ b/src/Http/Resources/Metric.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
+/**
+ * @mixin \Cachet\Models\Metric
+ */
 class Metric extends JsonApiResource
 {
     public function toAttributes(Request $request): array
@@ -34,6 +40,9 @@ class Metric extends JsonApiResource
         ];
     }
 
+    /**
+     * @return array<string, (callable(): JsonApiResourceCollection)>
+     */
     public function toRelationships(Request $request): array
     {
         return [

--- a/src/Http/Resources/MetricPoint.php
+++ b/src/Http/Resources/MetricPoint.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
 
+/**
+ * @mixin \Cachet\Models\MetricPoint
+ */
 class MetricPoint extends JsonApiResource
 {
     public function toAttributes(Request $request): array

--- a/src/Http/Resources/Schedule.php
+++ b/src/Http/Resources/Schedule.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
+/**
+ * @mixin \Cachet\Models\Schedule
+ */
 class Schedule extends JsonApiResource
 {
     public function toAttributes(Request $request): array
@@ -32,6 +38,9 @@ class Schedule extends JsonApiResource
         ];
     }
 
+    /**
+     * @return array<string, (callable(): JsonApiResourceCollection)>
+     */
     public function toRelationships(Request $request): array
     {
         return [

--- a/src/Http/Resources/ScheduleComponent.php
+++ b/src/Http/Resources/ScheduleComponent.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource;
 
+/**
+ * @mixin \Cachet\Models\ScheduleComponent
+ */
 class ScheduleComponent extends JsonApiResource
 {
     public function toAttributes(Request $request): array

--- a/src/Http/Resources/Tag.php
+++ b/src/Http/Resources/Tag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Http\Resources;
 
 use Illuminate\Http\Request;

--- a/src/Jobs/SendBeaconJob.php
+++ b/src/Jobs/SendBeaconJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Jobs;
 
 class SendBeaconJob

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Events\Components\ComponentCreated;
 use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,10 +19,36 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $component_group_id
+ * @property string $name
+ * @property string $description
+ * @property string $link
+ * @property ComponentStatusEnum $status
+ * @property int $order
+ * @property bool $enabled
+ * @property array $meta
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon $deleted_at
+ *
+ * Relationships
+ * @property ?ComponentGroup $group
+ * @property Collection<array-key, Incident> $incidents
+ * @property Collection<array-key, Subscriber> $subscribers
+ *
+ * Methods
+ *
+ * @method static ComponentFactory factory($count = null, $state = [])
+ */
 class Component extends Model
 {
     use HasFactory, SoftDeletes;
 
+    /** @var array<string, string> */
     protected $casts = [
         'status' => ComponentStatusEnum::class,
         'order' => 'int',
@@ -25,6 +56,7 @@ class Component extends Model
         'meta' => 'json',
     ];
 
+    /** @var array<array-key, string> */
     protected $fillable = [
         'name',
         'description',
@@ -36,6 +68,7 @@ class Component extends Model
         'meta',
     ];
 
+    /** @var array<string, class-string> */
     protected $dispatchesEvents = [
         'created' => ComponentCreated::class,
         'deleted' => ComponentDeleted::class,

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -1,22 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ComponentGroupFactory;
 use Cachet\Enums\ComponentGroupVisibilityEnum;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $name
+ * @property int $order
+ * @property ComponentGroupVisibilityEnum $visible
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Collection<array-key, Component> $components
+ *
+ * Methods
+ *
+ * @method static ComponentGroupFactory factory($count = null, $state = [])
+ */
 class ComponentGroup extends Model
 {
     use HasFactory;
 
+    /** @var array<string, string> */
     protected $casts = [
         'order' => 'int',
         'visible' => ComponentGroupVisibilityEnum::class,
     ];
 
+    /** @var array<array-key, string> */
     protected $fillable = [
         'name',
         'order',

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -1,12 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use App\Models\User;
+use Cachet\Database\Factories\IncidentFactory;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Events\Incidents\IncidentCreated;
 use Cachet\Events\Incidents\IncidentDeleted;
 use Cachet\Events\Incidents\IncidentUpdated;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,6 +20,35 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $guid
+ * @property int $user_id
+ * @property int $component_id
+ * @property string $name
+ * @property string $message
+ * @property IncidentStatusEnum $status
+ * @property bool $visible
+ * @property bool $stickied
+ * @property array $notifications
+ * @property Carbon $scheduled_at
+ * @property Carbon $occurred_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon $deleted_at
+ *
+ * Relationships
+ * @property ?User $user
+ * @property Component $component
+ * @property Collection<array-key, Component> $components
+ * @property Collection<array-key, IncidentUpdate> $incidentUpdates
+ *
+ * Methods
+ *
+ * @method static IncidentFactory factory($count = null, $state = [])
+ */
 class Incident extends Model
 {
     use HasFactory, SoftDeletes;

--- a/src/Models/IncidentComponent.php
+++ b/src/Models/IncidentComponent.php
@@ -1,11 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentComponentFactory;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $component_id
+ * @property int $incident_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Component $component
+ * @property Incident $incident
+ *
+ * Methods
+ *
+ * @method static IncidentComponentFactory factory($count = null, $state = [])
+ */
 class IncidentComponent extends Model
 {
     use HasFactory;

--- a/src/Models/IncidentTemplate.php
+++ b/src/Models/IncidentTemplate.php
@@ -1,11 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentTemplateFactory;
 use Cachet\Enums\IncidentTemplateEngineEnum;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $name
+ * @property string $template
+ * @property string $slug
+ * @property IncidentTemplateEngineEnum $engine
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Methods
+ *
+ * @method static IncidentTemplateFactory factory($count = null, $state = [])
+ */
 class IncidentTemplate extends Model
 {
     use HasFactory;
@@ -34,11 +53,11 @@ class IncidentTemplate extends Model
 
     private function renderWithTwig(array $variables = []): string
     {
-
+        return '';
     }
 
     private function renderWithBlade(array $variables = []): string
     {
-
+        return '';
     }
 }

--- a/src/Models/IncidentUpdate.php
+++ b/src/Models/IncidentUpdate.php
@@ -1,12 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentUpdateFactory;
 use Cachet\Enums\IncidentStatusEnum;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $user_id
+ * @property IncidentStatusEnum $status
+ * @property string $message
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Incident $incident
+ *
+ * Methods
+ *
+ * @method static IncidentUpdateFactory factory($count = null, $state = [])
+ */
 class IncidentUpdate extends Model
 {
     use HasFactory;

--- a/src/Models/Metric.php
+++ b/src/Models/Metric.php
@@ -1,17 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\MetricFactory;
 use Cachet\Enums\MetricTypeEnum;
 use Cachet\Enums\MetricViewEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Events\Metrics\MetricCreated;
 use Cachet\Events\Metrics\MetricDeleted;
 use Cachet\Events\Metrics\MetricUpdated;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $name
+ * @property string $suffix
+ * @property string $description
+ * @property int $status
+ * @property string $default_value
+ * @property int $threshold
+ * @property MetricTypeEnum $calc_type
+ * @property bool $display_chart
+ * @property int $places
+ * @property MetricViewEnum $default_view
+ * @property ResourceVisibilityEnum $visible
+ * @property int $order
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Collection<array-key, MetricPoint> $metricPoints
+ * @property Collection<array-key, MetricPoint> $recentMetricPoints
+ *
+ * Methods
+ *
+ * @method static MetricFactory factory($count = null, $state = [])
+ */
 class Metric extends Model
 {
     use HasFactory;

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\MetricPointFactory;
 use Cachet\Events\Metrics\MetricPointCreated;
 use Cachet\Events\Metrics\MetricPointDeleted;
 use DateTime;
@@ -11,6 +14,24 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $metric_id
+ * @property float $value
+ * @property int $counter
+ * @property int|float $calculated_value
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Metric $metric
+ *
+ * Methods
+ *
+ * @method static  MetricPointFactory factory($count = null, $state = [])
+ */
 class MetricPoint extends Model
 {
     use HasFactory;
@@ -42,9 +63,9 @@ class MetricPoint extends Model
     public function createdAt(): Attribute
     {
         return Attribute::make(
-            set: function ($createdAt) {
+            set: function ($createdAt): ?Carbon {
                 if (! $createdAt) {
-                    return;
+                    return null;
                 }
 
                 if (! $createdAt instanceof DateTime) {
@@ -72,7 +93,7 @@ class MetricPoint extends Model
      */
     public function withinThreshold(int $threshold, string|int|DateTime $timestamp = null): bool
     {
-        $now = Carbon::parse($timestamp) ?? now();
+        $now = $timestamp ? Carbon::parse($timestamp) : now();
 
         return $this->created_at->startOfMinute()->diffInMinutes($now->startOfMinute()) < $threshold;
     }

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -1,15 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
 use Cachet\Enums\ScheduleStatusEnum;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $name
+ * @property string $message
+ * @property ScheduleStatusEnum $status
+ * @property Carbon $scheduled_at
+ * @property Carbon $completed_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Collection<array-key, Component> $components
+ */
 class Schedule extends Model
 {
     use HasFactory, SoftDeletes;

--- a/src/Models/ScheduleComponent.php
+++ b/src/Models/ScheduleComponent.php
@@ -1,11 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ScheduleComponentFactory;
+use Cachet\Enums\ComponentStatusEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $schedule_id
+ * @property int $component_id
+ * @property ComponentStatusEnum $component_status
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property ?Schedule $schedule
+ * @property ?Component $component
+ *
+ * Methods
+ *
+ * @method static ScheduleComponentFactory factory($count = null, $state = [])
+ */
 class ScheduleComponent extends Model
 {
     use HasFactory;

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -1,10 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
 class Setting extends Model
 {
     use HasFactory;

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -1,15 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\SubscriberFactory;
 use Cachet\Events\Subscribers\SubscriberCreated;
 use Cachet\Events\Subscribers\SubscriberUnsubscribed;
 use Cachet\Events\Subscribers\SubscriberVerified;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property string $email
+ * @property ?string $verify_code
+ * @property ?Carbon $verified_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Collection<array-key, Component> $components
+ *
+ * Methods
+ *
+ * @method static SubscriberFactory factory($count = null, $state = [])
+ */
 class Subscriber extends Model
 {
     use HasFactory;

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -1,10 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * Properties
+ *
+ * @property-read int $id
+ * @property int $component_id
+ * @property int $subscriber_id
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * Relationships
+ * @property Component $component
+ * @property Subscriber $subscriber*
+ */
 class Subscription extends Model
 {
     /**

--- a/src/PendingRouteRegistration.php
+++ b/src/PendingRouteRegistration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet;
 
 use Cachet\Http\Controllers\HealthController;

--- a/src/Rules/FactorOfSixty.php
+++ b/src/Rules/FactorOfSixty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Rules;
 
 use Closure;

--- a/src/View/Components/Footer.php
+++ b/src/View/Components/Footer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\View\Components;
 
 use Cachet\Cachet;

--- a/src/View/Components/StatusBar.php
+++ b/src/View/Components/StatusBar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\View\Components;
 
 use Closure;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cachet\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/workbench/app/User.php
+++ b/workbench/app/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Workbench\App;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;

--- a/workbench/database/factories/UserFactory.php
+++ b/workbench/database/factories/UserFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Workbench\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;


### PR DESCRIPTION
## TL;DR
Adds dev tooling to cachet/core


## Description
This PR adds the following dev tools into the cachet/core project

- PHPStan (via Larastan), set to Level 5 – this can be incremented gradually if we want a higher level of strictness
- PHPInsights – configured to the "laravel" preset with "phpstorm" set as the IDE
- Laravel Pint – default preset, could be changed / adjusted as required

### Important things to note
- I've updated all PHP files to use `declare(strict_types=1);`
- I've added `format` (pint), `analyse` (phpstan) and `complexity` scripts to the `composer.json`
- I've **not** added any checks into CI (yet)