### PR TITLE
Set default path to root

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -21,7 +21,7 @@ return [
      |
      | This is the URI path where Cachet will be accessible from.
      */
-    'path' => env('CACHET_PATH', '/status'),
+    'path' => env('CACHET_PATH', '/'),
 
     'guard' => env('CACHET_GUARD', null),
 


### PR DESCRIPTION
Since Cachet should ideally be installed at the root of a Laravel application, let's make this the default. 

On my phone, so probably going to have tests to fix first. 

Fixes https://github.com/cachethq/cachet/issues/4446