### PR TITLE
Local scopes can return `void`

### DIFF
--- a/src/Concerns/HasVisibility.php
+++ b/src/Concerns/HasVisibility.php
@@ -10,9 +10,9 @@ trait HasVisibility
     /**
      * Scope to visible incidents.
      */
-    public function scopeVisible(Builder $query, bool $authenticated = false): Builder
+    public function scopeVisible(Builder $query, bool $authenticated = false): void
     {
-        return $query->whereIn('visible', match ($authenticated) {
+        $query->whereIn('visible', match ($authenticated) {
             true => ResourceVisibilityEnum::visibleToUsers(),
             default => ResourceVisibilityEnum::visibleToGuests(),
         });
@@ -21,24 +21,24 @@ trait HasVisibility
     /**
      * Scope the resource to a given visibility setting.
      */
-    public function scopeVisibility(Builder $query, ResourceVisibilityEnum $visibility): Builder
+    public function scopeVisibility(Builder $query, ResourceVisibilityEnum $visibility): void
     {
-        return $query->where('visible', $visibility);
+        $query->where('visible', $visibility);
     }
 
     /**
      * Scope the resource to those visible to guests.
      */
-    public function scopeGuests(Builder $query): Builder
+    public function scopeGuests(Builder $query): void
     {
-        return $query->whereIn('visible', ResourceVisibilityEnum::visibleToGuests());
+        $query->whereIn('visible', ResourceVisibilityEnum::visibleToGuests());
     }
 
     /**
      * Scope the resource to those visible to authenticated users.
      */
-    public function scopeUsers(Builder $query): Builder
+    public function scopeUsers(Builder $query): void
     {
-        return $query->whereIn('visible', ResourceVisibilityEnum::visibleToUsers());
+        $query->whereIn('visible', ResourceVisibilityEnum::visibleToUsers());
     }
 }

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -70,30 +70,30 @@ class Component extends Model
     /**
      * Scope to disabled components only.
      */
-    public function scopeDisabled(Builder $query): Builder
+    public function scopeDisabled(Builder $query): void
     {
-        return $query->where('enabled', false);
+        $query->where('enabled', false);
     }
 
     /**
      * Scope to enabled components only.
      */
-    public function scopeEnabled(Builder $query): Builder
+    public function scopeEnabled(Builder $query): void
     {
-        return $query->where('enabled', true);
+        $query->where('enabled', true);
     }
 
     /**
      * Scope to a specific status.
      */
-    public function scopeStatus(Builder $query, ComponentStatusEnum $status): Builder
+    public function scopeStatus(Builder $query, ComponentStatusEnum $status): void
     {
-        return $query->where('status', $status);
+        $query->where('status', $status);
     }
 
-    public function scopeOutage(Builder $query): Builder
+    public function scopeOutage(Builder $query): void
     {
-        return $query->whereIn('status', ComponentStatusEnum::outage());
+        $query->whereIn('status', ComponentStatusEnum::outage());
     }
 
     /**

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -94,22 +94,22 @@ class Incident extends Model
     /**
      * Scope to a specific status.
      */
-    public function scopeStatus(Builder $query, IncidentStatusEnum $status): Builder
+    public function scopeStatus(Builder $query, IncidentStatusEnum $status): void
     {
-        return $query->where('status', $status);
+        $query->where('status', $status);
     }
 
-    public function scopeUnresolved(Builder $query): Builder
+    public function scopeUnresolved(Builder $query): void
     {
-        return $query->whereIn('status', IncidentStatusEnum::unresolved());
+        $query->whereIn('status', IncidentStatusEnum::unresolved());
     }
 
     /**
      * Scope to stickied incidents.
      */
-    public function scopeStickied(Builder $query): Builder
+    public function scopeStickied(Builder $query): void
     {
-        return $query->where('stickied', true);
+        $query->where('stickied', true);
     }
 
     public function timestamp(): Attribute

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -79,18 +79,18 @@ class Schedule extends Model
     /**
      * Scope schedules that are incomplete.
      */
-    public function scopeIncomplete(Builder $query): Builder
+    public function scopeIncomplete(Builder $query): void
     {
-        return $query->whereDate('scheduled_at', '>=', Carbon::now())
+        $query->whereDate('scheduled_at', '>=', Carbon::now())
             ->whereNull('completed_at');
     }
 
     /**
      * Scope schedules that are in progress.
      */
-    public function scopeInProgress(Builder $query): Builder
+    public function scopeInProgress(Builder $query): void
     {
-        return $query->whereDate('scheduled_at', '<=', Carbon::now())
+        $query->whereDate('scheduled_at', '<=', Carbon::now())
             ->where(function (Builder $query) {
                 $query->whereDate('completed_at', '>=', Carbon::now())
                     ->orWhereNull('completed_at');
@@ -100,17 +100,17 @@ class Schedule extends Model
     /**
      * Scopes schedules to those in the future.
      */
-    public function scopeInTheFuture(Builder $query): Builder
+    public function scopeInTheFuture(Builder $query): void
     {
-        return $query->whereDate('scheduled_at', '>=', Carbon::now());
+        $query->whereDate('scheduled_at', '>=', Carbon::now());
     }
 
     /**
      * Scopes schedules to those scheduled in the past.
      */
-    public function scopeInThePast(Builder $query): Builder
+    public function scopeInThePast(Builder $query): void
     {
-        return $query->where('completed_at', '<=', Carbon::now());
+        $query->where('completed_at', '<=', Carbon::now());
     }
 
     /**


### PR DESCRIPTION
I forget this, but local scopes can either return the same builder instance **or** `void`. I'm settling on returning `void`.

https://laravel.com/docs/11.x/eloquent#local-scopes