### PR TITLE
Fix attaching components to incidents

### DIFF
--- a/database/factories/IncidentComponentFactory.php
+++ b/database/factories/IncidentComponentFactory.php
@@ -20,7 +20,7 @@ class IncidentComponentFactory extends Factory
         return [
             'incident_id' => Incident::factory(),
             'component_id' => Component::factory(),
-            'status' => ComponentStatusEnum::performance_issues->value,
+            'component_status' => ComponentStatusEnum::performance_issues->value,
         ];
     }
 }

--- a/database/migrations/2024_12_24_120457_rename_incident_components_status.php
+++ b/database/migrations/2024_12_24_120457_rename_incident_components_status.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('incident_components', function (Blueprint $table) {
+            $table->renameColumn('status', 'component_status');
+        });
+    }
+};

--- a/src/Filament/Resources/IncidentResource/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/IncidentResource/RelationManagers/ComponentsRelationManager.php
@@ -26,7 +26,7 @@ class ComponentsRelationManager extends RelationManager
             ->schema([
                 Forms\Components\TextInput::make('name')
                     ->label(__('Name')),
-                Forms\Components\ToggleButtons::make('status')
+                Forms\Components\ToggleButtons::make('component_status')
                     ->label(__('Status'))
                     ->inline()
                     ->options(ComponentStatusEnum::class)
@@ -43,7 +43,7 @@ class ComponentsRelationManager extends RelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('name')
                     ->label(__('Name')),
-                Tables\Columns\TextColumn::make('status')
+                Tables\Columns\TextColumn::make('component_status')
                     ->label(__('Status'))
                     ->badge()
                     ->sortable(),
@@ -55,7 +55,7 @@ class ComponentsRelationManager extends RelationManager
                 Tables\Actions\AttachAction::make()
                     ->form(fn (Tables\Actions\AttachAction $action): array => [
                         $action->getRecordSelect(),
-                        Forms\Components\ToggleButtons::make('status')
+                        Forms\Components\ToggleButtons::make('component_status')
                             ->label(__('Status'))
                             ->inline()
                             ->columnSpanFull()
@@ -69,7 +69,7 @@ class ComponentsRelationManager extends RelationManager
                     ->multiple(),
             ])
             ->actions([
-                //                Tables\Actions\EditAction::make(),
+//                Tables\Actions\EditAction::make(),
                 Tables\Actions\DetachAction::make(),
             ])
             ->bulkActions([

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -83,7 +83,7 @@ class Component extends Model
      */
     public function incidents(): BelongsToMany
     {
-        return $this->belongsToMany(Incident::class, 'incident_components')->withPivot('status');
+        return $this->belongsToMany(Incident::class, 'incident_components')->withPivot('component_status');
     }
 
     /**

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -114,7 +114,7 @@ class Incident extends Model
         return $this->belongsToMany(Component::class, 'incident_components')
             ->using(IncidentComponent::class)
             ->withTimestamps()
-            ->withPivot(['status']);
+            ->withPivot(['component_status']);
     }
 
     /**

--- a/src/Models/IncidentComponent.php
+++ b/src/Models/IncidentComponent.php
@@ -29,7 +29,7 @@ class IncidentComponent extends Pivot
 
     /** @var array<string, string> */
     protected $casts = [
-        'status' => ComponentStatusEnum::class,
+        'component_status' => ComponentStatusEnum::class,
     ];
 
     /**

--- a/tests/Unit/Models/ComponentTest.php
+++ b/tests/Unit/Models/ComponentTest.php
@@ -18,7 +18,7 @@ it('has a group', function () {
 
 it('has incidents', function () {
     $component = Component::factory()->hasAttached(Incident::factory()->count(2), [
-        'status' => IncidentStatusEnum::investigating,
+        'component_status' => ComponentStatusEnum::performance_issues,
     ])->create();
 
     expect($component->incidents)->toHaveCount(2);

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
@@ -8,7 +9,7 @@ it('can have multiple components', function () {
     $incident = Incident::factory()->create();
 
     $components = Component::factory(2)->create();
-    $incident->components()->attach($components, ['status' => IncidentStatusEnum::investigating->value]);
+    $incident->components()->attach($components, ['component_status' => ComponentStatusEnum::performance_issues->value]);
 
     expect($incident->components)->toHaveCount(2)
         ->and($incident->status)->toBeInstanceOf(IncidentStatusEnum::class);


### PR DESCRIPTION
Due to the `status` column clashing with incidents themselves, we were always showing the incident's status for attached components.

This PR renames `incident_components.status` to `incident_components.component_status`.