### PR TITLE
Prefix the default cachet path with slash

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -21,7 +21,7 @@ return [
      |
      | This is the URI path where Cachet will be accessible from.
      */
-    'path' => env('CACHET_PATH', 'status'),
+    'path' => env('CACHET_PATH', '/status'),
 
     'guard' => env('CACHET_GUARD', null),
 

--- a/src/Cachet.php
+++ b/src/Cachet.php
@@ -58,7 +58,7 @@ class Cachet
      */
     public static function path(): string
     {
-        return config('cachet.path', 'status');
+        return config('cachet.path', '/status');
     }
 
     /**


### PR DESCRIPTION
Hey,

When clicking around the application I noticed that the `Status Page` in the navigation menu was resolving to the relative path:-

```
http://127.0.0.1:8000/status/status
```

So I've updated the defaults to contain the prefixed forward slash.