### PR TITLE
Set workbench auth model

### DIFF
--- a/testbench.yaml
+++ b/testbench.yaml
@@ -6,6 +6,7 @@ providers:
   - Spatie\LaravelData\LaravelDataServiceProvider
 
 env:
+  - AUTH_MODEL=\Workbench\App\User
   - MAIL_MAILER=smtp
   - MAIL_HOST=127.0.0.1
   - MAIL_PORT=2525


### PR DESCRIPTION
Sets the `AUTH_MODEL` env variable for workbench so that it uses the `Workbench\App\User` model instead of the workbench default (`Illuminate\Foundation\Auth\User`)