### PR TITLE
Improves the empty state view

### DIFF
--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -69,8 +69,12 @@
         </div>
     </div>
     @empty
-        <div class="mt-1 prose-sm md:prose prose-zinc dark:prose-invert prose-a:text-primary-500 prose-a:underline">
-            {{ __('No incidents reported.') }}
+        <div class="bg-white border divide-y rounded-lg ml-9 dark:divide-zinc-700 dark:border-zinc-700 dark:bg-zinc-800">
+            <div class="flex flex-col px-4 divide-y dark:divide-zinc-700">
+                <div class="relative py-4">
+                    {{ __('No incidents reported.') }}
+                </div>
+            </div>
         </div>
     @endforelse
 </div>


### PR DESCRIPTION
This PR improves the empty state view by adding some styling and aligning the sections.

- Desktop:
<img width="1036" alt="Screenshot 2024-10-12 at 11 03 39 PM" src="https://github.com/user-attachments/assets/fbdf6191-b9f0-4b10-b67e-f0658a1f0584">
<img width="1026" alt="Screenshot 2024-10-12 at 11 04 27 PM" src="https://github.com/user-attachments/assets/ec663e29-8c5d-4afe-a6af-0c2109b97248">

- Mobile:
<img width="388" alt="Screenshot 2024-10-12 at 11 03 21 PM" src="https://github.com/user-attachments/assets/bdb77c2a-7205-48ad-a083-738234fa039e">
<img width="388" alt="Screenshot 2024-10-12 at 11 04 53 PM" src="https://github.com/user-attachments/assets/c8ac92bc-0c3e-446e-8bc8-0fe6273cb619">

Closes #94
