### PR TITLE
Fix sponsor shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://github.com/cachethq/core/actions">
         <img src="https://github.com/cachethq/core/workflows/run-tests/badge.svg" alt="Build Status">
     </a>
-    <a href="https://github.com/cachethq/cacheth/?sponsor=1">
+    <a href="https://github.com/sponsors/cachethq/?sponsor=1">
         <img src="https://img.shields.io/github/sponsors/cachethq" alt="GitHub Sponsors">
     </a>
     <a href="https://packagist.org/packages/cachethq/core">


### PR DESCRIPTION
The href in the sponsor shield was pointing to the wrong URL