### PR TITLE
Support change of completed at date and clear when status is changed.

### DIFF
--- a/src/Enums/ScheduleStatusEnum.php
+++ b/src/Enums/ScheduleStatusEnum.php
@@ -60,4 +60,13 @@ enum ScheduleStatusEnum: int implements HasColor, HasIcon, HasLabel
             self::complete => 'heroicon-m-check-circle',
         };
     }
+
+    public static function parse(ScheduleStatusEnum|string|null $value): ?self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        return self::tryFrom($value);
+    }
 }

--- a/src/Filament/Resources/ScheduleResource.php
+++ b/src/Filament/Resources/ScheduleResource.php
@@ -28,16 +28,21 @@ class ScheduleResource extends Resource
                         ->required()
                         ->options(ScheduleStatusEnum::class)
                         ->default(ScheduleStatusEnum::upcoming)
+                        ->afterStateUpdated(function (Forms\Set $set, int|ScheduleStatusEnum $state): void {
+                            if (ScheduleStatusEnum::parse($state) !== ScheduleStatusEnum::complete) {
+                                $set('completed_at', null);
+                            }
+                        })
                         ->live(),
                     Forms\Components\MarkdownEditor::make('message')
                         ->columnSpanFull(),
-                ])->columnspan(3),
+                ])->columnSpan(3),
                 Forms\Components\Section::make()->schema([
                     Forms\Components\DateTimePicker::make('scheduled_at')
                         ->required(),
                     Forms\Components\DateTimePicker::make('completed_at')
-                        ->visible(fn (Forms\Get $get): bool => $get('status') === ScheduleStatusEnum::complete)
-                        ->markAsRequired(fn (Forms\Get $get): bool => $get('status') === ScheduleStatusEnum::complete),
+                        ->visible(fn (Forms\Get $get): bool => ScheduleStatusEnum::parse($get('status')) === ScheduleStatusEnum::complete)
+                        ->required(fn (Forms\Get $get): bool => ScheduleStatusEnum::parse($get('status')) === ScheduleStatusEnum::complete)
                 ])->columnSpan(1),
             ])->columns(4);
     }

--- a/src/Filament/Resources/ScheduleResource/Pages/EditSchedule.php
+++ b/src/Filament/Resources/ScheduleResource/Pages/EditSchedule.php
@@ -16,4 +16,11 @@ class EditSchedule extends EditRecord
             Actions\DeleteAction::make(),
         ];
     }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $data['completed_at'] = $data['completed_at'] ?? null;
+
+        return $data;
+    }
 }


### PR DESCRIPTION
**Issue:** https://github.com/cachethq/core/issues/75

Hopefully this is ok, I'm changing the completed_at timestamp to null when the status is changed to any status which isn't completed. We have to also do this in `mutateFormDataBeforeSave` method before saving as well as because the input is not visible it doesn't post the data and therefore preserves the original value.

The reason I had to add the enum method is sourced from a very similar issue here: https://github.com/filamentphp/filament/issues/10206

The Filament resource was returning inconsistent types, on create it was returning the enum type but on edit the values were being returned as integers. 