### PR TITLE
Don't use `lorisleiva/laravel-actions`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "illuminate/queue": "^10.0",
         "illuminate/support": "^10.0",
         "inertiajs/inertia-laravel": "^0.6",
-        "lorisleiva/laravel-actions": "^2.7",
         "nesbot/carbon": "^2.70",
         "spatie/laravel-query-builder": "^5.5",
         "tightenco/ziggy": "^1.6",

--- a/src/Actions/Component/CreateComponent.php
+++ b/src/Actions/Component/CreateComponent.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Models\Component;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateComponent
 {
-    use AsAction;
-
     public function handle(array $component): Component
     {
         return Component::create($component);

--- a/src/Actions/Component/DeleteComponent.php
+++ b/src/Actions/Component/DeleteComponent.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Models\Component;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteComponent
 {
-    use AsAction;
-
     public function handle(Component $component): void
     {
         $component->subscribers()->detach();

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\Component;
 
 use Cachet\Events\Components\ComponentStatusWasChanged;
 use Cachet\Models\Component;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateComponent
 {
-    use AsAction;
-
     public function handle(Component $component, array $data): Component
     {
         $oldStatus = $component->status;

--- a/src/Actions/ComponentGroup/CreateComponentGroup.php
+++ b/src/Actions/ComponentGroup/CreateComponentGroup.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateComponentGroup
 {
-    use AsAction;
-
     public function handle(array $data, ?array $components = []): ComponentGroup
     {
         return tap(ComponentGroup::create($data), function (ComponentGroup $componentGroup) use ($components) {

--- a/src/Actions/ComponentGroup/DeleteComponentGroup.php
+++ b/src/Actions/ComponentGroup/DeleteComponentGroup.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\ComponentGroup;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteComponentGroup
 {
-    use AsAction;
-
     public function handle(ComponentGroup $componentGroup)
     {
         $componentGroup->components()->update(['component_group_id' => null]);

--- a/src/Actions/ComponentGroup/UpdateComponentGroup.php
+++ b/src/Actions/ComponentGroup/UpdateComponentGroup.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\ComponentGroup;
 
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateComponentGroup
 {
-    use AsAction;
-
     public function handle(ComponentGroup $componentGroup, array $data = [], ?array $components = []): ComponentGroup
     {
         $componentGroup->update($data);

--- a/src/Actions/Incident/CreateIncident.php
+++ b/src/Actions/Incident/CreateIncident.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;
 use Illuminate\Support\Str;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateIncident
 {
-    use AsAction;
-
     public function handle(array $incident): Incident
     {
         return Incident::create(array_merge(

--- a/src/Actions/Incident/DeleteIncident.php
+++ b/src/Actions/Incident/DeleteIncident.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteIncident
 {
-    use AsAction;
-
     public function handle(Incident $incident)
     {
         $incident->incidentUpdates()->delete();

--- a/src/Actions/Incident/UpdateIncident.php
+++ b/src/Actions/Incident/UpdateIncident.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateIncident
 {
-    use AsAction;
-
     public function handle(Incident $incident, array $data): Incident
     {
         $incident->update($data);

--- a/src/Actions/IncidentTemplate/CreateIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/CreateIncidentTemplate.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\IncidentTemplate;
 
 use Cachet\Models\IncidentTemplate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateIncidentTemplate
 {
-    use AsAction;
-
     public function handle(): IncidentTemplate
     {
         //

--- a/src/Actions/IncidentTemplate/DeleteIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/DeleteIncidentTemplate.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\IncidentTemplate;
 
 use Cachet\Models\IncidentTemplate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteIncidentTemplate
 {
-    use AsAction;
-
     public function handle(IncidentTemplate $incidentTemplate)
     {
         $incidentTemplate->delete();

--- a/src/Actions/IncidentTemplate/UpdateIncidentTemplate.php
+++ b/src/Actions/IncidentTemplate/UpdateIncidentTemplate.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\IncidentTemplate;
 
 use Cachet\Models\IncidentTemplate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateIncidentTemplate
 {
-    use AsAction;
-
     public function handle(IncidentTemplate $incidentTemplate): IncidentTemplate
     {
         //

--- a/src/Actions/IncidentUpdate/CreateIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/CreateIncidentUpdate.php
@@ -5,19 +5,16 @@ namespace Cachet\Actions\IncidentUpdate;
 use Cachet\Actions\Incident\UpdateIncident;
 use Cachet\Models\Incident;
 use Cachet\Models\IncidentUpdate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateIncidentUpdate
 {
-    use AsAction;
-
     public function handle(Incident $incident, array $data): IncidentUpdate
     {
         $incidentUpdate = $incident->incidentUpdates()->create(array_merge(['user_id' => auth()->id()], $data));
 
         // Update the incident with the new status.
         if ($incident->status !== $data['status']) {
-            UpdateIncident::run($incidentUpdate->incident, [
+            app(UpdateIncident::class)->handle($incidentUpdate->incident, [
                 'status' => $data['status'],
             ]);
         }

--- a/src/Actions/IncidentUpdate/DeleteIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/DeleteIncidentUpdate.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\IncidentUpdate;
 
 use Cachet\Models\IncidentUpdate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteIncidentUpdate
 {
-    use AsAction;
-
     public function handle(IncidentUpdate $incidentUpdate)
     {
         $incidentUpdate->delete();

--- a/src/Actions/IncidentUpdate/UpdateIncidentUpdate.php
+++ b/src/Actions/IncidentUpdate/UpdateIncidentUpdate.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\IncidentUpdate;
 
 use Cachet\Models\IncidentUpdate;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateIncidentUpdate
 {
-    use AsAction;
-
     public function handle(IncidentUpdate $incidentUpdate, array $data): IncidentUpdate
     {
         $incidentUpdate->update($data);

--- a/src/Actions/Metric/CreateMetric.php
+++ b/src/Actions/Metric/CreateMetric.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateMetric
 {
-    use AsAction;
-
     public function handle(array $data): Metric
     {
         return Metric::create($data);

--- a/src/Actions/Metric/CreateMetricPoint.php
+++ b/src/Actions/Metric/CreateMetricPoint.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;
 use Cachet\Models\MetricPoint;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateMetricPoint
 {
-    use AsAction;
-
     public function handle(Metric $metric, array $data = []): MetricPoint
     {
         $lastPoint = $metric->metricPoints()->latest()->first();

--- a/src/Actions/Metric/DeleteMetric.php
+++ b/src/Actions/Metric/DeleteMetric.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteMetric
 {
-    use AsAction;
-
     public function handle(Metric $metric)
     {
         $metric->metricPoints()->delete();

--- a/src/Actions/Metric/DeleteMetricPoint.php
+++ b/src/Actions/Metric/DeleteMetricPoint.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\MetricPoint;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteMetricPoint
 {
-    use AsAction;
-
     public function handle(MetricPoint $metricPoint): void
     {
         $metricPoint->delete();

--- a/src/Actions/Metric/UpdateMetric.php
+++ b/src/Actions/Metric/UpdateMetric.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Metric;
 
 use Cachet\Models\Metric;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateMetric
 {
-    use AsAction;
-
     public function handle(Metric $metric, ?array $data = []): Metric
     {
         $metric->update($data);

--- a/src/Actions/Schedule/CreateSchedule.php
+++ b/src/Actions/Schedule/CreateSchedule.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateSchedule
 {
-    use AsAction;
-
     public function handle(array $data, ?array $components = []): Schedule
     {
         return tap(Schedule::create($data), function (Schedule $schedule) use ($components) {

--- a/src/Actions/Schedule/DeleteSchedule.php
+++ b/src/Actions/Schedule/DeleteSchedule.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteSchedule
 {
-    use AsAction;
-
     public function handle(Schedule $schedule)
     {
         $schedule->delete();

--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateSchedule
 {
-    use AsAction;
-
     public function handle(Schedule $schedule, array $data = [], ?array $components = []): Schedule
     {
         $schedule->update($data);

--- a/src/Actions/Subscriber/CreateSubscriber.php
+++ b/src/Actions/Subscriber/CreateSubscriber.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\Subscriber;
 
 use Cachet\Models\Subscriber;
 use Illuminate\Support\Str;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateSubscriber
 {
-    use AsAction;
-
     public function handle(string $email, bool $global = false, array $components = [], bool $verified = false): Subscriber
     {
         $subscriber = Subscriber::firstOrCreate([

--- a/src/Actions/Subscriber/UnsubscribeSubscriber.php
+++ b/src/Actions/Subscriber/UnsubscribeSubscriber.php
@@ -4,12 +4,9 @@ namespace Cachet\Actions\Subscriber;
 
 use Cachet\Events\Subscribers\SubscriberUnsubscribed;
 use Cachet\Models\Subscriber;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UnsubscribeSubscriber
 {
-    use AsAction;
-
     public function handle(Subscriber $subscriber): void
     {
         $subscriber->components()->delete();

--- a/src/Actions/Subscriber/UpdateSubscriber.php
+++ b/src/Actions/Subscriber/UpdateSubscriber.php
@@ -3,12 +3,9 @@
 namespace Cachet\Actions\Subscriber;
 
 use Cachet\Models\Subscriber;
-use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateSubscriber
 {
-    use AsAction;
-
     public function handle(Subscriber $subscriber, ?string $email = null, bool $global = false, array $components = []): Subscriber
     {
         $subscriber->update(array_filter([

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -32,9 +32,9 @@ class ComponentController extends Controller
     /**
      * Create Component.
      */
-    public function store(CreateComponentRequest $request)
+    public function store(CreateComponentRequest $request, CreateComponent $createComponentAction)
     {
-        $component = CreateComponent::run($request->validated());
+        $component = $createComponentAction->handle($request->validated());
 
         return ComponentResource::make($component);
     }
@@ -52,9 +52,9 @@ class ComponentController extends Controller
     /**
      * Update Component.
      */
-    public function update(UpdateComponentRequest $request, Component $component)
+    public function update(UpdateComponentRequest $request, Component $component, UpdateComponent $updateComponentAction)
     {
-        UpdateComponent::run($component, $request->validated());
+        $updateComponentAction->handle($component, $request->validated());
 
         return ComponentResource::make($component->fresh());
     }
@@ -62,12 +62,12 @@ class ComponentController extends Controller
     /**
      * Delete Component.
      */
-    public function destroy(Component $component)
+    public function destroy(Component $component, DeleteComponent $deleteComponentAction)
     {
         // @todo what happens to incidents linked to this component?
         // @todo re-calculate existing component orders?
 
-        DeleteComponent::run($component);
+        $deleteComponentAction->handle($component);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -31,11 +31,11 @@ class ComponentGroupController extends Controller
     /**
      * Create Component Group.
      */
-    public function store(CreateComponentGroupRequest $request)
+    public function store(CreateComponentGroupRequest $request, CreateComponentGroup $createComponentGroupAction)
     {
         [$data, $components] = [$request->except('components'), $request->validated('components')];
 
-        $componentGroup = CreateComponentGroup::run($data, $components);
+        $componentGroup = $createComponentGroupAction->handle($data, $components);
 
         return ComponentGroupResource::make($componentGroup);
     }
@@ -53,11 +53,11 @@ class ComponentGroupController extends Controller
     /**
      * Update Component Group
      */
-    public function update(UpdateComponentGroupRequest $request, ComponentGroup $componentGroup)
+    public function update(UpdateComponentGroupRequest $request, ComponentGroup $componentGroup, UpdateComponentGroup $updateComponentGroupAction)
     {
         [$data, $components] = [$request->except('components'), $request->validated('components')];
 
-        UpdateComponentGroup::run($componentGroup, $data, $components);
+        $updateComponentGroupAction->handle($componentGroup, $data, $components);
 
         return ComponentGroupResource::make($componentGroup->fresh());
     }
@@ -65,9 +65,9 @@ class ComponentGroupController extends Controller
     /**
      * Delete Component Group.
      */
-    public function destroy(ComponentGroup $componentGroup)
+    public function destroy(ComponentGroup $componentGroup, DeleteComponentGroup $deleteComponentGroupAction)
     {
-        DeleteComponentGroup::run($componentGroup);
+        $deleteComponentGroupAction->handle($componentGroup);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -36,9 +36,9 @@ class IncidentController extends Controller
     /**
      * Create Incident.
      */
-    public function store(CreateIncidentRequest $request)
+    public function store(CreateIncidentRequest $request, CreateIncident $createIncidentAction)
     {
-        $incident = CreateIncident::run($request->validated());
+        $incident = $createIncidentAction->handle($request->validated());
 
         return IncidentResource::make($incident);
     }
@@ -56,9 +56,9 @@ class IncidentController extends Controller
     /**
      * Update Incident.
      */
-    public function update(UpdateIncidentRequest $request, Incident $incident)
+    public function update(UpdateIncidentRequest $request, Incident $incident, UpdateIncident $updateIncidentAction)
     {
-        UpdateIncident::run($incident, $request->validated());
+        $updateIncidentAction->handle($incident, $request->validated());
 
         return IncidentResource::make($incident->fresh());
     }
@@ -66,9 +66,9 @@ class IncidentController extends Controller
     /**
      * Delete Incident.
      */
-    public function destroy(Incident $incident)
+    public function destroy(Incident $incident, DeleteIncident $deleteIncidentAction)
     {
-        DeleteIncident::run($incident);
+        $deleteIncidentAction->handle($incident);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -33,9 +33,9 @@ class IncidentUpdateController extends Controller
     /**
      * Create Incident Update.
      */
-    public function store(CreateIncidentUpdateRequest $request, Incident $incident)
+    public function store(CreateIncidentUpdateRequest $request, Incident $incident, CreateIncidentUpdate $createIncidentUpdateAction)
     {
-        $incidentUpdate = CreateIncidentUpdate::run($incident, $request->validated());
+        $incidentUpdate = $createIncidentUpdateAction->handle($incident, $request->validated());
 
         return IncidentUpdateResource::make($incidentUpdate);
     }
@@ -53,9 +53,9 @@ class IncidentUpdateController extends Controller
     /**
      * Update Incident Update.
      */
-    public function update(UpdateIncidentUpdateRequest $request, Incident $incident, IncidentUpdate $incidentUpdate)
+    public function update(UpdateIncidentUpdateRequest $request, Incident $incident, IncidentUpdate $incidentUpdate, UpdateIncidentUpdate $updateIncidentUpdateAction)
     {
-        UpdateIncidentUpdate::run($incidentUpdate, $request->validated());
+        $updateIncidentUpdateAction->handle($incidentUpdate, $request->validated());
 
         return IncidentUpdateResource::make($incidentUpdate->fresh());
     }
@@ -63,9 +63,9 @@ class IncidentUpdateController extends Controller
     /**
      * Delete Incident Update.
      */
-    public function destroy(Incident $incident, IncidentUpdate $incidentUpdate)
+    public function destroy(Incident $incident, IncidentUpdate $incidentUpdate, DeleteIncidentUpdate $deleteIncidentUpdateAction)
     {
-        DeleteIncidentUpdate::run($incidentUpdate);
+        $deleteIncidentUpdateAction->handle($incidentUpdate);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -36,9 +36,9 @@ class MetricController extends Controller
     /**
      * Create Metric.
      */
-    public function store(CreateMetricRequest $request)
+    public function store(CreateMetricRequest $request, CreateMetric $createMetricAction)
     {
-        $metric = CreateMetric::run($request->validated());
+        $metric = $createMetricAction->handle($request->validated());
 
         return MetricResource::make($metric);
     }
@@ -56,9 +56,9 @@ class MetricController extends Controller
     /**
      * Update Metric.
      */
-    public function update(UpdateMetricRequest $request, Metric $metric)
+    public function update(UpdateMetricRequest $request, Metric $metric, UpdateMetric $updateMetricAction)
     {
-        UpdateMetric::run($metric, $request->validated());
+        $updateMetricAction->handle($metric, $request->validated());
 
         return MetricResource::make($metric->fresh());
     }
@@ -66,9 +66,9 @@ class MetricController extends Controller
     /**
      * Delete Metric.
      */
-    public function destroy(Metric $metric)
+    public function destroy(Metric $metric, DeleteMetric $deleteMetricAction)
     {
-        DeleteMetric::run($metric);
+        $deleteMetricAction->handle($metric);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -31,9 +31,9 @@ class MetricPointController extends Controller
     /**
      * Create Metric Point.
      */
-    public function store(CreateMetricPointRequest $request, Metric $metric)
+    public function store(CreateMetricPointRequest $request, Metric $metric, CreateMetricPoint $createMetricPointAction)
     {
-        $metricPoint = CreateMetricPoint::run($metric, $request->validated());
+        $metricPoint = $createMetricPointAction->handle($metric, $request->validated());
 
         return MetricPointResource::make($metricPoint)
             ->response()
@@ -53,9 +53,9 @@ class MetricPointController extends Controller
     /**
      * Delete Metric Point.
      */
-    public function destroy(Metric $metric, MetricPoint $metricPoint)
+    public function destroy(Metric $metric, MetricPoint $metricPoint, DeleteMetricPoint $deleteMetricPointAction)
     {
-        DeleteMetricPoint::run($metricPoint);
+        $deleteMetricPointAction->handle($metricPoint);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -32,11 +32,11 @@ class ScheduleController extends Controller
     /**
      * Create Schedule.
      */
-    public function store(CreateScheduleRequest $request)
+    public function store(CreateScheduleRequest $request, CreateSchedule $createScheduleAction)
     {
         [$data, $components] = [$request->except('components'), $request->input('components')];
 
-        $schedule = CreateSchedule::run($data, $components);
+        $schedule = $createScheduleAction->handle($data, $components);
 
         return ScheduleResource::make($schedule);
     }
@@ -54,10 +54,10 @@ class ScheduleController extends Controller
     /**
      * Update Schedule.
      */
-    public function update(UpdateScheduleRequest $request, Schedule $schedule)
+    public function update(UpdateScheduleRequest $request, Schedule $schedule, UpdateSchedule $updateScheduleAction)
     {
         [$data, $components] = [$request->except('components'), $request->input('components')];
-        UpdateSchedule::run($schedule, $data, $components);
+        $updateScheduleAction->handle($schedule, $data, $components);
 
         return ScheduleResource::make($schedule->fresh());
     }
@@ -65,9 +65,9 @@ class ScheduleController extends Controller
     /**
      * Delete Schedule.
      */
-    public function destroy(Schedule $schedule)
+    public function destroy(Schedule $schedule, DeleteSchedule $deleteScheduleAction)
     {
-        DeleteSchedule::run($schedule);
+        $deleteScheduleAction->handle($schedule);
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Dashboard/ComponentController.php
+++ b/src/Http/Controllers/Dashboard/ComponentController.php
@@ -36,7 +36,7 @@ class ComponentController extends Controller
      */
     public function store(CreateComponentRequest $request): RedirectResponse
     {
-        CreateComponent::run(
+        app(CreateComponent::class)->handle(
             name: $request->input('name'),
             description: $request->input('description'),
             link: $request->input('link'),
@@ -78,7 +78,7 @@ class ComponentController extends Controller
      */
     public function destroy(Component $component): RedirectResponse
     {
-        DeleteComponent::run($component);
+        app(DeleteComponent::class)->handle($component);
 
         return redirect()->back();
     }

--- a/tests/Unit/Actions/Component/CreateComponentTest.php
+++ b/tests/Unit/Actions/Component/CreateComponentTest.php
@@ -15,7 +15,7 @@ it('can create a component', function () {
         'description' => 'My component description',
     ];
 
-    $component = CreateComponent::run($data);
+    $component = app(CreateComponent::class)->handle($data);
 
     expect($component)
         ->name->toBe($data['name'])
@@ -31,7 +31,7 @@ it('can create a component with a given status', function () {
         'status' => ComponentStatusEnum::performance_issues,
     ];
 
-    $component = CreateComponent::run($data);
+    $component = app(CreateComponent::class)->handle($data);
 
     expect($component)
         ->name->toBe($data['name'])

--- a/tests/Unit/Actions/Component/DeleteComponentTest.php
+++ b/tests/Unit/Actions/Component/DeleteComponentTest.php
@@ -10,7 +10,7 @@ it('can delete components', function () {
 
     $component = Component::factory()->create();
 
-    DeleteComponent::run($component);
+    app(DeleteComponent::class)->handle($component);
 
     $this->assertSoftDeleted('components', [
         'id' => $component->id,
@@ -27,7 +27,7 @@ it('deletes attached subscriptions when deleted', function () {
         'subscriber_id' => $subscriber->id,
     ]);
 
-    DeleteComponent::run($component);
+    app(DeleteComponent::class)->handle($component);
 
     $this->assertDatabaseMissing('subscriptions', [
         'subscriber_id' => $subscriber->id,

--- a/tests/Unit/Actions/Component/UpdateComponentTest.php
+++ b/tests/Unit/Actions/Component/UpdateComponentTest.php
@@ -20,7 +20,7 @@ it('can update a component', function () {
         'description' => 'My updated component description.',
     ];
 
-    UpdateComponent::run(
+    app(UpdateComponent::class)->handle(
         $component,
         $data
     );
@@ -42,7 +42,7 @@ it('dispatches ComponentStatusWasChanged when the status is changed', function (
         'status' => ComponentStatusEnum::operational,
     ]);
 
-    UpdateComponent::run($component, [
+    app(UpdateComponent::class)->handle($component, [
         'status' => ComponentStatusEnum::major_outage,
     ]);
 

--- a/tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
+++ b/tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
@@ -9,7 +9,7 @@ it('can create a component group with just a name', function () {
         'name' => 'Services',
     ];
 
-    $componentGroup = CreateComponentGroup::run($data);
+    $componentGroup = app(CreateComponentGroup::class)->handle($data);
 
     expect($componentGroup)
         ->name->toBe($data['name'])
@@ -24,7 +24,7 @@ it('can create a component group with a name, order and visibility', function ()
         'visible' => ComponentGroupVisibilityEnum::expanded,
     ];
 
-    $componentGroup = CreateComponentGroup::run($data);
+    $componentGroup = app(CreateComponentGroup::class)->handle($data);
 
     expect($componentGroup)
         ->name->toBe($data['name'])
@@ -39,7 +39,7 @@ it('can create a component group and add components', function () {
 
     $components = Component::factory()->count(3)->create();
 
-    $componentGroup = CreateComponentGroup::run($data, $components->pluck('id')->values()->all());
+    $componentGroup = app(CreateComponentGroup::class)->handle($data, $components->pluck('id')->values()->all());
 
     $this->assertDatabaseHas('components', [
         'component_group_id' => $componentGroup->id,

--- a/tests/Unit/Actions/ComponentGroup/DeleteComponentGroupTest.php
+++ b/tests/Unit/Actions/ComponentGroup/DeleteComponentGroupTest.php
@@ -7,7 +7,7 @@ use Cachet\Models\ComponentGroup;
 it('can delete a component group', function () {
     $componentGroup = ComponentGroup::factory()->create();
 
-    DeleteComponentGroup::run($componentGroup);
+    app(DeleteComponentGroup::class)->handle($componentGroup);
 
     $this->assertDatabaseMissing('component_groups', [
         'id' => $componentGroup->id,
@@ -18,7 +18,7 @@ it('resets the component_group_id for components in a deleted component group', 
     $component = Component::factory()->forGroup()->create();
     $componentGroupId = $component->component_group_id;
 
-    DeleteComponentGroup::run($component->group);
+    app(DeleteComponentGroup::class)->handle($component->group);
 
     $this->assertDatabaseMissing('component_groups', [
         'id' => $componentGroupId,

--- a/tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
+++ b/tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
@@ -11,7 +11,7 @@ it('can update a component group with just a name', function () {
         'name' => 'Services',
     ];
 
-    $componentGroup = UpdateComponentGroup::run($componentGroup, $data);
+    $componentGroup = app(UpdateComponentGroup::class)->handle($componentGroup, $data);
 
     expect($componentGroup)
         ->name->toBe($data['name']);
@@ -25,7 +25,7 @@ it('can update a component group without touching components', function () {
         'name' => 'Services',
     ];
 
-    $componentGroup = UpdateComponentGroup::run($componentGroup, $data);
+    $componentGroup = app(UpdateComponentGroup::class)->handle($componentGroup, $data);
 
     expect($componentGroup)
         ->name->toBe($data['name']);
@@ -38,7 +38,7 @@ it('can update a component group with components', function () {
     $components = Component::factory()->count(3)->create();
     $componentGroup = ComponentGroup::factory()->create();
 
-    $componentGroup = UpdateComponentGroup::run($componentGroup, [], $components->pluck('id')->values()->all());
+    $componentGroup = app(UpdateComponentGroup::class)->handle($componentGroup, [], $components->pluck('id')->values()->all());
 
     $this->assertDatabaseHas('components', [
         'component_group_id' => $componentGroup->id,

--- a/tests/Unit/Actions/Incident/CreateIncidentTest.php
+++ b/tests/Unit/Actions/Incident/CreateIncidentTest.php
@@ -15,7 +15,7 @@ it('can create an incident', function () {
         'message' => 'This is an incident message.',
     ];
 
-    $incident = CreateIncident::run($data);
+    $incident = app(CreateIncident::class)->handle($data);
 
     expect($incident)
         ->name->toBe($data['name'])
@@ -31,7 +31,7 @@ it('can create an incident with a given status', function () {
         'status' => IncidentStatusEnum::investigating,
     ];
 
-    $incident = CreateIncident::run($data);
+    $incident = app(CreateIncident::class)->handle($data);
 
     expect($incident)
         ->name->toBe($data['name'])

--- a/tests/Unit/Actions/Incident/DeleteIncidentTest.php
+++ b/tests/Unit/Actions/Incident/DeleteIncidentTest.php
@@ -10,7 +10,7 @@ it('can create delete an incident', function () {
 
     $incident = Incident::factory()->create();
 
-    DeleteIncident::run($incident);
+    app(DeleteIncident::class)->handle($incident);
 
     $this->assertSoftDeleted('incidents', [
         'id' => $incident->id,
@@ -22,7 +22,7 @@ it('can create delete an incident', function () {
 it('deletes related incident updates', function () {
     $incident = Incident::factory()->hasIncidentUpdates(2)->create();
 
-    DeleteIncident::run($incident);
+    app(DeleteIncident::class)->handle($incident);
 
     $this->assertSoftDeleted('incidents', [
         'id' => $incident->id,

--- a/tests/Unit/Actions/Incident/UpdateIncidentTest.php
+++ b/tests/Unit/Actions/Incident/UpdateIncidentTest.php
@@ -10,7 +10,7 @@ it('can update an incident', function () {
         'name' => 'Incident Updated',
     ];
 
-    UpdateIncident::run($incident, $data);
+    app(UpdateIncident::class)->handle($incident, $data);
 
     expect($incident)
         ->name->toBe($data['name']);

--- a/tests/Unit/Actions/IncidentUpdate/CreateIncidentUpdateTest.php
+++ b/tests/Unit/Actions/IncidentUpdate/CreateIncidentUpdateTest.php
@@ -12,7 +12,7 @@ it('can create an incident update', function () {
         'status' => IncidentStatusEnum::investigating,
     ];
 
-    $incidentUpdate = CreateIncidentUpdate::run($incident, $data);
+    $incidentUpdate = app(CreateIncidentUpdate::class)->handle($incident, $data);
 
     expect($incidentUpdate)
         ->message->toBe($data['message']);
@@ -28,7 +28,7 @@ it('updates the incident when the status is changed', function () {
         'status' => IncidentStatusEnum::identified,
     ];
 
-    $incidentUpdate = CreateIncidentUpdate::run($incident, $data);
+    $incidentUpdate = app(CreateIncidentUpdate::class)->handle($incident, $data);
 
     expect($incidentUpdate)
         ->message->toBe($data['message'])

--- a/tests/Unit/Actions/IncidentUpdate/DeleteIncidentUpdateTest.php
+++ b/tests/Unit/Actions/IncidentUpdate/DeleteIncidentUpdateTest.php
@@ -6,7 +6,7 @@ use Cachet\Models\IncidentUpdate;
 it('can delete an incident update', function () {
     $incidentUpdate = IncidentUpdate::factory()->forIncident()->create();
 
-    DeleteIncidentUpdate::run($incidentUpdate);
+    app(DeleteIncidentUpdate::class)->handle($incidentUpdate);
 
     $this->assertDatabaseMissing('incident_updates', [
         'id' => $incidentUpdate->id,

--- a/tests/Unit/Actions/IncidentUpdate/UpdateIncidentUpdateTest.php
+++ b/tests/Unit/Actions/IncidentUpdate/UpdateIncidentUpdateTest.php
@@ -10,7 +10,7 @@ it('can update an incident update', function () {
         'message' => 'Incident Updated',
     ];
 
-    UpdateIncidentUpdate::run($incidentUpdate, $data);
+    app(UpdateIncidentUpdate::class)->handle($incidentUpdate, $data);
 
     expect($incidentUpdate)
         ->message->toBe($data['message'])

--- a/tests/Unit/Actions/Metric/CreateMetricPointTest.php
+++ b/tests/Unit/Actions/Metric/CreateMetricPointTest.php
@@ -12,7 +12,7 @@ it('creates a metric point if it is the first point', function () {
 
     $metric = Metric::factory()->create();
 
-    $point = CreateMetricPoint::run($metric, [
+    $point = app(CreateMetricPoint::class)->handle($metric, [
         'value' => 1,
     ]);
 
@@ -34,7 +34,7 @@ it('creates a metric point with a default value', function () {
         'default_value' => 1234,
     ]);
 
-    $point = CreateMetricPoint::run($metric);
+    $point = app(CreateMetricPoint::class)->handle($metric);
 
     expect($point)->toBeInstanceOf(MetricPoint::class);
     $this->assertDatabaseHas('metric_points', [
@@ -54,7 +54,7 @@ it('increments the counter if within the metric\'s threshold', function () {
         'threshold' => 1,
     ]);
 
-    $point = CreateMetricPoint::run($metric, [
+    $point = app(CreateMetricPoint::class)->handle($metric, [
         'value' => 1,
     ]);
 
@@ -76,7 +76,7 @@ it('creates a metric point if it is outside of the metric\'s threshold', functio
         'threshold' => 1,
     ]);
 
-    $point = CreateMetricPoint::run($metric, [
+    $point = app(CreateMetricPoint::class)->handle($metric, [
         'value' => 1,
     ]);
 
@@ -98,7 +98,7 @@ it('creates a metric point for a given timestamp', function ($timestamp) {
         'threshold' => 1,
     ]);
 
-    $point = CreateMetricPoint::run($metric, [
+    $point = app(CreateMetricPoint::class)->handle($metric, [
         'value' => 1,
         'timestamp' => $timestamp,
     ]);

--- a/tests/Unit/Actions/Metric/CreateMetricTest.php
+++ b/tests/Unit/Actions/Metric/CreateMetricTest.php
@@ -17,7 +17,7 @@ it('can create a metric', function () {
         'places' => 1,
     ];
 
-    $metric = CreateMetric::run($data);
+    $metric = app(CreateMetric::class)->handle($data);
 
     expect($metric)
         ->name->toBe('Foo')

--- a/tests/Unit/Actions/Metric/DeleteMetricPointTest.php
+++ b/tests/Unit/Actions/Metric/DeleteMetricPointTest.php
@@ -9,7 +9,7 @@ it('can delete a metric point', function () {
     Event::fake();
     $metricPoint = MetricPoint::factory()->create();
 
-    DeleteMetricPoint::run($metricPoint);
+    app(DeleteMetricPoint::class)->handle($metricPoint);
 
     $this->assertDatabaseMissing('metric_points', [
         'id' => $metricPoint->id,

--- a/tests/Unit/Actions/Metric/DeleteMetricTest.php
+++ b/tests/Unit/Actions/Metric/DeleteMetricTest.php
@@ -9,7 +9,7 @@ it('can delete a metric', function () {
     Event::fake();
     $metric = Metric::factory()->create();
 
-    DeleteMetric::run($metric);
+    app(DeleteMetric::class)->handle($metric);
 
     $this->assertDatabaseMissing('metrics', [
         'id' => $metric->id,

--- a/tests/Unit/Actions/Metric/UpdateMetricTest.php
+++ b/tests/Unit/Actions/Metric/UpdateMetricTest.php
@@ -13,7 +13,7 @@ it('can update a metric', function () {
         'name' => 'Updated Metric',
     ];
 
-    $metric = UpdateMetric::run($metric, $data);
+    $metric = app(UpdateMetric::class)->handle($metric, $data);
 
     expect($metric)
         ->name->toBe($data['name']);

--- a/tests/Unit/Actions/Schedule/CreateScheduleTest.php
+++ b/tests/Unit/Actions/Schedule/CreateScheduleTest.php
@@ -11,7 +11,7 @@ it('can create a schedule without components', function () {
         'scheduled_at' => '2023-09-01 12:00:00',
     ];
 
-    $schedule = CreateSchedule::run($data);
+    $schedule = app(CreateSchedule::class)->handle($data);
 
     expect($schedule)
         ->name->toBe($data['name'])
@@ -29,7 +29,7 @@ it('can create a schedule with components', function () {
 
     [$componentA, $componentB] = Component::factory()->count(2)->create();
 
-    $schedule = CreateSchedule::run($data, [
+    $schedule = app(CreateSchedule::class)->handle($data, [
         ['id' => $componentA->id, 'status' => 3], // Partial Outage
         ['id' => $componentB->id, 'status' => 4], // Major Outage
     ]);

--- a/tests/Unit/Actions/Schedule/DeleteScheduleTest.php
+++ b/tests/Unit/Actions/Schedule/DeleteScheduleTest.php
@@ -6,7 +6,7 @@ use Cachet\Models\Schedule;
 it('can delete schedules', function () {
     $schedule = Schedule::factory()->create();
 
-    DeleteSchedule::run($schedule);
+    app(DeleteSchedule::class)->handle($schedule);
 
     $this->assertSoftDeleted('schedules', [
         'id' => $schedule->id,

--- a/tests/Unit/Actions/Schedule/UpdateScheduleTest.php
+++ b/tests/Unit/Actions/Schedule/UpdateScheduleTest.php
@@ -12,7 +12,7 @@ it('can update a schedule', function () {
         'name' => 'Schedule Updated',
     ];
 
-    UpdateSchedule::run($schedule, $data);
+    app(UpdateSchedule::class)->handle($schedule, $data);
 
     expect($schedule)
         ->name->toBe($data['name']);
@@ -22,7 +22,7 @@ it('can update a schedule with components', function () {
     $schedule = Schedule::factory()->create();
     [$componentA, $componentB] = Component::factory()->count(2)->create();
 
-    UpdateSchedule::run($schedule, [], [
+    app(UpdateSchedule::class)->handle($schedule, [], [
         ['id' => $componentA->id, 'status' => ComponentStatusEnum::performance_issues],
         ['id' => $componentB->id, 'status' => ComponentStatusEnum::major_outage],
     ]);

--- a/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
+++ b/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Event;
 it('can create a subscriber', function () {
     Event::fake();
 
-    $subscriber = CreateSubscriber::run('james@alt-three.com');
+    $subscriber = app(CreateSubscriber::class)->handle('james@alt-three.com');
 
     expect($subscriber)
         ->email->toBe('james@alt-three.com')
@@ -22,7 +22,7 @@ it('can create a subscriber', function () {
 it('can create a global subscriber', function () {
     Event::fake();
 
-    $subscriber = CreateSubscriber::run('james@alt-three.com', global: true);
+    $subscriber = app(CreateSubscriber::class)->handle('james@alt-three.com', global: true);
 
     expect($subscriber)
         ->email->toBe('james@alt-three.com')
@@ -36,7 +36,7 @@ it('can create a global subscriber', function () {
 it('can create a verified subscriber', function () {
     Event::fake();
 
-    $subscriber = CreateSubscriber::run('james@alt-three.com', verified: true);
+    $subscriber = app(CreateSubscriber::class)->handle('james@alt-three.com', verified: true);
 
     expect($subscriber)
         ->email->toBe('james@alt-three.com')
@@ -52,7 +52,7 @@ it('can create a subscriber with components', function () {
 
     [$componentA, $componentB] = Component::factory()->count(2)->create();
 
-    $subscriber = CreateSubscriber::run('james@alt-three.com', components: [
+    $subscriber = app(CreateSubscriber::class)->handle('james@alt-three.com', components: [
         $componentA->id, $componentB->id,
     ], verified: true);
 

--- a/tests/Unit/Actions/Subscriber/UnsubscribeSubscriberTest.php
+++ b/tests/Unit/Actions/Subscriber/UnsubscribeSubscriberTest.php
@@ -10,7 +10,7 @@ it('can unsubscribe a subscriber', function () {
 
     $subscriber = Subscriber::factory()->create();
 
-    UnsubscribeSubscriber::run($subscriber);
+    app(UnsubscribeSubscriber::class)->handle($subscriber);
 
     expect($subscriber->fresh())
         ->toBeNull();

--- a/tests/Unit/Actions/Subscriber/UpdateSubscriberTest.php
+++ b/tests/Unit/Actions/Subscriber/UpdateSubscriberTest.php
@@ -7,7 +7,7 @@ use Cachet\Models\Subscriber;
 it('can update a subscriber\'s email address', function () {
     $subscriber = Subscriber::factory()->create();
 
-    UpdateSubscriber::run($subscriber, email: 'james@alt-three.com');
+    app(UpdateSubscriber::class)->handle($subscriber, email: 'james@alt-three.com');
 
     expect($subscriber->fresh())
         ->email->toBe('james@alt-three.com');
@@ -18,7 +18,7 @@ it('can update a subscriber without passing an email address', function () {
         'email' => 'james@alt-three.com',
     ]);
 
-    UpdateSubscriber::run($subscriber);
+    app(UpdateSubscriber::class)->handle($subscriber);
 
     expect($subscriber->fresh())
         ->email->toBe('james@alt-three.com')
@@ -30,7 +30,7 @@ it('does not reset the verified_at column when updating a subscriber without cha
         'email' => 'james@alt-three.com',
     ]);
 
-    UpdateSubscriber::run($subscriber, email: 'james@alt-three.com');
+    app(UpdateSubscriber::class)->handle($subscriber, email: 'james@alt-three.com');
 
     expect($subscriber->fresh())
         ->email->toBe('james@alt-three.com')
@@ -44,7 +44,7 @@ it('resets the verified_at and verify_code columns when changing email', functio
 
     $verifyCode = $subscriber->verify_code;
 
-    UpdateSubscriber::run($subscriber, email: 'james@cachethq.io');
+    app(UpdateSubscriber::class)->handle($subscriber, email: 'james@cachethq.io');
 
     expect($subscriber->fresh())
         ->email->toBe('james@cachethq.io')
@@ -59,7 +59,7 @@ it('can update a subscriber\'s component subscriptions', function () {
     expect($subscriber->components)
         ->toHaveCount(1);
 
-    UpdateSubscriber::run($subscriber, components: [
+    app(UpdateSubscriber::class)->handle($subscriber, components: [
         $componentA->id, $componentB->id,
     ]);
 


### PR DESCRIPTION
By not relying on `lorisleiva/laravel-actions` we can support Laravel 11 sooner, we require less dependencies and we simplify some code.