### PR TITLE
Scribe Annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "autoload-dev": {
         "psr-4": {
             "Cachet\\Tests\\": "tests",
+            "Cachet\\Database\\Factories\\": "database/factories",
             "Workbench\\App\\": "workbench/app/",
             "Workbench\\Database\\Factories\\": "workbench/database/factories/",
             "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"

--- a/database/factories/ScheduleComponentFactory.php
+++ b/database/factories/ScheduleComponentFactory.php
@@ -4,13 +4,12 @@ namespace Cachet\Database\Factories;
 
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
-use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
 use Cachet\Models\ScheduleComponent;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends Factory<Incident>
+ * @extends Factory<ScheduleComponent>
  */
 class ScheduleComponentFactory extends Factory
 {

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -19,7 +19,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class ComponentController extends Controller
 {
     /**
-     * List Components.
+     * List Components
      *
      * @apiResourceCollection \Cachet\Http\Resources\Component
      * @apiResourceModel \Cachet\Models\Component
@@ -36,7 +36,7 @@ class ComponentController extends Controller
     }
 
     /**
-     * Create Component.
+     * Create Component
      *
      * @apiResource \Cachet\Http\Resources\Component
      * @apiResourceModel \Cachet\Models\Component
@@ -50,7 +50,7 @@ class ComponentController extends Controller
     }
 
     /**
-     * Get Component.
+     * Get Component
      *
      * @apiResource \Cachet\Http\Resources\Component
      * @apiResourceModel \Cachet\Models\Component
@@ -63,7 +63,7 @@ class ComponentController extends Controller
     }
 
     /**
-     * Update Component.
+     * Update Component
      *
      * @apiResource \Cachet\Http\Resources\Component
      * @apiResourceModel \Cachet\Models\Component
@@ -77,7 +77,7 @@ class ComponentController extends Controller
     }
 
     /**
-     * Delete Component.
+     * Delete Component
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -13,10 +13,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Components
+ */
 class ComponentController extends Controller
 {
     /**
      * List Components.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\Component
+     * @apiResourceModel \Cachet\Models\Component
      */
     public function index()
     {
@@ -31,6 +37,10 @@ class ComponentController extends Controller
 
     /**
      * Create Component.
+     *
+     * @apiResource \Cachet\Http\Resources\Component
+     * @apiResourceModel \Cachet\Models\Component
+     * @authenticated
      */
     public function store(CreateComponentRequest $request, CreateComponent $createComponentAction)
     {
@@ -41,6 +51,9 @@ class ComponentController extends Controller
 
     /**
      * Get Component.
+     *
+     * @apiResource \Cachet\Http\Resources\Component
+     * @apiResourceModel \Cachet\Models\Component
      */
     public function show(Component $component)
     {
@@ -51,6 +64,10 @@ class ComponentController extends Controller
 
     /**
      * Update Component.
+     *
+     * @apiResource \Cachet\Http\Resources\Component
+     * @apiResourceModel \Cachet\Models\Component
+     * @authenticated
      */
     public function update(UpdateComponentRequest $request, Component $component, UpdateComponent $updateComponentAction)
     {
@@ -61,6 +78,9 @@ class ComponentController extends Controller
 
     /**
      * Delete Component.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Component $component, DeleteComponent $deleteComponentAction)
     {

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -19,7 +19,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class ComponentGroupController extends Controller
 {
     /**
-     * List Component Groups.
+     * List Component Groups
      *
      * @apiResource \Cachet\Http\Resources\ComponentGroup
      * @apiResourceModel \Cachet\Models\ComponentGroup
@@ -35,7 +35,7 @@ class ComponentGroupController extends Controller
     }
 
     /**
-     * Create Component Group.
+     * Create Component Group
      *
      * @apiResource \Cachet\Http\Resources\ComponentGroup
      * @apiResourceModel \Cachet\Models\ComponentGroup
@@ -51,7 +51,7 @@ class ComponentGroupController extends Controller
     }
 
     /**
-     * Get Component Group.
+     * Get Component Group
      *
      * @apiResource \Cachet\Http\Resources\ComponentGroup
      * @apiResourceModel \Cachet\Models\ComponentGroup
@@ -64,7 +64,7 @@ class ComponentGroupController extends Controller
     }
 
     /**
-     * Update Component Group.
+     * Update Component Group
      *
      * @apiResource \Cachet\Http\Resources\ComponentGroup
      * @apiResourceModel \Cachet\Models\ComponentGroup
@@ -80,7 +80,7 @@ class ComponentGroupController extends Controller
     }
 
     /**
-     * Delete Component Group.
+     * Delete Component Group
      *
      * @apiResource \Cachet\Http\Resources\ComponentGroup
      * @apiResourceModel \Cachet\Models\ComponentGroup

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -13,10 +13,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Component Groups
+ */
 class ComponentGroupController extends Controller
 {
     /**
      * List Component Groups.
+     *
+     * @apiResource \Cachet\Http\Resources\ComponentGroup
+     * @apiResourceModel \Cachet\Models\ComponentGroup
      */
     public function index()
     {
@@ -30,6 +36,10 @@ class ComponentGroupController extends Controller
 
     /**
      * Create Component Group.
+     *
+     * @apiResource \Cachet\Http\Resources\ComponentGroup
+     * @apiResourceModel \Cachet\Models\ComponentGroup
+     * @authenticated
      */
     public function store(CreateComponentGroupRequest $request, CreateComponentGroup $createComponentGroupAction)
     {
@@ -42,6 +52,9 @@ class ComponentGroupController extends Controller
 
     /**
      * Get Component Group.
+     *
+     * @apiResource \Cachet\Http\Resources\ComponentGroup
+     * @apiResourceModel \Cachet\Models\ComponentGroup
      */
     public function show(ComponentGroup $componentGroup)
     {
@@ -51,7 +64,11 @@ class ComponentGroupController extends Controller
     }
 
     /**
-     * Update Component Group
+     * Update Component Group.
+     *
+     * @apiResource \Cachet\Http\Resources\ComponentGroup
+     * @apiResourceModel \Cachet\Models\ComponentGroup
+     * @authenticated
      */
     public function update(UpdateComponentGroupRequest $request, ComponentGroup $componentGroup, UpdateComponentGroup $updateComponentGroupAction)
     {
@@ -64,6 +81,10 @@ class ComponentGroupController extends Controller
 
     /**
      * Delete Component Group.
+     *
+     * @apiResource \Cachet\Http\Resources\ComponentGroup
+     * @apiResourceModel \Cachet\Models\ComponentGroup
+     * @authenticated
      */
     public function destroy(ComponentGroup $componentGroup, DeleteComponentGroup $deleteComponentGroupAction)
     {

--- a/src/Http/Controllers/Api/GeneralController.php
+++ b/src/Http/Controllers/Api/GeneralController.php
@@ -6,10 +6,17 @@ use Cachet\Cachet;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 
+/**
+ * @group Cachet
+ */
 class GeneralController extends Controller
 {
     /**
      * Ping the API.
+     *
+     * @response {
+     *     "data": "Pong!"
+     * }
      */
     public function ping(): JsonResponse
     {
@@ -18,6 +25,12 @@ class GeneralController extends Controller
 
     /**
      * Get the Cachet version.
+     *
+     * @response {
+     *     "data": {
+     *        "version": "3.x-dev"
+     *    }
+     * }
      */
     public function version(): JsonResponse
     {

--- a/src/Http/Controllers/Api/GeneralController.php
+++ b/src/Http/Controllers/Api/GeneralController.php
@@ -12,7 +12,7 @@ use Illuminate\Routing\Controller;
 class GeneralController extends Controller
 {
     /**
-     * Ping the API.
+     * Test the API
      *
      * @response {
      *     "data": "Pong!"
@@ -24,7 +24,7 @@ class GeneralController extends Controller
     }
 
     /**
-     * Get the Cachet version.
+     * Get Version
      *
      * @response {
      *     "data": {

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -20,7 +20,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class IncidentController extends Controller
 {
     /**
-     * List Incidents.
+     * List Incidents
      *
      * @apiResourceCollection \Cachet\Http\Resources\Incident
      * @apiResourceModel \Cachet\Models\Incident
@@ -40,7 +40,7 @@ class IncidentController extends Controller
     }
 
     /**
-     * Create Incident.
+     * Create Incident
      *
      * @apiResource \Cachet\Http\Resources\Incident
      * @apiResourceModel \Cachet\Models\Incident
@@ -54,7 +54,7 @@ class IncidentController extends Controller
     }
 
     /**
-     * Get Incident.
+     * Get Incident
      *
      * @apiResource \Cachet\Http\Resources\Incident
      * @apiResourceModel \Cachet\Models\Incident
@@ -67,7 +67,7 @@ class IncidentController extends Controller
     }
 
     /**
-     * Update Incident.
+     * Update Incident
      *
      * @apiResource \Cachet\Http\Resources\Incident
      * @apiResourceModel \Cachet\Models\Incident
@@ -81,7 +81,7 @@ class IncidentController extends Controller
     }
 
     /**
-     * Delete Incident.
+     * Delete Incident
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -14,10 +14,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Incidents
+ */
 class IncidentController extends Controller
 {
     /**
      * List Incidents.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\Incident
+     * @apiResourceModel \Cachet\Models\Incident
      */
     public function index()
     {
@@ -35,6 +41,10 @@ class IncidentController extends Controller
 
     /**
      * Create Incident.
+     *
+     * @apiResource \Cachet\Http\Resources\Incident
+     * @apiResourceModel \Cachet\Models\Incident
+     * @authenticated
      */
     public function store(CreateIncidentRequest $request, CreateIncident $createIncidentAction)
     {
@@ -45,6 +55,9 @@ class IncidentController extends Controller
 
     /**
      * Get Incident.
+     *
+     * @apiResource \Cachet\Http\Resources\Incident
+     * @apiResourceModel \Cachet\Models\Incident
      */
     public function show(Incident $incident)
     {
@@ -55,6 +68,10 @@ class IncidentController extends Controller
 
     /**
      * Update Incident.
+     *
+     * @apiResource \Cachet\Http\Resources\Incident
+     * @apiResourceModel \Cachet\Models\Incident
+     * @authenticated
      */
     public function update(UpdateIncidentRequest $request, Incident $incident, UpdateIncident $updateIncidentAction)
     {
@@ -65,6 +82,9 @@ class IncidentController extends Controller
 
     /**
      * Delete Incident.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Incident $incident, DeleteIncident $deleteIncidentAction)
     {

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -19,7 +19,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class IncidentTemplateController extends Controller
 {
     /**
-     * List Incident Templates.
+     * List Incident Templates
      *
      * @apiResourceCollection \Cachet\Http\Resources\IncidentTemplate
      * @apiResourceModel \Cachet\Models\IncidentTemplate
@@ -35,7 +35,7 @@ class IncidentTemplateController extends Controller
     }
 
     /**
-     * Create Incident Template.
+     * Create Incident Template
      *
      * @apiResource \Cachet\Http\Resources\IncidentTemplate
      * @apiResourceModel \Cachet\Models\IncidentTemplate
@@ -49,7 +49,7 @@ class IncidentTemplateController extends Controller
     }
 
     /**
-     * Get Incident Template.
+     * Get Incident Template
      *
      * @apiResource \Cachet\Http\Resources\IncidentTemplate
      * @apiResourceModel \Cachet\Models\IncidentTemplate
@@ -62,7 +62,7 @@ class IncidentTemplateController extends Controller
     }
 
     /**
-     * Update Incident Template.
+     * Update Incident Template
      *
      * @apiResource \Cachet\Http\Resources\IncidentTemplate
      * @apiResourceModel \Cachet\Models\IncidentTemplate
@@ -76,7 +76,7 @@ class IncidentTemplateController extends Controller
     }
 
     /**
-     * Delete Incident Template.
+     * Delete Incident Template
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -13,10 +13,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Incident Templates
+ */
 class IncidentTemplateController extends Controller
 {
     /**
      * List Incident Templates.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\IncidentTemplate
+     * @apiResourceModel \Cachet\Models\IncidentTemplate
      */
     public function index()
     {
@@ -30,6 +36,10 @@ class IncidentTemplateController extends Controller
 
     /**
      * Create Incident Template.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentTemplate
+     * @apiResourceModel \Cachet\Models\IncidentTemplate
+     * @authenticated
      */
     public function store(CreateIncidentTemplateRequest $request)
     {
@@ -40,6 +50,9 @@ class IncidentTemplateController extends Controller
 
     /**
      * Get Incident Template.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentTemplate
+     * @apiResourceModel \Cachet\Models\IncidentTemplate
      */
     public function show(IncidentTemplate $incidentTemplate)
     {
@@ -50,6 +63,10 @@ class IncidentTemplateController extends Controller
 
     /**
      * Update Incident Template.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentTemplate
+     * @apiResourceModel \Cachet\Models\IncidentTemplate
+     * @authenticated
      */
     public function update(UpdateIncidentTemplateRequest $request, IncidentTemplate $incidentTemplate)
     {
@@ -60,6 +77,9 @@ class IncidentTemplateController extends Controller
 
     /**
      * Delete Incident Template.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(IncidentTemplate $incidentTemplate)
     {

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -20,7 +20,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class IncidentUpdateController extends Controller
 {
     /**
-     * List Incident Updates.
+     * List Incident Updates
      *
      * @apiResourceCollection \Cachet\Http\Resources\IncidentUpdate
      * @apiResourceModel \Cachet\Models\IncidentUpdate
@@ -37,7 +37,7 @@ class IncidentUpdateController extends Controller
     }
 
     /**
-     * Create Incident Update.
+     * Create Incident Update
      *
      * @apiResource \Cachet\Http\Resources\IncidentUpdate
      * @apiResourceModel \Cachet\Models\IncidentUpdate
@@ -51,7 +51,7 @@ class IncidentUpdateController extends Controller
     }
 
     /**
-     * Get Incident Update.
+     * Get Incident Update
      *
      * @apiResource \Cachet\Http\Resources\IncidentUpdate
      * @apiResourceModel \Cachet\Models\IncidentUpdate
@@ -64,7 +64,7 @@ class IncidentUpdateController extends Controller
     }
 
     /**
-     * Update Incident Update.
+     * Update Incident Update
      *
      * @apiResource \Cachet\Http\Resources\IncidentUpdate
      * @apiResourceModel \Cachet\Models\IncidentUpdate
@@ -78,7 +78,7 @@ class IncidentUpdateController extends Controller
     }
 
     /**
-     * Delete Incident Update.
+     * Delete Incident Update
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -14,10 +14,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Incident Updates
+ */
 class IncidentUpdateController extends Controller
 {
     /**
      * List Incident Updates.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\IncidentUpdate
+     * @apiResourceModel \Cachet\Models\IncidentUpdate
      */
     public function index(Incident $incident)
     {
@@ -32,6 +38,10 @@ class IncidentUpdateController extends Controller
 
     /**
      * Create Incident Update.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentUpdate
+     * @apiResourceModel \Cachet\Models\IncidentUpdate
+     * @authenticated
      */
     public function store(CreateIncidentUpdateRequest $request, Incident $incident, CreateIncidentUpdate $createIncidentUpdateAction)
     {
@@ -42,6 +52,9 @@ class IncidentUpdateController extends Controller
 
     /**
      * Get Incident Update.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentUpdate
+     * @apiResourceModel \Cachet\Models\IncidentUpdate
      */
     public function show(Incident $incident, IncidentUpdate $incidentUpdate)
     {
@@ -52,6 +65,10 @@ class IncidentUpdateController extends Controller
 
     /**
      * Update Incident Update.
+     *
+     * @apiResource \Cachet\Http\Resources\IncidentUpdate
+     * @apiResourceModel \Cachet\Models\IncidentUpdate
+     * @authenticated
      */
     public function update(UpdateIncidentUpdateRequest $request, Incident $incident, IncidentUpdate $incidentUpdate, UpdateIncidentUpdate $updateIncidentUpdateAction)
     {
@@ -62,6 +79,9 @@ class IncidentUpdateController extends Controller
 
     /**
      * Delete Incident Update.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Incident $incident, IncidentUpdate $incidentUpdate, DeleteIncidentUpdate $deleteIncidentUpdateAction)
     {

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -14,10 +14,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Metrics
+ */
 class MetricController extends Controller
 {
     /**
      * List Metrics.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\Metric
+     * @apiResourceModel \Cachet\Models\Metric
      */
     public function index()
     {
@@ -35,6 +41,10 @@ class MetricController extends Controller
 
     /**
      * Create Metric.
+     *
+     * @apiResource \Cachet\Http\Resources\Metric
+     * @apiResourceModel \Cachet\Models\Metric
+     * @authenticated
      */
     public function store(CreateMetricRequest $request, CreateMetric $createMetricAction)
     {
@@ -45,6 +55,9 @@ class MetricController extends Controller
 
     /**
      * Get Metric.
+     *
+     * @apiResource \Cachet\Http\Resources\Metric
+     * @apiResourceModel \Cachet\Models\Metric
      */
     public function show(Metric $metric)
     {
@@ -55,6 +68,10 @@ class MetricController extends Controller
 
     /**
      * Update Metric.
+     *
+     * @apiResource \Cachet\Http\Resources\Metric
+     * @apiResourceModel \Cachet\Models\Metric
+     * @authenticated
      */
     public function update(UpdateMetricRequest $request, Metric $metric, UpdateMetric $updateMetricAction)
     {
@@ -65,6 +82,9 @@ class MetricController extends Controller
 
     /**
      * Delete Metric.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Metric $metric, DeleteMetric $deleteMetricAction)
     {

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -20,7 +20,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class MetricController extends Controller
 {
     /**
-     * List Metrics.
+     * List Metrics
      *
      * @apiResourceCollection \Cachet\Http\Resources\Metric
      * @apiResourceModel \Cachet\Models\Metric
@@ -40,7 +40,7 @@ class MetricController extends Controller
     }
 
     /**
-     * Create Metric.
+     * Create Metric
      *
      * @apiResource \Cachet\Http\Resources\Metric
      * @apiResourceModel \Cachet\Models\Metric
@@ -54,7 +54,7 @@ class MetricController extends Controller
     }
 
     /**
-     * Get Metric.
+     * Get Metric
      *
      * @apiResource \Cachet\Http\Resources\Metric
      * @apiResourceModel \Cachet\Models\Metric
@@ -67,7 +67,7 @@ class MetricController extends Controller
     }
 
     /**
-     * Update Metric.
+     * Update Metric
      *
      * @apiResource \Cachet\Http\Resources\Metric
      * @apiResourceModel \Cachet\Models\Metric
@@ -81,7 +81,7 @@ class MetricController extends Controller
     }
 
     /**
-     * Delete Metric.
+     * Delete Metric
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -12,10 +12,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Metric Points
+ */
 class MetricPointController extends Controller
 {
     /**
      * List Metric Points.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\MetricPoint
+     * @apiResourceModel \Cachet\Models\MetricPoint
      */
     public function index(Metric $metric)
     {
@@ -30,6 +36,10 @@ class MetricPointController extends Controller
 
     /**
      * Create Metric Point.
+     *
+     * @apiResource \Cachet\Http\Resources\MetricPoint
+     * @apiResourceModel \Cachet\Models\MetricPoint
+     * @authenticated
      */
     public function store(CreateMetricPointRequest $request, Metric $metric, CreateMetricPoint $createMetricPointAction)
     {
@@ -42,6 +52,9 @@ class MetricPointController extends Controller
 
     /**
      * Get Metric Point.
+     *
+     * @apiResource \Cachet\Http\Resources\MetricPoint
+     * @apiResourceModel \Cachet\Models\MetricPoint
      */
     public function show(Metric $metric, MetricPoint $metricPoint)
     {
@@ -52,6 +65,9 @@ class MetricPointController extends Controller
 
     /**
      * Delete Metric Point.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Metric $metric, MetricPoint $metricPoint, DeleteMetricPoint $deleteMetricPointAction)
     {

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -18,7 +18,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class MetricPointController extends Controller
 {
     /**
-     * List Metric Points.
+     * List Metric Points
      *
      * @apiResourceCollection \Cachet\Http\Resources\MetricPoint
      * @apiResourceModel \Cachet\Models\MetricPoint
@@ -35,7 +35,7 @@ class MetricPointController extends Controller
     }
 
     /**
-     * Create Metric Point.
+     * Create Metric Point
      *
      * @apiResource \Cachet\Http\Resources\MetricPoint
      * @apiResourceModel \Cachet\Models\MetricPoint
@@ -51,7 +51,7 @@ class MetricPointController extends Controller
     }
 
     /**
-     * Get Metric Point.
+     * Get Metric Point
      *
      * @apiResource \Cachet\Http\Resources\MetricPoint
      * @apiResourceModel \Cachet\Models\MetricPoint
@@ -64,7 +64,7 @@ class MetricPointController extends Controller
     }
 
     /**
-     * Delete Metric Point.
+     * Delete Metric Point
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -19,7 +19,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 class ScheduleController extends Controller
 {
     /**
-     * List Schedules.
+     * List Schedules
      *
      * @apiResourceCollection \Cachet\Http\Resources\Schedule
      * @apiResourceModel \Cachet\Models\Schedule
@@ -36,7 +36,7 @@ class ScheduleController extends Controller
     }
 
     /**
-     * Create Schedule.
+     * Create Schedule
      *
      * @apiResource \Cachet\Http\Resources\Schedule
      * @apiResourceModel \Cachet\Models\Schedule
@@ -52,7 +52,7 @@ class ScheduleController extends Controller
     }
 
     /**
-     * Get Schedule.
+     * Get Schedule
      *
      * @apiResource \Cachet\Http\Resources\Schedule
      * @apiResourceModel \Cachet\Models\Schedule
@@ -65,7 +65,7 @@ class ScheduleController extends Controller
     }
 
     /**
-     * Update Schedule.
+     * Update Schedule
      *
      * @apiResource \Cachet\Http\Resources\Schedule
      * @apiResourceModel \Cachet\Models\Schedule
@@ -80,7 +80,7 @@ class ScheduleController extends Controller
     }
 
     /**
-     * Delete Schedule.
+     * Delete Schedule
      *
      * @response 204
      * @authenticated

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -13,10 +13,16 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Spatie\QueryBuilder\QueryBuilder;
 
+/**
+ * @group Schedules
+ */
 class ScheduleController extends Controller
 {
     /**
      * List Schedules.
+     *
+     * @apiResourceCollection \Cachet\Http\Resources\Schedule
+     * @apiResourceModel \Cachet\Models\Schedule
      */
     public function index()
     {
@@ -31,6 +37,10 @@ class ScheduleController extends Controller
 
     /**
      * Create Schedule.
+     *
+     * @apiResource \Cachet\Http\Resources\Schedule
+     * @apiResourceModel \Cachet\Models\Schedule
+     * @authenticated
      */
     public function store(CreateScheduleRequest $request, CreateSchedule $createScheduleAction)
     {
@@ -43,6 +53,9 @@ class ScheduleController extends Controller
 
     /**
      * Get Schedule.
+     *
+     * @apiResource \Cachet\Http\Resources\Schedule
+     * @apiResourceModel \Cachet\Models\Schedule
      */
     public function show(Schedule $schedule)
     {
@@ -53,6 +66,10 @@ class ScheduleController extends Controller
 
     /**
      * Update Schedule.
+     *
+     * @apiResource \Cachet\Http\Resources\Schedule
+     * @apiResourceModel \Cachet\Models\Schedule
+     * @authenticated
      */
     public function update(UpdateScheduleRequest $request, Schedule $schedule, UpdateSchedule $updateScheduleAction)
     {
@@ -64,6 +81,9 @@ class ScheduleController extends Controller
 
     /**
      * Delete Schedule.
+     *
+     * @response 204
+     * @authenticated
      */
     public function destroy(Schedule $schedule, DeleteSchedule $deleteScheduleAction)
     {

--- a/src/Http/Controllers/Api/StatusController.php
+++ b/src/Http/Controllers/Api/StatusController.php
@@ -10,7 +10,7 @@ use Cachet\Status;
 class StatusController
 {
     /**
-     * Get the current system status.
+     * Get System Status
      *
      * @response {
      *     "data": {

--- a/src/Http/Controllers/Api/StatusController.php
+++ b/src/Http/Controllers/Api/StatusController.php
@@ -4,10 +4,20 @@ namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Status;
 
+/**
+ * @group Cachet
+ */
 class StatusController
 {
     /**
      * Get the current system status.
+     *
+     * @response {
+     *     "data": {
+     *        "status": "operational",
+     *        "message": "All Systems Operational"
+     *     }
+     * }
      */
     public function __invoke(Status $status)
     {

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -2,11 +2,13 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Events\Components\ComponentCreated;
 use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -92,5 +94,13 @@ class Component extends Model
     public function scopeOutage(Builder $query): Builder
     {
         return $query->whereIn('status', ComponentStatusEnum::outage());
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return ComponentFactory::new();
     }
 }

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -3,8 +3,10 @@
 namespace Cachet\Models;
 
 use Cachet\Concerns\HasVisibility;
+use Cachet\Database\Factories\ComponentGroupFactory;
 use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -57,5 +59,13 @@ class ComponentGroup extends Model
         return Incident::query()
             ->whereIn('component_id', $this->components->pluck('id'))
             ->exists();
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return ComponentGroupFactory::new();
     }
 }

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -3,6 +3,7 @@
 namespace Cachet\Models;
 
 use Cachet\Concerns\HasVisibility;
+use Cachet\Database\Factories\IncidentFactory;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Events\Incidents\IncidentCreated;
@@ -11,6 +12,7 @@ use Cachet\Events\Incidents\IncidentUpdated;
 use Cachet\Filament\Resources\IncidentResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -127,5 +129,13 @@ class Incident extends Model
     public function filamentDashboardEditUrl(): string
     {
         return IncidentResource::getUrl(name: 'edit', parameters: ['record' => $this->id]);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return IncidentFactory::new();
     }
 }

--- a/src/Models/IncidentComponent.php
+++ b/src/Models/IncidentComponent.php
@@ -2,7 +2,9 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -29,5 +31,13 @@ class IncidentComponent extends Pivot
     public function incident(): BelongsTo
     {
         return $this->belongsTo(Incident::class);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return IncidentComponentFactory::new();
     }
 }

--- a/src/Models/IncidentTemplate.php
+++ b/src/Models/IncidentTemplate.php
@@ -2,9 +2,11 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentTemplateFactory;
 use Cachet\Enums\IncidentTemplateEngineEnum;
 use Cachet\Renderers\BladeRenderer;
 use Cachet\Renderers\TwigRenderer;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -48,5 +50,13 @@ class IncidentTemplate extends Model
     private function renderWithBlade(array $variables = []): string
     {
         return app(BladeRenderer::class)->render($this->template, $variables);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return IncidentTemplateFactory::new();
     }
 }

--- a/src/Models/IncidentUpdate.php
+++ b/src/Models/IncidentUpdate.php
@@ -2,7 +2,9 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\IncidentUpdateFactory;
 use Cachet\Enums\IncidentStatusEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -41,5 +43,13 @@ class IncidentUpdate extends Model
     public function formattedMessage(): string
     {
         return Str::of($this->message)->markdown();
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return IncidentUpdateFactory::new();
     }
 }

--- a/src/Models/Metric.php
+++ b/src/Models/Metric.php
@@ -3,12 +3,14 @@
 namespace Cachet\Models;
 
 use Cachet\Concerns\HasVisibility;
+use Cachet\Database\Factories\MetricFactory;
 use Cachet\Enums\MetricTypeEnum;
 use Cachet\Enums\MetricViewEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Events\Metrics\MetricCreated;
 use Cachet\Events\Metrics\MetricDeleted;
 use Cachet\Events\Metrics\MetricUpdated;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -59,5 +61,13 @@ class Metric extends Model
     public function recentMetricPoints(int $points = 15): HasMany
     {
         return $this->metricPoints()->latest()->limit($points);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return MetricFactory::new();
     }
 }

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -2,10 +2,12 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\MetricFactory;
 use Cachet\Events\Metrics\MetricPointCreated;
 use Cachet\Events\Metrics\MetricPointDeleted;
 use DateTime;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -75,5 +77,13 @@ class MetricPoint extends Model
         $now = Carbon::parse($timestamp) ?? now();
 
         return $this->created_at->startOfMinute()->diffInMinutes($now->startOfMinute()) < $threshold;
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return MetricFactory::new();
     }
 }

--- a/src/Models/MetricPoint.php
+++ b/src/Models/MetricPoint.php
@@ -2,7 +2,7 @@
 
 namespace Cachet\Models;
 
-use Cachet\Database\Factories\MetricFactory;
+use Cachet\Database\Factories\MetricPointFactory;
 use Cachet\Events\Metrics\MetricPointCreated;
 use Cachet\Events\Metrics\MetricPointDeleted;
 use DateTime;
@@ -84,6 +84,6 @@ class MetricPoint extends Model
      */
     protected static function newFactory(): Factory
     {
-        return MetricFactory::new();
+        return MetricPointFactory::new();
     }
 }

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -2,9 +2,11 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ScheduleFactory;
 use Cachet\Enums\ScheduleStatusEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -98,5 +100,13 @@ class Schedule extends Model
     public function scopeInThePast(Builder $query): Builder
     {
         return $query->where('completed_at', '<=', Carbon::now());
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return ScheduleFactory::new();
     }
 }

--- a/src/Models/ScheduleComponent.php
+++ b/src/Models/ScheduleComponent.php
@@ -2,6 +2,8 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\ScheduleFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,5 +32,13 @@ class ScheduleComponent extends Model
     public function schedule(): BelongsTo
     {
         return $this->belongsTo(Schedule::class);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return ScheduleFactory::new();
     }
 }

--- a/src/Models/ScheduleComponent.php
+++ b/src/Models/ScheduleComponent.php
@@ -2,7 +2,7 @@
 
 namespace Cachet\Models;
 
-use Cachet\Database\Factories\ScheduleFactory;
+use Cachet\Database\Factories\ScheduleComponentFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -39,6 +39,6 @@ class ScheduleComponent extends Model
      */
     protected static function newFactory(): Factory
     {
-        return ScheduleFactory::new();
+        return ScheduleComponentFactory::new();
     }
 }

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -2,9 +2,11 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\SubscriberFactory;
 use Cachet\Events\Subscribers\SubscriberCreated;
 use Cachet\Events\Subscribers\SubscriberUnsubscribed;
 use Cachet\Events\Subscribers\SubscriberVerified;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -63,5 +65,13 @@ class Subscriber extends Model
         ]);
 
         SubscriberVerified::dispatch($this);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return SubscriberFactory::new();
     }
 }

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -2,6 +2,8 @@
 
 namespace Cachet\Models;
 
+use Cachet\Database\Factories\SubscriptionFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -21,5 +23,13 @@ class Subscription extends Model
     public function subscriber(): BelongsTo
     {
         return $this->belongsTo(Subscriber::class);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return SubscriptionFactory::new();
     }
 }


### PR DESCRIPTION
This PR annotates the API controllers in a way that we can use [Scribe](https://scribe.knuckles.wtf) to generate the API documentation.

1. I'm currently using Scribe within the `cachethq/cachet` application itself to generate the documentation. For this to work, I've had to override each model's `newFactory` method to return the correct class.
2. I've updated all endpoint docblocks to use Scribe's PHP annotations (we can't use the attribute syntax, since Scribe isn't in the core itself).

At some point, I'm going to automate all of this in the main repo itself.