### PR TITLE
Fix #167: Make 'no incidents reported' full width

### DIFF
--- a/resources/views/components/incident.blade.php
+++ b/resources/views/components/incident.blade.php
@@ -69,7 +69,7 @@
         </div>
     </div>
     @empty
-        <div class="bg-white border divide-y rounded-lg ml-9 dark:divide-zinc-700 dark:border-zinc-700 dark:bg-white/5">
+        <div class="bg-white border divide-y rounded-lg dark:divide-zinc-700 dark:border-zinc-700 dark:bg-white/5">
             <div class="flex flex-col p-4 divide-y dark:divide-zinc-700">
                 <div class="prose-sm md:prose prose-zinc dark:prose-invert prose-a:text-accent-content prose-a:underline prose-p:leading-normal">
                     {{ __('cachet::incident.no_incidents_reported') }}


### PR DESCRIPTION
removing `ml-9` fixed the problem. 
![image](https://github.com/user-attachments/assets/065c4b6d-cf89-447c-96d3-b809ba8440d0)
