### PR TITLE
fix migration with postgresql

### DIFF
--- a/database/migrations/2023_08_23_210836_make_incident_components_table_status_id_column_null.php
+++ b/database/migrations/2023_08_23_210836_make_incident_components_table_status_id_column_null.php
@@ -12,9 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('incident_components', function (Blueprint $table) {
-            $table->unsignedInteger('status_id')->nullable()->change();
-
             $table->renameColumn('status_id', 'status');
+            $table->unsignedInteger('status')->nullable()->change();
         });
     }
 };


### PR DESCRIPTION
When running this migration with php8.3, postgresql 15 and latest version of all components, I get the following migration error:

```
  2023_08_23_210836_make_incident_components_table_status_id_column_null .............................. 1.84ms FAIL

   Illuminate\Database\QueryException 

  SQLSTATE[42703]: Undefined column: 7 ERROR:  column "status_id" of relation "incident_components" does not exist (Connection: pgsql, SQL: comment on column "incident_components"."status_id" is NULL)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:825
    821▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    822▕                 );debug2: channel 0: window 999401 sent adjust 49175

    823▕             }
    824▕ 
  ➜ 825▕             throw new QueryException(
    826▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    827▕             );
    828▕         }
    829▕     }

      +48 vendor frames 

  49  artisan:13
      Illuminate\Foundation\Application::handleCommand()
```

I appears that with postgresql, the rename is trigger before the nullable change leading to an error. This PR, just switches the order and allows the migration to run correctly.