### PR TITLE
Make the UUID visible for incidents

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -14,6 +14,7 @@
     "Custom Footer HTML": "Custom Footer HTML",
     "Custom Header HTML": "Custom Header HTML",
     "Dashboard": "Dashboard",
+    "Edit Incident": "Edit Incident",
     "Fixed": "Fixed",
     "Guests": "Guests",
     "Identified": "Identified",

--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -24,8 +24,18 @@
                     <x-cachet::incident-badge :type="$incident->status" />
                 </div>
             </div>
-            <div class="mt-5 text-sm md:text-base w-1/2">
-                {!! $incident->formattedMessage() !!}
+            <div class="mt-5 text-sm md:text-base flex">
+                <div class="w-1/2">
+                    {!! $incident->formattedMessage() !!}
+                </div>
+                <div class="w-1/2 flex flex-wrap justify-end items-end">
+                    @if(auth()->check())
+                        <a href="{{ $incident->filamentDashboardEditUrl() }}" class="underline">View in Dashboard</a>
+                    @endif
+                    <p class="text-xs">
+                        Incident UUID: {{ $incident->guid }}
+                    </p>
+                </div>
             </div>
         </div>
         @if($incident->incidentUpdates->isNotEmpty())

--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -1,7 +1,6 @@
 @props([
     'date',
     'incidents',
-    'showIncidentUuid' => false,
 ])
 
 <div class="relative flex flex-col gap-5" x-data="{ forDate: new Date(@js($date)) }">
@@ -30,6 +29,9 @@
             <div class="prose-sm md:prose md:prose-zinc dark:text-zinc-100">
                 {!! $incident->formattedMessage() !!}
             </div>
+            @if(auth()->check())
+                <a href="{{ $incident->filamentDashboardEditUrl() }}" class="underline text-right text-sm text-zinc-500 dark:text-zinc-400">View in Dashboard</a>
+            @endif
         </div>
 
         @if($incident->incidentUpdates->isNotEmpty())

--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -1,6 +1,7 @@
 @props([
     'date',
     'incidents',
+    'showIncidentUuid' => false,
 ])
 
 <div class="relative flex flex-col">
@@ -32,9 +33,11 @@
                     @if(auth()->check())
                         <a href="{{ $incident->filamentDashboardEditUrl() }}" class="underline">View in Dashboard</a>
                     @endif
-                    <p class="text-xs">
-                        Incident UUID: {{ $incident->guid }}
-                    </p>
+                    @if($showIncidentUuid)
+                        <p class="text-xs">
+                            Incident UUID: {{ $incident->guid }}
+                        </p>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -15,9 +15,16 @@
             <div class="text-xs font-medium">{{ $incident->components->pluck('name')->join(', ') }}</div>
             <div class="flex flex-col sm:flex-row justify-between gap-2 flex-col-reverse">
                 <div class="flex flex-col flex-1">
-                    <h3 class="max-w-full text-base font-semibold break-words sm:text-xl">
-                        <a href="{{ route('cachet.status-page.incident', $incident) }}">{{ $incident->name}}</a>
-                    </h3>
+                    <div class="flex gap-2 items-center">
+                        <h3 class="max-w-full text-base font-semibold break-words sm:text-xl">
+                            <a href="{{ route('cachet.status-page.incident', $incident) }}">{{ $incident->name}}</a>
+                        </h3>
+                        @auth
+                            <a href="{{ $incident->filamentDashboardEditUrl() }}" class="underline text-right text-sm text-zinc-500 hover:text-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-300" title="{{ __('Edit Incident') }}">
+                                <x-heroicon-m-pencil-square class="size-4" />
+                            </a>
+                        @endauth
+                    </div>
                     <span class="text-xs text-zinc-500 dark:text-zinc-400">
                         {{ $incident->timestamp->diffForHumans() }} — <span x-text="timestamp.toLocaleString()"></span>
                     </span>
@@ -29,9 +36,6 @@
             <div class="prose-sm md:prose md:prose-zinc dark:text-zinc-100">
                 {!! $incident->formattedMessage() !!}
             </div>
-            @if(auth()->check())
-                <a href="{{ $incident->filamentDashboardEditUrl() }}" class="underline text-right text-sm text-zinc-500 dark:text-zinc-400">View in Dashboard</a>
-            @endif
         </div>
 
         @if($incident->incidentUpdates->isNotEmpty())

--- a/resources/views/status-page/incident.blade.php
+++ b/resources/views/status-page/incident.blade.php
@@ -6,7 +6,7 @@
 
         <div class="flex flex-col gap-6">
             <div class="flex flex-col gap-14 w-full">
-                <x-cachet::incident :date="$incident->timestamp" :incidents="[$incident]" />
+                <x-cachet::incident :date="$incident->timestamp" :incidents="[$incident]" :show-incident-uuid="true" />
             </div>
         </div>
     </div>

--- a/resources/views/status-page/incident.blade.php
+++ b/resources/views/status-page/incident.blade.php
@@ -6,7 +6,7 @@
 
         <div class="flex flex-col gap-6">
             <div class="flex flex-col gap-14 w-full">
-                <x-cachet::incident :date="$incident->timestamp" :incidents="[$incident]" :show-incident-uuid="true" />
+                <x-cachet::incident :date="$incident->timestamp" :incidents="[$incident]" />
             </div>
         </div>
 

--- a/resources/views/status-page/incident.blade.php
+++ b/resources/views/status-page/incident.blade.php
@@ -9,6 +9,10 @@
                 <x-cachet::incident :date="$incident->timestamp" :incidents="[$incident]" :show-incident-uuid="true" />
             </div>
         </div>
+
+        <p class="text-xs text-right">
+            Incident UUID: {{ $incident->guid }}
+        </p>
     </div>
 
     <x-cachet::footer />

--- a/src/Filament/Resources/IncidentResource.php
+++ b/src/Filament/Resources/IncidentResource.php
@@ -141,6 +141,10 @@ class IncidentResource extends Resource
                             ->inline()
                             ->required(),
                     ]),
+                Action::make('view-incident')
+                    ->icon('heroicon-o-eye')
+                    ->url(fn (Incident $record): string => route('cachet.status-page.incident', $record))
+                    ->label(__('View Incident')),
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ])

--- a/src/Filament/Resources/IncidentResource.php
+++ b/src/Filament/Resources/IncidentResource.php
@@ -68,6 +68,12 @@ class IncidentResource extends Resource
                     Forms\Components\Toggle::make('stickied')
                         ->label(__('Sticky Incident?'))
                         ->required(),
+                    Forms\Components\TextInput::make('guid')
+                        ->label('Incident UUID')
+                        ->visibleOn(['edit'])
+                        ->disabled()
+                        ->readonly()
+                        ->columnSpanFull(),
                 ])
                     ->columnSpan(1),
             ])

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -8,6 +8,7 @@ use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Events\Incidents\IncidentCreated;
 use Cachet\Events\Incidents\IncidentDeleted;
 use Cachet\Events\Incidents\IncidentUpdated;
+use Cachet\Filament\Resources\IncidentResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -118,5 +119,10 @@ class Incident extends Model
     public function formattedMessage(): string
     {
         return Str::of($this->message)->markdown();
+    }
+
+    public function filamentDashboardEditUrl(): string
+    {
+        return IncidentResource::getUrl(name: 'edit', parameters: ['record' => $this->id]);
     }
 }

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -121,6 +121,9 @@ class Incident extends Model
         return Str::of($this->message)->markdown();
     }
 
+    /**
+     * Get the URL to the incident page within the dashboard.
+     */
     public function filamentDashboardEditUrl(): string
     {
         return IncidentResource::getUrl(name: 'edit', parameters: ['record' => $this->id]);


### PR DESCRIPTION
Hey @jbrooksuk! This PR is an attempt to add some features mentioned in #73. I'm still really new to Cachet and Filament, so I do apologise if I've completely misunderstood what's needed and done it wrong. If that's the case, gimme a shout, and I'll get this PR updated right away 😄

This PR proposes that the UUID is now available in the Filament dashboard (at the bottom of the right hand panel):

<img width="1412" alt="Screenshot 2024-10-04 at 18 52 03" src="https://github.com/user-attachments/assets/01b34116-d28c-47c7-99b5-022ef335dab6">

It also adds the incident UUID to the incidents on the public-facing pages (in the bottom right of the incident cards):

<img width="1418" alt="Screenshot 2024-10-04 at 18 51 27" src="https://github.com/user-attachments/assets/007a6d6c-959d-4866-b75a-bcc69111fee8">

<img width="1429" alt="Screenshot 2024-10-04 at 18 51 35" src="https://github.com/user-attachments/assets/72ecd6be-c2b9-4390-91dc-6138ccaa7342">

And if the user is authenticated, then a "View in Dashboard" link will be displayed that takes the user directly to the "edit" page in the Filament dashboard. This link is in the bottom right of the incident card again:

<img width="1407" alt="Screenshot 2024-10-04 at 18 52 46" src="https://github.com/user-attachments/assets/fe4b7eee-5e6d-42e5-bf12-86bb3e801b65">
<img width="1432" alt="Screenshot 2024-10-04 at 18 52 54" src="https://github.com/user-attachments/assets/c8f6899d-54af-40e3-8bb8-5fef476f7148">

I've not committed my `manifest.json` and `public/build/assets/cache.XXXX.css` files, but I noticed they're being tracked in GIt. Would you like me to commit them and push them up? 😄

Closes #73