### PR TITLE
Composer Dev Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,15 @@ This package provides the core functionality of Cachet and may be installed into
 1. Clone this repository.
 2. Run the following commands from within the `core` directory:
     ```shell
-   composer update
    npm install
-   npm run build
+   composer update
+   composer dev
     ```
-3. Start running Cachet via the Orchestra Workbench:
-    ```shell
-   composer start
-    ```
-4. From within the `core` directory, you can now run to actively compile the frontend assets:
-    ```shell
-    npm run dev
-    ```
-5. Make your changes to the frontend. Currently, HMR is not enabled so manual refreshes are needed.
+3. Develop Cachet. Currently, HMR is not enabled so manual refreshes are needed.
 
 ### Dashboard Credentials
 
-When running Cachet via the `composer start` command, Workbench will seed a user that you can use to log in to the dashboard.
+When running Cachet via the `composer dev` command, Workbench will seed a user that you can use to log in to the dashboard.
 Login to the account at `/dashboard` and use credentials:
 
 - **Email:** `test@test.com`

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
+        "laravel/pail": "^1.1",
         "orchestra/testbench": "^9.5.1",
         "pestphp/pest": "^3.2",
         "pestphp/pest-plugin-laravel": "^3.0",
@@ -68,10 +69,13 @@
             "@clear",
             "@php vendor/bin/testbench workbench:build"
         ],
-        "start": [
+        "dev": [
             "@build",
             "Composer\\Config::disableProcessTimeout",
-            "@php vendor/bin/testbench serve"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php vendor/bin/testbench serve\" \"php vendor/bin/testbench queue:listen --tries=1\" \"php vendor/bin/testbench pail\" \"npm run dev\" --names=server,queue,logs,vite"
+        ],
+        "start": [
+            "@dev"
         ]
     },
     "config": {


### PR DESCRIPTION
Laravel 11.x has introduced a new `composer dev` command to get up and running quickly. I've added this to our `composer.json` file and aliased `composer start` to it 🚀 

We also now install `laravel/pail` as a dev dependency and start queues, so it's even easier to build features such as #22 and #79.