### PR TITLE
feat: translate plurals independently

### DIFF
--- a/src/Filament/Resources/ComponentGroupResource.php
+++ b/src/Filament/Resources/ComponentGroupResource.php
@@ -97,4 +97,9 @@ class ComponentGroupResource extends Resource
     {
         return __('Component Group');
     }
+
+    public static function getPluralLabel(): ?string
+    {
+        return __('Component Groups');
+    }
 }

--- a/src/Filament/Resources/ComponentResource.php
+++ b/src/Filament/Resources/ComponentResource.php
@@ -118,6 +118,11 @@ class ComponentResource extends Resource
         return __('Component');
     }
 
+    public static function getPluralLabel(): ?string
+    {
+        return __('Components');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::outage()->count();

--- a/src/Filament/Resources/IncidentResource.php
+++ b/src/Filament/Resources/IncidentResource.php
@@ -177,6 +177,11 @@ class IncidentResource extends Resource
         return __('Incident');
     }
 
+    public static function getPluralLabel(): ?string
+    {
+        return __('Incidents');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::unresolved()->count();

--- a/src/Filament/Resources/IncidentTemplateResource.php
+++ b/src/Filament/Resources/IncidentTemplateResource.php
@@ -109,4 +109,9 @@ class IncidentTemplateResource extends Resource
     {
         return __('Incident Template');
     }
+
+    public static function getPluralLabel(): ?string
+    {
+        return __('Incident Templates');
+    }
 }

--- a/src/Filament/Resources/MetricResource.php
+++ b/src/Filament/Resources/MetricResource.php
@@ -136,6 +136,16 @@ class MetricResource extends Resource
             ->defaultSort('order');
     }
 
+    public static function getLabel(): ?string
+    {
+        return __('Metric');
+    }
+
+    public static function getPluralLabel(): ?string
+    {
+        return __('Metrics');
+    }
+
     public static function getRelations(): array
     {
         return [

--- a/src/Filament/Resources/ScheduleResource.php
+++ b/src/Filament/Resources/ScheduleResource.php
@@ -111,6 +111,11 @@ class ScheduleResource extends Resource
         return __('Schedule');
     }
 
+    public static function getPluralLabel(): ?string
+    {
+        return __('Schedules');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::incomplete()->count();

--- a/src/Filament/Resources/SubscriberResource.php
+++ b/src/Filament/Resources/SubscriberResource.php
@@ -106,6 +106,11 @@ class SubscriberResource extends Resource
 
     public static function getLabel(): ?string
     {
+        return __('Subscriber');
+    }
+
+    public static function getPluralLabel(): ?string
+    {
         return __('Subscribers');
     }
 }


### PR DESCRIPTION
Laravel by default forms plurals by appending an “s”, but this does not work in all languages (such as German).
This PR explicitly adds the plural forms in order to be able to translate them independently.