### PR TITLE
Create Admin users

### DIFF
--- a/database/migrations/2025_01_15_121008_add_admin_flag_to_users_table.php
+++ b/database/migrations/2025_01_15_121008_add_admin_flag_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -22,5 +22,6 @@ return [
         'email_label' => 'Email Address',
         'password_label' => 'Password',
         'password_confirmation_label' => 'Confirm Password',
+        'is_admin_label' => 'Admin',
     ],
 ];

--- a/src/Commands/MakeUserCommand.php
+++ b/src/Commands/MakeUserCommand.php
@@ -4,6 +4,7 @@ namespace Cachet\Commands;
 
 use Illuminate\Console\Command;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
 
@@ -14,7 +15,7 @@ class MakeUserCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cachet:make:user {email?} {--password=}';
+    protected $signature = 'cachet:make:user {email?} {--password= : The user\'s password} {--admin : Whether the user is an admin}';
 
     /**
      * The console command description.
@@ -39,25 +40,36 @@ class MakeUserCommand extends Command
     protected ?string $password = null;
 
     /**
+     * Whether the user is an admin.
+     */
+    protected ?bool $isAdmin = null;
+
+    /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(): int
     {
-        if ($password = $this->option('password')) {
-            $this->password = $password;
+        $this->email = $this->argument('email');
+        $this->isAdmin = $this->option('admin');
+        $this->password = $this->option('password');
+
+        $this->promptName();
+
+        if (! $this->email) {
+            $this->promptEmail();
         }
 
-        if ($this->email = $this->argument('email')) {
-            $this->createUser();
-
-            return;
+        if (is_null($this->isAdmin)) {
+            $this->promptIsAdmin();
         }
 
-        $this
-            ->promptEmail()
-            ->promptName()
-            ->promptPassword()
-            ->createUser();
+        if (! $this->password) {
+            $this->promptPassword();
+        }
+
+        $this->createUser();
+
+        return self::SUCCESS;
     }
 
     /**
@@ -95,6 +107,16 @@ class MakeUserCommand extends Command
     }
 
     /**
+     * Prompt the user for whether they are an admin.
+     */
+    protected function promptIsAdmin(): self
+    {
+        $this->isAdmin = confirm('Is the user an admin?', default: false);
+
+        return $this;
+    }
+
+    /**
      * Create the user.
      */
     protected function createUser(): void
@@ -105,6 +127,7 @@ class MakeUserCommand extends Command
             'name' => $this->data['name'],
             'email' => $this->email,
             'password' => bcrypt($this->password),
+            'is_admin' => $this->isAdmin,
         ]);
 
         $this->components->info('User created successfully.');

--- a/src/Filament/Resources/UserResource.php
+++ b/src/Filament/Resources/UserResource.php
@@ -11,11 +11,17 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 
 class UserResource extends Resource
 {
     protected static ?string $navigationIcon = 'heroicon-o-users';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()->is_admin;
+    }
 
     public static function form(Form $form): Form
     {
@@ -75,6 +81,7 @@ class UserResource extends Resource
                     ->dateTime(),
 
                 Tables\Columns\ToggleColumn::make('is_admin')
+                    ->disabled(fn () => !auth()->user()->is_admin)
                     ->label(__('cachet::user.list.headers.is_admin')),
             ])
             ->filters([

--- a/src/Filament/Resources/UserResource.php
+++ b/src/Filament/Resources/UserResource.php
@@ -2,7 +2,6 @@
 
 namespace Cachet\Filament\Resources;
 
-use Cachet\Concerns\CachetUser;
 use Cachet\Filament\Resources\UserResource\Pages;
 use Cachet\Filament\Resources\UserResource\RelationManagers;
 use Filament\Forms;
@@ -12,7 +11,6 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Hash;
 
 class UserResource extends Resource
@@ -53,6 +51,9 @@ class UserResource extends Resource
                         ->maxLength(255)
                         ->same('password')
                         ->label(__('cachet::user.form.password_confirmation_label')),
+
+                    Forms\Components\Toggle::make('is_admin')
+                        ->label(__('cachet::user.form.is_admin_label')),
                 ])
             ]);
     }
@@ -72,6 +73,9 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('email_verified_at')
                     ->label(__('cachet::user.list.headers.email_verified_at'))
                     ->dateTime(),
+
+                Tables\Columns\ToggleColumn::make('is_admin')
+                    ->label(__('cachet::user.list.headers.is_admin')),
             ])
             ->filters([
                 //


### PR DESCRIPTION
## TL;DR
Allows admin users to be created for cachet.

## Details
- Adds an `is_admin` flag to the `users` table
- Adds a toggle to the create user form
- Adds a toggle to the users table
- Updates the `cachet:make:user` command