### PR TITLE
Fix bug determining incomplete schedules

### DIFF
--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -114,8 +114,7 @@ class Schedule extends Model
      */
     public function scopeIncomplete(Builder $query): void
     {
-        $query->whereDate('scheduled_at', '>=', Carbon::now())
-            ->whereNull('completed_at');
+        $query->whereNull('completed_at');
     }
 
     /**

--- a/tests/Unit/Models/ScheduleTest.php
+++ b/tests/Unit/Models/ScheduleTest.php
@@ -3,6 +3,7 @@
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Schedule;
 use Cachet\Models\ScheduleComponent;
+use Illuminate\Support\Carbon;
 
 it('has components', function () {
     $schedule = Schedule::factory()->create();
@@ -17,6 +18,18 @@ it('has components', function () {
 });
 
 it('can get incomplete schedules', function () {
+    $scheduleA = Schedule::factory()->inTheFuture()->create();
+    Schedule::factory()->inProgress()->create();
+    Schedule::factory()->inThePast()->create();
+
+    expect(Schedule::query()->incomplete()->get())
+        ->toHaveCount(2)
+        ->first()->id->toBe($scheduleA->id);
+});
+
+it('can get incomplete schedules at midnight', function () {
+    Carbon::setTestNow(Carbon::create(2024, 12, 23, 0));
+
     $scheduleA = Schedule::factory()->inTheFuture()->create();
     Schedule::factory()->inProgress()->create();
     Schedule::factory()->inThePast()->create();


### PR DESCRIPTION
Fixes an issue detected by running the tests at midnight 😅 See [schedule test-run](https://github.com/cachethq/core/actions/runs/12449503451).

I added an additional test to check what happens around midnight, which is when this issue was noticed.