### PR TITLE
API Rate Limiting

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -76,6 +76,18 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Cachet API Rate Limit (attempts per minute)
+     |--------------------------------------------------------------------------
+     |
+     | This is the rate limit for the Cachet API. By default, the API is rate
+     | limited to 300 requests a minute (or 5 requests a second). You can
+     | adjust the limit as needed by your application.
+     |
+     */
+    'rate_limit' => env('CACHET_API_RATE_LIMIT', 300),
+
+    /*
+     |--------------------------------------------------------------------------
      | Cachet Major Outage Threshold
      |--------------------------------------------------------------------------
      |

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -84,7 +84,7 @@ return [
      | adjust the limit as needed by your application.
      |
      */
-    'rate_limit' => env('CACHET_API_RATE_LIMIT', 300),
+    'api_rate_limit' => env('CACHET_API_RATE_LIMIT', 300),
 
     /*
      |--------------------------------------------------------------------------

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -76,7 +76,7 @@ class CachetCoreServiceProvider extends ServiceProvider
     private function configureRateLimiting(): void
     {
         RateLimiter::for('cachet-api', function ($request) {
-            return Limit::perMinute(config('cachet.rate_limit', 300))
+            return Limit::perMinute(config('cachet.api_rate_limit', 300))
                 ->by(optional($request->user())->id ?: $request->ip());
         });
     }

--- a/src/CachetServiceProvider.php
+++ b/src/CachetServiceProvider.php
@@ -42,7 +42,7 @@ class CachetServiceProvider extends ServiceProvider
     private function configureRateLimiting(): void
     {
         RateLimiter::for('cachet-api', function ($request) {
-            return Limit::perMinute(config('cachet.rate_limit', 300))
+            return Limit::perMinute(config('cachet.api_rate_limit', 300))
                 ->by(optional($request->user())->id ?: $request->ip());
         });
     }

--- a/src/CachetServiceProvider.php
+++ b/src/CachetServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace Cachet;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class CachetServiceProvider extends ServiceProvider
@@ -26,10 +28,23 @@ class CachetServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->configureRateLimiting();
+
         $this->registerRoutes();
         $this->registerResources();
         $this->registerPublishing();
         $this->registerCommands();
+    }
+
+    /**
+     * Configure the rate limiting for the application.
+     */
+    private function configureRateLimiting(): void
+    {
+        RateLimiter::for('cachet-api', function ($request) {
+            return Limit::perMinute(config('cachet.rate_limit', 300))
+                ->by(optional($request->user())->id ?: $request->ip());
+        });
     }
 
     /**
@@ -42,7 +57,7 @@ class CachetServiceProvider extends ServiceProvider
                 'domain' => config('cachet.domain', null),
                 'as' => 'cachet.api.',
                 'prefix' => Cachet::path().'/api',
-                'middleware' => 'cachet:api',
+                'middleware' => ['cachet:api', 'throttle:cachet-api'],
             ], function (Router $router) {
                 $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
             });

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -23,7 +23,7 @@ it('API routes are rate limited to 300 requests a minute', function () {
 });
 
 test('API rate limiting can be configured via config', function (int $limit) {
-    $this->app['config']->set(['cachet.rate_limit' => $limit]);
+    $this->app['config']->set(['cachet.api_rate_limit' => $limit]);
 
     for ($i = 0; $i <= $limit; $i++) {
         $response = getJson('test');

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+use Pest\Expectation;
+use function Pest\Laravel\getJson;
+
+beforeEach(function () {
+    Route::get('/test', fn () => response()->json())
+        ->middleware('throttle:cachet-api');
+
+    RateLimiter::clear(md5('cachet-api'));
+});
+
+it('API routes are rate limited to 300 requests a minute', function () {
+    for ($i = 0; $i <= 300; $i++) {
+        $response = getJson('/test');
+
+        expect($response->status())
+            ->when($i < 300, fn (Expectation $value) => $value->toBe(200))
+            ->when($i === 300, fn (Expectation $value) => $value->toBe(429));
+    }
+});
+
+test('API rate limiting can be configured via config', function (int $limit) {
+    $this->app['config']->set(['cachet.rate_limit' => $limit]);
+
+    for ($i = 0; $i <= $limit; $i++) {
+        $response = getJson('test');
+
+        expect($response->status())
+            ->when($i < $limit, fn (Expectation $value) => $value->toBe(200))
+            ->when($i === $limit, fn (Expectation $value) => $value->toBe(429));
+    }
+})->with([
+    1,
+    10,
+    60,
+    100,
+    1000,
+]);

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Pest\Expectation;
 use function Pest\Laravel\getJson;
@@ -8,8 +7,6 @@ use function Pest\Laravel\getJson;
 beforeEach(function () {
     Route::get('/test', fn () => response()->json())
         ->middleware('throttle:cachet-api');
-
-    RateLimiter::clear(md5('cachet-api'));
 });
 
 it('API routes are rate limited to 300 requests a minute', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ namespace Cachet\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\RateLimiter;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -19,8 +18,6 @@ abstract class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Cachet\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
-
-        $this->withoutApiRateLimiting();
     }
 
     /**
@@ -33,13 +30,5 @@ abstract class TestCase extends Orchestra
             'database.default' => 'testing',
             // 'query-builder.request_data_source' => 'body',
         ]);
-    }
-
-    /**
-     * Overrides the rate limiting defined by workbench.
-     */
-    protected function withoutApiRateLimiting(): void
-    {
-        RateLimiter::for('api', fn () => null);
     }
 }


### PR DESCRIPTION
closes #35 

Adds a default rating limit of 300 requests / minute to all cachet API routes, overridable via the `cachet.api_rate_limit` config setting.