### PR TITLE
Separate ungrouped components on the status page

### DIFF
--- a/resources/views/components/component-ungrouped.blade.php
+++ b/resources/views/components/component-ungrouped.blade.php
@@ -1,0 +1,9 @@
+@props(['component' => null])
+
+<div class="overflow-hidden rounded-lg border shadow dark:border-zinc-700">
+    <div class="flex flex-col divide-y bg-white dark:bg-zinc-800">
+        <ul class="divide-y dark:divide-zinc-700">
+            <x-cachet::component :component="$component" />
+        </ul>
+    </div>
+</div>

--- a/resources/views/status-page/index.blade.php
+++ b/resources/views/status-page/index.blade.php
@@ -10,9 +10,9 @@
         <x-cachet::component-group :component-group="$componentGroup"/>
         @endforeach
 
-        @if($ungroupedComponents->components->isNotEmpty())
-        <x-cachet::component-group :component-group="$ungroupedComponents"/>
-        @endif
+        @foreach($ungroupedComponents as $component)
+        <x-cachet::component-ungrouped :component="$component" />
+        @endforeach
 
         @if($schedules->isNotEmpty())
         <x-cachet::schedules :schedules="$schedules" />

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -25,20 +25,12 @@ class StatusPageController
                 ->visible(auth()->check())
                 ->when(auth()->check(), fn (Builder $query) => $query->users(), fn ($query) => $query->guests())
                 ->get(),
-            'ungroupedComponents' => (new ComponentGroup([
-                'name' => __('Other Components'),
-                'collapsed' => ComponentGroupVisibilityEnum::expanded,
-                'visible' => ResourceVisibilityEnum::guest,
-            ]))
-                ->setRelation(
-                    'components',
-                    Component::query()
-                        ->enabled()
-                        ->whereNull('component_group_id')
-                        ->orderBy('order')
-                        ->withCount('incidents')
-                        ->get()
-                ),
+            'ungroupedComponents' => Component::query()
+                ->enabled()
+                ->whereNull('component_group_id')
+                ->orderBy('order')
+                ->withCount('incidents')
+                ->get(),
 
             'schedules' => Schedule::query()->inTheFuture()->orderBy('scheduled_at')->get(),
         ]);


### PR DESCRIPTION
Instead of grouping ungrouped components into an "Ungrouped Components" group, let's just list them separately, as intended. If you want them grouped, create a group :)

![image](https://github.com/user-attachments/assets/bb99829b-2bce-4e13-aa5c-347009851d6e)
