### PR TITLE
feat: Time-controlled status for Planned Maintenances / Schedules

### DIFF
--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -22,16 +22,14 @@ class ScheduleFactory extends Factory
     {
         return [
             'name' => 'Incident Schedule',
-            'status' => ScheduleStatusEnum::upcoming,
             'scheduled_at' => now()->addDays(7),
-            'completed_at' => null,
+            'completed_at' => now()->addDays(14),
         ];
     }
 
     public function completed(): self
     {
         return $this->state([
-            'status' => ScheduleStatusEnum::complete,
             'completed_at' => now()->subMinutes(30),
         ]);
     }
@@ -39,35 +37,23 @@ class ScheduleFactory extends Factory
     public function inProgress(): self
     {
         return $this->state([
-            'status' => ScheduleStatusEnum::in_progress,
             'scheduled_at' => now()->subMinutes(30),
-            'completed_at' => null,
+            'completed_at' => now()->addDays(14),
         ]);
     }
 
     public function inTheFuture(): self
     {
         return $this->state([
-            'status' => ScheduleStatusEnum::upcoming->value,
             'scheduled_at' => now()->addDays(30),
-            'completed_at' => null,
+            'completed_at' => now()->addDays(180),
         ]);
     }
 
     public function inThePast(): self
     {
         return $this->state([
-            'status' => ScheduleStatusEnum::upcoming,
             'scheduled_at' => now()->subDays(30)->subHours(2),
-            'completed_at' => null,
-        ]);
-    }
-
-    public function completedInThePast(): self
-    {
-        return $this->state([
-            'status' => ScheduleStatusEnum::complete,
-            'scheduled_at' => now()->addDays(30)->subHours(2),
             'completed_at' => now()->subDays(30),
         ]);
     }

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -30,6 +30,7 @@ class ScheduleFactory extends Factory
     public function completed(): self
     {
         return $this->state([
+            'scheduled_at' => now()->subMinutes(45),
             'completed_at' => now()->subMinutes(30),
         ]);
     }

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -2,7 +2,6 @@
 
 namespace Cachet\Database\Factories;
 
-use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Schedule;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -39,7 +38,7 @@ class ScheduleFactory extends Factory
     {
         return $this->state([
             'scheduled_at' => now()->subMinutes(30),
-            'completed_at' => now()->addDays(14),
+            'completed_at' => null,
         ]);
     }
 
@@ -47,7 +46,7 @@ class ScheduleFactory extends Factory
     {
         return $this->state([
             'scheduled_at' => now()->addDays(30),
-            'completed_at' => now()->addDays(180),
+            'completed_at' => null,
         ]);
     }
 

--- a/database/migrations/2024_10_13_214300_drop_schedule_status.php
+++ b/database/migrations/2024_10_13_214300_drop_schedule_status.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('incidents', function (Blueprint $table) {
+            $table->tinyInteger('status')->unsigned()->default(0);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,7 +54,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Database Maintenance',
             'message' => 'We will be conducting maintenance on our database servers. You may experience degraded performance during this time.',
             'scheduled_at' => now()->addHours(6),
-            'status' => ScheduleStatusEnum::upcoming,
+            'completed_at' => now()->addHours(10),
         ]);
 
         $componentGroup = ComponentGroup::create([

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -51,10 +51,17 @@ class DatabaseSeeder extends Seeder
         ]);
 
         Schedule::create([
+            'name' => 'Documentation Maintenance',
+            'message' => 'We will be conducting maintenance on our documentation servers. Documentation may not be available during this time.',
+            'scheduled_at' => now()->subHours(12)->subMinutes(45),
+            'completed_at' => now()->subHours(12),
+        ]);
+
+        Schedule::create([
             'name' => 'Database Maintenance',
             'message' => 'We will be conducting maintenance on our database servers. You may experience degraded performance during this time.',
-            'scheduled_at' => now()->addHours(6),
-            'completed_at' => now()->addHours(10),
+            'scheduled_at' => now()->addHours(24),
+            'completed_at' => null,
         ]);
 
         $componentGroup = ComponentGroup::create([

--- a/src/Filament/Resources/ScheduleResource.php
+++ b/src/Filament/Resources/ScheduleResource.php
@@ -25,17 +25,6 @@ class ScheduleResource extends Resource
                     Forms\Components\TextInput::make('name')
                         ->label(__('Name'))
                         ->required(),
-                    Forms\Components\Select::make('status')
-                        ->label(__('Status'))
-                        ->required()
-                        ->options(ScheduleStatusEnum::class)
-                        ->default(ScheduleStatusEnum::upcoming)
-                        ->afterStateUpdated(function (Forms\Set $set, int|ScheduleStatusEnum $state): void {
-                            if (ScheduleStatusEnum::parse($state) !== ScheduleStatusEnum::complete) {
-                                $set('completed_at', null);
-                            }
-                        })
-                        ->live(),
                     Forms\Components\MarkdownEditor::make('message')
                         ->label(__('Message'))
                         ->columnSpanFull(),
@@ -45,9 +34,7 @@ class ScheduleResource extends Resource
                         ->label(__('Scheduled at'))
                         ->required(),
                     Forms\Components\DateTimePicker::make('completed_at')
-                        ->label(__('Completed at'))
-                        ->visible(fn (Forms\Get $get): bool => ScheduleStatusEnum::parse($get('status')) === ScheduleStatusEnum::complete)
-                        ->required(fn (Forms\Get $get): bool => ScheduleStatusEnum::parse($get('status')) === ScheduleStatusEnum::complete),
+                        ->label(__('Completed at')),
                 ])->columnSpan(1),
             ])->columns(4);
     }
@@ -99,7 +86,7 @@ class ScheduleResource extends Resource
                             ->required(),
                     ])
                     ->color('success')
-                    ->action(fn (Schedule $record, array $data) => $record->update(['completed_at' => $data['completed_at'], 'status' => ScheduleStatusEnum::complete])),
+                    ->action(fn (Schedule $record, array $data) => $record->update(['completed_at' => $data['completed_at']])),
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -22,8 +22,8 @@ class ScheduleController extends Controller
     {
         $schedules = QueryBuilder::for(Schedule::class)
             ->allowedIncludes(['components'])
-            ->allowedFilters(['name', 'status'])
-            ->allowedSorts(['name', 'status', 'id', 'scheduled_at', 'completed_at'])
+            ->allowedFilters(['name'])
+            ->allowedSorts(['name', 'id', 'scheduled_at', 'completed_at'])
             ->simplePaginate(request('per_page', 15));
 
         return ScheduleResource::collection($schedules);

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -30,7 +30,7 @@ class StatusPageController
                 ->withCount('incidents')
                 ->get(),
 
-            'schedules' => Schedule::query()->inTheFuture()->orderBy('scheduled_at')->get(),
+            'schedules' => Schedule::query()->incomplete()->orderBy('scheduled_at')->get(),
         ]);
     }
 

--- a/src/Http/Resources/Schedule.php
+++ b/src/Http/Resources/Schedule.php
@@ -21,6 +21,10 @@ class Schedule extends JsonApiResource
                 'human' => optional($this->scheduled_at)->diffForHumans(),
                 'string' => optional($this->scheduled_at)->toDateTimeString(),
             ],
+            'completed' => [
+                'human' => optional($this->completed_at)->diffForHumans(),
+                'string' => optional($this->completed_at)->toDateTimeString(),
+            ],
             'created' => [
                 'human' => optional($this->created_at)->diffForHumans(),
                 'string' => optional($this->created_at)->toDateTimeString(),

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -36,9 +36,9 @@ class Schedule extends Model
         return Attribute::get(function () {
             $now = Carbon::now();
 
-            return match(true) {
+            return match (true) {
                 $this->scheduled_at->gte($now) => ScheduleStatusEnum::upcoming,
-                $this->completed_at->gte($now) || $this->completed_at === null => ScheduleStatusEnum::in_progress,
+                $this->completed_at === null => ScheduleStatusEnum::in_progress,
                 default => ScheduleStatusEnum::complete,
             };
         });
@@ -68,8 +68,8 @@ class Schedule extends Model
      */
     public function scopeIncomplete(Builder $query): Builder
     {
-        return $query->whereDate('completed_at', '>=', Carbon::now())
-        ->orWhereNull('completed_at');
+        return $query->whereDate('scheduled_at', '>=', Carbon::now())
+            ->whereNull('completed_at');
     }
 
     /**
@@ -78,10 +78,10 @@ class Schedule extends Model
     public function scopeInProgress(Builder $query): Builder
     {
         return $query->whereDate('scheduled_at', '<=', Carbon::now())
-        ->where(function (Builder $query) {
-            $query->whereDate('completed_at', '>=', Carbon::now())
-            ->orWhereNull('completed_at');
-        });
+            ->where(function (Builder $query) {
+                $query->whereDate('completed_at', '>=', Carbon::now())
+                    ->orWhereNull('completed_at');
+            });
     }
 
     /**

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Schedule;
 
@@ -199,7 +198,7 @@ it('can update a schedule', function () {
 
     $response = putJson('/status/api/schedules/'.$schedule->id, [
         'name' => 'Updated Scheduled Maintenance',
-        'message' => 'Something went wrong.'
+        'message' => 'Something went wrong.',
     ]);
 
     $response->assertOk();

--- a/tests/Unit/Actions/Schedule/CreateScheduleTest.php
+++ b/tests/Unit/Actions/Schedule/CreateScheduleTest.php
@@ -7,8 +7,8 @@ it('can create a schedule without components', function () {
     $data = [
         'name' => 'My Scheduled Maintenance',
         'message' => 'Something will go down...',
-        'status' => 0, // Upcoming...
         'scheduled_at' => '2023-09-01 12:00:00',
+        'completed_at' => '2023-10-01 12:00:00',
     ];
 
     $schedule = app(CreateSchedule::class)->handle($data);
@@ -23,8 +23,8 @@ it('can create a schedule with components', function () {
     $data = [
         'name' => 'My Scheduled Maintenance',
         'message' => 'Something will go down...',
-        'status' => 0, // Upcoming...
         'scheduled_at' => '2023-09-01 12:00:00',
+        'completed_at' => '2023-10-01 12:00:00',
     ];
 
     [$componentA, $componentB] = Component::factory()->count(2)->create();

--- a/tests/Unit/Models/ScheduleTest.php
+++ b/tests/Unit/Models/ScheduleTest.php
@@ -17,14 +17,9 @@ it('has components', function () {
 });
 
 it('can get incomplete schedules', function () {
-    [$scheduleA] = Schedule::factory()
-        ->count(3)
-        ->sequence(
-            ['status' => ScheduleStatusEnum::in_progress],
-            ['status' => ScheduleStatusEnum::upcoming],
-            ['status' => ScheduleStatusEnum::complete],
-        )
-        ->create();
+    $scheduleA = Schedule::factory()->inTheFuture()->create();
+    Schedule::factory()->inProgress()->create();
+    Schedule::factory()->inThePast()->create();
 
     expect(Schedule::query()->incomplete()->get())
         ->toHaveCount(2)
@@ -51,17 +46,9 @@ it('can get schedules in the future', function () {
 
 it('can get schedules from the past', function () {
     Schedule::factory()->inTheFuture()->create();
-    Schedule::factory()->inThePast()->completed()->create();
     $scheduleInPast = Schedule::factory()->inThePast()->create();
 
     expect(Schedule::query()->inThePast()->get())
         ->toHaveCount(1)
         ->first()->id->toBe($scheduleInPast->id);
-});
-
-it('can get schedules previously completed', function () {
-    Schedule::factory()->inThePast()->completed()->count(2)->create();
-
-    expect(Schedule::query()->completedPreviously()->get())
-        ->toHaveCount(2);
 });

--- a/tests/Unit/Models/ScheduleTest.php
+++ b/tests/Unit/Models/ScheduleTest.php
@@ -52,3 +52,21 @@ it('can get schedules from the past', function () {
         ->toHaveCount(1)
         ->first()->id->toBe($scheduleInPast->id);
 });
+
+it('can determine a schedule\'s upcoming status', function () {
+    $schedule = Schedule::factory()->inTheFuture()->create();
+
+    expect($schedule)->status->toBe(ScheduleStatusEnum::upcoming);
+});
+
+it('can determine a schedule\'s in-progress status', function () {
+    $schedule = Schedule::factory()->inProgress()->create();
+
+    expect($schedule)->status->toBe(ScheduleStatusEnum::in_progress);
+});
+
+it('can determine a schedule\'s completed status', function () {
+    $schedule = Schedule::factory()->completed()->create();
+
+    expect($schedule)->status->toBe(ScheduleStatusEnum::complete);
+});


### PR DESCRIPTION
Closes #111

- [x] drop `status` column
- [x] determine status from `scheduled_at` and `completed_at`
- [x] tests