### PR TITLE
fix: alignment of swatch icon

### DIFF
--- a/src/Filament/Pages/Settings/ManageTheme.php
+++ b/src/Filament/Pages/Settings/ManageTheme.php
@@ -42,7 +42,7 @@ class ManageTheme extends SettingsPage
                                     ->map(function (array $shades, string $color) {
                                         $colorName = __(ucwords($color));
 
-                                        return "<div class=\"theme-swatch\" style=\"--swatch: {$shades[400]}\"></div> {$colorName}";
+                                        return "<div class=\"flex items-center\"><div class=\"theme-swatch\" style=\"--swatch: {$shades[400]}\"></div><div>{$colorName}</div></div>";
                                     }),
                             ])
                             ->native(false)
@@ -63,7 +63,7 @@ class ManageTheme extends SettingsPage
                                     ...collect(Color::all())->only(ThemeData::GRAYS)->map(function (array $shades, string $color) {
                                         $colorName = __(ucwords($color));
 
-                                        return "<div class=\"theme-swatch\" style=\"--swatch: {$shades[400]}\"></div> {$colorName}";
+                                        return "<div class=\"flex items-center\"><div class=\"theme-swatch\" style=\"--swatch: {$shades[400]}\"></div><div>{$colorName}</div></div>";
                                     }),
                                 ];
                             })


### PR DESCRIPTION
The alignment of the swatch icon to the text was bugging me. This PR centres them vertically.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/fcbbb1d9-de8d-411a-ab76-974e4fd75b3d) | ![image](https://github.com/user-attachments/assets/e0e47dc9-a0c6-4dca-8f26-69e84ad93178) |


