### PR TITLE
Create and Manage Sanctum API Tokens 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "illuminate/events": "^11.23.0",
         "illuminate/queue": "^11.23.0",
         "illuminate/support": "^11.23.0",
+        "laravel/sanctum": "^4.0",
         "nesbot/carbon": "^2.70",
         "spatie/laravel-data": "^4.11",
         "spatie/laravel-query-builder": "^5.5",

--- a/database/migrations/2025_01_11_090556_create_api_keys_table.php
+++ b/database/migrations/2025_01_11_090556_create_api_keys_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_keys', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('token_', 64)->unique();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->boolean('revoked_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_keys');
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Access to an undefined property Laravel\\Sanctum\\PersonalAccessToken\:\:\$expires_at\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Filament/Resources/ApiKeyResource.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - vendor/larastan/larastan/extension.neon
+    - phpstan-baseline.neon
 
 parameters:
     level: 5

--- a/resources/lang/en/api_key.php
+++ b/resources/lang/en/api_key.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'resource_label' => 'API Key|API Keys',
+    'show_token' => [
+        'heading' => 'Your API Token has been generated',
+        'description' => 'Please copy your new API token. For your security, it won\'t be shown again.',
+        'copy_tooltip' => 'Token copied!',
+    ],
+    'abilities_label' => ':ability :resource',
+    'form' => [
+        'name_label' => 'Token Name',
+        'expires_at_label' => 'Expires At',
+        'expires_at_helper' => 'Expires at midnight. Leave empty for no expiry',
+        'expires_at_validation' => 'The expiry date must be in the future',
+        'abilities_label' => 'Permissions',
+        'abilities_hint' => 'Leaving this empty will give the token full permissions',
+    ],
+    'list' => [
+        'actions' => [
+            'revoke' => 'Revoke',
+        ],
+        'headers' => [
+            'name' => 'Token Name',
+            'abilities' => 'Permissions',
+            'created_at' => 'Created At',
+            'expires_at' => 'Expires At',
+            'updated_at' => 'Updated At',
+        ],
+    ],
+];

--- a/resources/lang/en/navigation.php
+++ b/resources/lang/en/navigation.php
@@ -7,6 +7,7 @@ return [
             'manage_cachet' => 'Manage Cachet',
             'manage_customization' => 'Manage Customization',
             'manage_theme' => 'Manage Theme',
+            'manage_api_keys' => 'Manage API Keys',
             'manage_webhooks' => 'Manage Webhooks',
         ],
     ],

--- a/resources/views/filament/pages/api-key/index.blade.php
+++ b/resources/views/filament/pages/api-key/index.blade.php
@@ -1,0 +1,27 @@
+<x-filament::page>
+    @if($token = session('api-token'))
+        <x-filament::section :heading="__('cachet::api_key.show_token.heading')">
+            <p class="text-sm leading-6 text-gray-500 dark:text-gray-400">
+                {{ __('cachet::api_key.show_token.description') }}
+            </p>
+
+            <div class="flex items-center gap-3 mt-3">
+                <div
+                    style="--c-50:var(--success-50);--c-400:var(--success-400);--c-600:var(--success-600);"
+                    class="fi-badge cursor-pointer inline-block rounded-md px-3 py-2 text-sm ring-1 ring-inset min-w-[theme(spacing.6)] fi-color-custom bg-custom-50 text-custom-600 ring-custom-600/10 dark:bg-custom-400/10 dark:text-custom-400 dark:ring-custom-400/30 fi-color-success"
+                    x-on:click="
+                        window.navigator.clipboard.writeText(@js($token))
+                        $tooltip(@js(__('cachet::api_key.show_token.copy_tooltip')), {
+                            theme: $store.theme,
+                            timeout: 2000,
+                        })
+                    "
+                >
+                    {{ $token }}
+                </div>
+            </div>
+        </x-filament::section>
+    @endsession
+
+    {{ $this->table }}
+</x-filament::page>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ApiAbility;
 use Cachet\Http\Controllers\Api\ComponentController;
 use Cachet\Http\Controllers\Api\ComponentGroupController;
 use Cachet\Http\Controllers\Api\GeneralController;
@@ -20,17 +21,50 @@ Route::apiResources([
     'incident-templates' => IncidentTemplateController::class,
     'metrics' => MetricController::class,
     'schedules' => ScheduleController::class,
-]);
+], ['except' => ['store', 'update', 'destroy']]);
 
-Route::apiResource('incidents.updates', IncidentUpdateController::class)
+Route::apiResource('incidents.updates', IncidentUpdateController::class, [
+    'except' => ['store', 'update', 'destroy'],
+])
     ->scoped(['updateable_id']);
 
-Route::apiResource('schedules.updates', ScheduleUpdateController::class)
+Route::apiResource('schedules.updates', ScheduleUpdateController::class, [
+    'except' => ['store', 'update', 'destroy'],
+])
     ->scoped(['updateable_id']);
 
-Route::apiResource('metrics.points', MetricPointController::class)
+Route::apiResource('metrics.points', MetricPointController::class, [
+    'except' => ['store', 'update', 'destroy'],
+])
     ->parameter('points', 'metricPoint')
     ->scoped();
+
+Route::middleware(['auth:sanctum'])->group(function () {
+    Route::apiResources([
+        'components' => ComponentController::class,
+        'component-groups' => ComponentGroupController::class,
+        'incidents' => IncidentController::class,
+        'incident-templates' => IncidentTemplateController::class,
+        'metrics' => MetricController::class,
+        'schedules' => ScheduleController::class,
+    ], ['except' => ['index', 'show']]);
+
+    Route::apiResource('incidents.updates', IncidentUpdateController::class, [
+        'except' => ['index', 'show'],
+    ])
+        ->scoped(['updateable_id']);
+
+    Route::apiResource('schedules.updates', ScheduleUpdateController::class, [
+        'except' => ['index', 'show'],
+    ])
+        ->scoped(['updateable_id']);
+
+    Route::apiResource('metrics.points', MetricPointController::class, [
+        'except' => ['index', 'show'],
+    ])
+        ->parameter('points', 'metricPoint')
+        ->scoped();
+});
 
 Route::get('/ping', [GeneralController::class, 'ping'])->name('ping');
 Route::get('/version', [GeneralController::class, 'version'])->name('version');

--- a/src/Cachet.php
+++ b/src/Cachet.php
@@ -67,4 +67,20 @@ class Cachet
     {
         return trim(file_get_contents(__DIR__.'/../VERSION'));
     }
+
+    /** @return array<string, list<string>> */
+    public static function getResourceApiAbilities(): array
+    {
+        return [
+            'components' => ['manage', 'delete'],
+            'component-groups' => ['manage', 'delete'],
+            'incidents' => ['manage', 'delete'],
+            'incident-updates' => ['manage', 'delete'],
+            'incident-templates' => ['manage', 'delete'],
+            'metrics' => ['manage', 'delete'],
+            'metric-points' => ['manage', 'delete'],
+            'schedules' => ['manage', 'delete'],
+            'schedule-updates' => ['manage', 'delete'],
+        ];
+    }
 }

--- a/src/Concerns/GuardsApiAbilities.php
+++ b/src/Concerns/GuardsApiAbilities.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cachet\Concerns;
+
+use Cachet\Models\User;
+use Laravel\Sanctum\Exceptions\MissingAbilityException;
+
+trait GuardsApiAbilities
+{
+    public function guard(string $ability): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        if (! $user->tokenCan($ability)) {
+            throw new MissingAbilityException($ability);
+        }
+    }
+}

--- a/src/Filament/Resources/ApiKeyResource.php
+++ b/src/Filament/Resources/ApiKeyResource.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Cachet\Filament\Resources;
+
+use Cachet\Cachet;
+use Cachet\Enums\ApiAbility;
+use Cachet\Filament\Resources\ApiKeyResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ApiKeyResource extends Resource
+{
+    protected static ?string $model = PersonalAccessToken::class;
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('tokenable_type', auth()->user()::class)
+            ->where('tokenable_id', auth()->id());
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('cachet::navigation.settings.label');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('cachet::navigation.settings.items.manage_api_keys');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()->schema([
+                    Forms\Components\TextInput::make('name')
+                        ->label(__('cachet::api_key.form.name_label'))
+                        ->required()
+                        ->unique('api_keys', 'name')
+                        ->maxLength(255)
+                        ->columnSpanFull()
+                        ->autofocus()
+                        ->autocomplete(false),
+                    Forms\Components\DatePicker::make('expires_at')
+                        ->label(__('cachet::api_key.form.expires_at_label'))
+                        ->helperText(__('cachet::api_key.form.expires_at_helper'))
+                        ->nullable()
+                        ->rules(['after:today'])
+                        ->validationMessages(['after' => __('cachet::api_key.form.expires_at_validation')])
+                        ->placeholder(null),
+                    Forms\Components\CheckboxList::make('abilities')
+                        ->label(__('cachet::api_key.form.abilities_label'))
+                        ->hint(__('cachet::api_key.form.abilities_hint'))
+                        ->hintColor('warning')
+                        ->options(self::getAbilities())
+                        ->columns(3)
+                ])->columnSpan(4),
+            ])->columns(4);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('cachet::api_key.list.headers.name'))
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('abilities')
+                    ->label(__('cachet::api_key.list.headers.abilities'))
+                    ->color('gray')
+                    ->badge()
+                    ->limitList(3),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('cachet::api_key.list.headers.created_at'))
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->label(__('cachet::api_key.list.headers.expires_at'))
+                    ->sortable()
+                    ->color(fn (PersonalAccessToken $record) => $record->expires_at ? null : 'gray')
+                    ->badge(fn (PersonalAccessToken $record) => !$record->expires_at)
+                    ->getStateUsing(fn (PersonalAccessToken $record) => $record->expires_at?->format(Table::$defaultDateDisplayFormat) ?? 'N/A'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('cachet::api_key.list.headers.updated_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\Filter::make('expired')
+                    ->toggle()
+                    ->query(fn (Builder $query) => $query->where('expires_at', '<', now())),
+            ])
+            ->actions([
+                Tables\Actions\DeleteAction::make('revoke')
+                    ->label(__('cachet::api_key.list.actions.revoke')),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkAction::make('revoke')
+                    ->label(__('cachet::api_key.list.actions.revoke'))
+                    ->action(fn (Collection $records) => $records->each->delete())
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->color('danger')
+                    ->icon('heroicon-o-trash'),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListApiKeys::route('/'),
+            'create' => Pages\CreateApiKey::route('/create'),
+        ];
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans_choice('cachet::api_key.resource_label', 1);
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('cachet::api_key.resource_label', 2);
+    }
+
+    /** @return array<string, string> */
+    private static function getAbilities(): array
+    {
+        $abilities = [];
+
+        foreach (Cachet::getResourceApiAbilities() as $resource => $apiAbilities) {
+            foreach ($apiAbilities as $ability) {
+                $key = "{$resource}.{$ability}";
+                $abilities[$key] = Str::headline(__('cachet::api_key.abilities_label', [
+                    'ability' => $ability,
+                    'resource' => Str::plural($resource),
+                ]));
+            }
+        }
+
+        return $abilities;
+    }
+}

--- a/src/Filament/Resources/ApiKeyResource/Pages/CreateApiKey.php
+++ b/src/Filament/Resources/ApiKeyResource/Pages/CreateApiKey.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cachet\Filament\Resources\ApiKeyResource\Pages;
+
+use Cachet\Filament\Resources\ApiKeyResource;
+use Cachet\Models\User;
+use Carbon\Carbon;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class CreateApiKey extends CreateRecord
+{
+    protected ?string $plainTextToken = null;
+
+    protected static string $resource = ApiKeyResource::class;
+
+    public function handleRecordCreation(array $data): Model
+    {
+        /** @var User $user */
+        $user = Filament::auth()->user();
+
+        $token = $user->createToken(
+            name: $data['name'],
+            abilities: empty($data['abilities']) ? ['*'] : $data['abilities'],
+            expiresAt: filled($data['expires_at']) ? Carbon::parse($data['expires_at']) : null,
+        );
+
+        session()->flash('api-token', $token->plainTextToken);
+
+        return $token->accessToken;
+    }
+}

--- a/src/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/src/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cachet\Filament\Resources\ApiKeyResource\Pages;
+
+use Cachet\Filament\Resources\ApiKeyResource;
+use Cachet\Models\User;
+use Carbon\Carbon;
+use Filament\Actions;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\ListRecords;
+use Laravel\Sanctum\NewAccessToken;
+
+class ListApiKeys extends ListRecords
+{
+    protected static string $view = 'cachet::filament.pages.api-key.index';
+
+    protected static string $resource = ApiKeyResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [Actions\CreateAction::make()];
+    }
+}

--- a/src/Filament/Resources/WebhookSubscriptionResource/Pages/CreateWebhookSubscription.php
+++ b/src/Filament/Resources/WebhookSubscriptionResource/Pages/CreateWebhookSubscription.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Resources\WebhookSubscriptionResource\Pages;
 
 use Cachet\Filament\Resources\WebhookSubscriptionResource;
+use Filament\Actions\Action;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateWebhookSubscription extends CreateRecord

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Component\CreateComponent;
 use Cachet\Actions\Component\DeleteComponent;
 use Cachet\Actions\Component\UpdateComponent;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Component\CreateComponentRequestData;
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
 use Cachet\Http\Resources\Component as ComponentResource;
@@ -18,6 +19,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class ComponentController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * The list of allowed includes.
      */
@@ -63,6 +66,8 @@ class ComponentController extends Controller
      */
     public function store(CreateComponentRequestData $data, CreateComponent $createComponentAction)
     {
+        $this->guard('components.manage');
+
         $component = $createComponentAction->handle(
             $data,
         );
@@ -101,6 +106,8 @@ class ComponentController extends Controller
      */
     public function update(UpdateComponentRequestData $data, Component $component, UpdateComponent $updateComponentAction)
     {
+        $this->guard('components.manage');
+
         $updateComponentAction->handle($component, $data);
 
         return ComponentResource::make($component->fresh());
@@ -115,6 +122,8 @@ class ComponentController extends Controller
      */
     public function destroy(Component $component, DeleteComponent $deleteComponentAction)
     {
+        $this->guard('components.delete');
+
         // @todo what happens to incidents linked to this component?
         // @todo re-calculate existing component orders?
 

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\ComponentGroup\CreateComponentGroup;
 use Cachet\Actions\ComponentGroup\DeleteComponentGroup;
 use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\ComponentGroup\CreateComponentGroupRequestData;
 use Cachet\Data\Requests\ComponentGroup\UpdateComponentGroupRequestData;
 use Cachet\Http\Resources\ComponentGroup as ComponentGroupResource;
@@ -18,6 +19,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class ComponentGroupController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Component Groups
      *
@@ -51,6 +54,8 @@ class ComponentGroupController extends Controller
      */
     public function store(CreateComponentGroupRequestData $data, CreateComponentGroup $createComponentGroupAction)
     {
+        $this->guard('component-groups.manage');
+
         $componentGroup = $createComponentGroupAction->handle($data);
 
         return ComponentGroupResource::make($componentGroup);
@@ -87,6 +92,8 @@ class ComponentGroupController extends Controller
      */
     public function update(UpdateComponentGroupRequestData $data, ComponentGroup $componentGroup, UpdateComponentGroup $updateComponentGroupAction)
     {
+        $this->guard('component-groups.manage');
+
         $updateComponentGroupAction->handle($componentGroup, $data);
 
         return ComponentGroupResource::make($componentGroup->fresh());
@@ -103,6 +110,7 @@ class ComponentGroupController extends Controller
      */
     public function destroy(ComponentGroup $componentGroup, DeleteComponentGroup $deleteComponentGroupAction)
     {
+        $this->guard('component-groups.delete');
         $deleteComponentGroupAction->handle($componentGroup);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Incident\CreateIncident;
 use Cachet\Actions\Incident\DeleteIncident;
 use Cachet\Actions\Incident\UpdateIncident;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Incident\CreateIncidentRequestData;
 use Cachet\Data\Requests\Incident\UpdateIncidentRequestData;
 use Cachet\Http\Resources\Incident as IncidentResource;
@@ -19,6 +20,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class IncidentController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * The list of allowed includes.
      */
@@ -67,6 +70,8 @@ class IncidentController extends Controller
      */
     public function store(CreateIncidentRequestData $data, CreateIncident $createIncidentAction)
     {
+        $this->guard('incidents.manage');
+
         $incident = $createIncidentAction->handle($data);
 
         return IncidentResource::make($incident);
@@ -103,6 +108,8 @@ class IncidentController extends Controller
      */
     public function update(UpdateIncidentRequestData $data, Incident $incident, UpdateIncident $updateIncidentAction)
     {
+        $this->guard('incidents.manage');
+
         $updateIncidentAction->handle($incident, $data);
 
         return IncidentResource::make($incident->fresh());
@@ -117,6 +124,8 @@ class IncidentController extends Controller
      */
     public function destroy(Incident $incident, DeleteIncident $deleteIncidentAction)
     {
+        $this->guard('incidents.delete');
+
         $deleteIncidentAction->handle($incident);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\IncidentTemplate\CreateIncidentTemplate;
 use Cachet\Actions\IncidentTemplate\DeleteIncidentTemplate;
 use Cachet\Actions\IncidentTemplate\UpdateIncidentTemplate;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\IncidentTemplate\CreateIncidentTemplateRequestData;
 use Cachet\Data\Requests\IncidentTemplate\UpdateIncidentTemplateRequestData;
 use Cachet\Http\Resources\IncidentTemplate as IncidentTemplateResource;
@@ -18,6 +19,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class IncidentTemplateController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Incident Templates
      *
@@ -53,6 +56,8 @@ class IncidentTemplateController extends Controller
      */
     public function store(CreateIncidentTemplateRequestData $data, CreateIncidentTemplate $createIncidentTemplateAction)
     {
+        $this->guard('incident-templates.manage');
+
         $template = $createIncidentTemplateAction->handle($data);
 
         return IncidentTemplateResource::make($template);
@@ -83,6 +88,8 @@ class IncidentTemplateController extends Controller
      */
     public function update(UpdateIncidentTemplateRequestData $data, IncidentTemplate $incidentTemplate, UpdateIncidentTemplate $updateIncidentTemplateAction)
     {
+        $this->guard('incident-templates.manage');
+
         $template = $updateIncidentTemplateAction->handle($incidentTemplate, $data);
 
         return IncidentTemplateResource::make($template);
@@ -97,6 +104,8 @@ class IncidentTemplateController extends Controller
      */
     public function destroy(IncidentTemplate $incidentTemplate)
     {
+        $this->guard('incident-templates.delete');
+
         app(DeleteIncidentTemplate::class)->handle($incidentTemplate);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Actions\Update\DeleteUpdate;
 use Cachet\Actions\Update\EditUpdate;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Data\Requests\IncidentUpdate\EditIncidentUpdateRequestData;
 use Cachet\Http\Resources\Update as UpdateResource;
@@ -20,6 +21,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class IncidentUpdateController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Incident Updates
      *
@@ -58,6 +61,8 @@ class IncidentUpdateController extends Controller
      */
     public function store(CreateIncidentUpdateRequestData $data, Incident $incident, CreateUpdate $createUpdateAction)
     {
+        $this->guard('incident-updates.manage');
+
         $update = $createUpdateAction->handle($incident, $data);
 
         return UpdateResource::make($update);
@@ -96,6 +101,8 @@ class IncidentUpdateController extends Controller
      */
     public function update(EditIncidentUpdateRequestData $data, Incident $incident, Update $update, EditUpdate $editUpdateAction)
     {
+        $this->guard('incident-updates.manage');
+
         $editUpdateAction->handle($update, $data);
 
         return UpdateResource::make($update->fresh());
@@ -110,6 +117,8 @@ class IncidentUpdateController extends Controller
      */
     public function destroy(Incident $incident, Update $update, DeleteUpdate $deleteUpdateAction)
     {
+        $this->guard('incident-updates.delete');
+
         $deleteUpdateAction->handle($update);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Metric\CreateMetric;
 use Cachet\Actions\Metric\DeleteMetric;
 use Cachet\Actions\Metric\UpdateMetric;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Metric\CreateMetricRequestData;
 use Cachet\Data\Requests\Metric\UpdateMetricRequestData;
 use Cachet\Http\Resources\Metric as MetricResource;
@@ -19,6 +20,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class MetricController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Metrics
      *
@@ -60,6 +63,8 @@ class MetricController extends Controller
      */
     public function store(CreateMetricRequestData $data, CreateMetric $createMetricAction)
     {
+        $this->guard('metrics.manage');
+
         $metric = $createMetricAction->handle($data);
 
         return MetricResource::make($metric);
@@ -96,6 +101,8 @@ class MetricController extends Controller
      */
     public function update(UpdateMetricRequestData $data, Metric $metric, UpdateMetric $updateMetricAction)
     {
+        $this->guard('metrics.manage');
+
         $updateMetricAction->handle($metric, $data);
 
         return MetricResource::make($metric->fresh());
@@ -110,6 +117,8 @@ class MetricController extends Controller
      */
     public function destroy(Metric $metric, DeleteMetric $deleteMetricAction)
     {
+        $this->guard('metrics.delete');
+
         $deleteMetricAction->handle($metric);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -4,6 +4,7 @@ namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Metric\CreateMetricPoint;
 use Cachet\Actions\Metric\DeleteMetricPoint;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Metric\CreateMetricPointRequestData;
 use Cachet\Http\Resources\MetricPoint as MetricPointResource;
 use Cachet\Models\Metric;
@@ -17,6 +18,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class MetricPointController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Metric Points
      *
@@ -53,6 +56,8 @@ class MetricPointController extends Controller
      */
     public function store(CreateMetricPointRequestData $data, Metric $metric, CreateMetricPoint $createMetricPointAction)
     {
+        $this->guard('metric-points.manage');
+
         $metricPoint = $createMetricPointAction->handle($metric, $data);
 
         return MetricPointResource::make($metricPoint)
@@ -89,6 +94,8 @@ class MetricPointController extends Controller
      */
     public function destroy(Metric $metric, MetricPoint $metricPoint, DeleteMetricPoint $deleteMetricPointAction)
     {
+        $this->guard('metric-points.delete');
+
         $deleteMetricPointAction->handle($metricPoint);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Schedule\CreateSchedule;
 use Cachet\Actions\Schedule\DeleteSchedule;
 use Cachet\Actions\Schedule\UpdateSchedule;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Schedule\CreateScheduleRequestData;
 use Cachet\Data\Requests\Schedule\UpdateScheduleRequestData;
 use Cachet\Http\Resources\Schedule as ScheduleResource;
@@ -18,6 +19,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class ScheduleController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Schedules
      *
@@ -53,6 +56,8 @@ class ScheduleController extends Controller
      */
     public function store(CreateScheduleRequestData $data, CreateSchedule $createScheduleAction)
     {
+        $this->guard('schedules.manage');
+
         $schedule = $createScheduleAction->handle($data);
 
         return ScheduleResource::make($schedule);
@@ -89,6 +94,8 @@ class ScheduleController extends Controller
      */
     public function update(UpdateScheduleRequestData $data, Schedule $schedule, UpdateSchedule $updateScheduleAction)
     {
+        $this->guard('schedules.manage');
+
         $updateScheduleAction->handle($schedule, $data);
 
         return ScheduleResource::make($schedule->fresh());
@@ -103,6 +110,8 @@ class ScheduleController extends Controller
      */
     public function destroy(Schedule $schedule, DeleteSchedule $deleteScheduleAction)
     {
+        $this->guard('schedules.delete');
+
         $deleteScheduleAction->handle($schedule);
 
         return response()->noContent();

--- a/src/Http/Controllers/Api/ScheduleUpdateController.php
+++ b/src/Http/Controllers/Api/ScheduleUpdateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Actions\Update\DeleteUpdate;
 use Cachet\Actions\Update\EditUpdate;
+use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\EditScheduleUpdateRequestData;
 use Cachet\Http\Resources\Update as UpdateResource;
@@ -21,6 +22,8 @@ use Spatie\QueryBuilder\QueryBuilder;
  */
 class ScheduleUpdateController extends Controller
 {
+    use GuardsApiAbilities;
+
     /**
      * List Schedule Updates
      *
@@ -58,6 +61,8 @@ class ScheduleUpdateController extends Controller
      */
     public function store(CreateScheduleUpdateRequestData $data, Schedule $schedule, CreateUpdate $createUpdateAction)
     {
+        $this->guard('schedule-updates.manage');
+
         $update = $createUpdateAction->handle($schedule, $data);
 
         return UpdateResource::make($update);
@@ -96,6 +101,8 @@ class ScheduleUpdateController extends Controller
      */
     public function update(EditScheduleUpdateRequestData $data, Schedule $schedule, Update $update, EditUpdate $editUpdateAction)
     {
+        $this->guard('schedule-updates.manage');
+
         $editUpdateAction->handle($update, $data);
 
         return UpdateResource::make($update->fresh());
@@ -110,6 +117,8 @@ class ScheduleUpdateController extends Controller
      */
     public function destroy(Schedule $schedule, Update $update, DeleteUpdate $deleteUpdateAction)
     {
+        $this->guard('schedule-updates.delete');
+
         $deleteUpdateAction->handle($update);
 
         return response()->noContent();

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 /**
  * @property int $id
@@ -20,7 +21,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable implements CachetUser, MustVerifyEmail
 {
     /** @use HasFactory<\Cachet\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -4,6 +4,7 @@ providers:
   - Cachet\CachetDashboardServiceProvider
   - Spatie\LaravelSettings\LaravelSettingsServiceProvider
   - Spatie\LaravelData\LaravelDataServiceProvider
+  - Laravel\Sanctum\SanctumServiceProvider
 
 env:
   - AUTH_MODEL=\Workbench\App\User

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -4,6 +4,9 @@ use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
@@ -170,7 +173,31 @@ it('can get a component with group', function () {
     $response->assertJsonFragment(['id' => $component->id]);
 });
 
+it('cannot create a component when not authenticated', function () {
+    $response = postJson('/status/api/components', [
+        'name' => 'Test',
+        'description' => 'This is a new component, created by the API.',
+        'order' => 2,
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot create a component without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $response = postJson('/status/api/components', [
+        'name' => 'Test',
+        'description' => 'This is a new component, created by the API.',
+        'order' => 2,
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can create a component', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $response = postJson('/status/api/components', [
         'name' => 'Test',
         'description' => 'This is a new component, created by the API.',
@@ -190,6 +217,8 @@ it('can create a component', function () {
 });
 
 it('can create a component and attach to a component group', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $componentGroup = ComponentGroup::factory()->create();
     $response = postJson('/status/api/components', [
         'name' => 'Test',
@@ -209,6 +238,8 @@ it('can create a component and attach to a component group', function () {
 });
 
 it('cannot attach a new component to a component group that does not exist', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $response = postJson('/status/api/components', [
         'name' => 'Test',
         'description' => 'This is a new component, created by the API.',
@@ -223,7 +254,37 @@ it('cannot attach a new component to a component group that does not exist', fun
     ]);
 });
 
+it('cannot update a component when not authenticated', function () {
+    $component = Component::factory()->create([
+        'order' => 10,
+    ]);
+
+    $response = putJson('/status/api/components/'.$component->id, [
+        'name' => 'Updated Component Name',
+        'description' => 'This is an updated component.',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot update a component without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $component = Component::factory()->create([
+        'order' => 10,
+    ]);
+
+    $response = putJson('/status/api/components/'.$component->id, [
+        'name' => 'Updated Component Name',
+        'description' => 'This is an updated component.',
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can update a component', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $component = Component::factory()->create([
         'order' => 10,
     ]);
@@ -246,6 +307,8 @@ it('can update a component', function () {
 });
 
 it('can update a component and attach it to a component group', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $componentGroup = ComponentGroup::factory()->create();
     $component = Component::factory()->create([
         'order' => 10,
@@ -271,6 +334,8 @@ it('can update a component and attach it to a component group', function () {
 });
 
 it('cannot update a component and attach it to a component group that does not exist', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
     $component = Component::factory()->create();
 
     $response = putJson('/status/api/components/'.$component->id, [
@@ -286,7 +351,27 @@ it('cannot update a component and attach it to a component group that does not e
     ]);
 });
 
+it('cannot delete a component when not authenticated', function () {
+    $component = Component::factory()->create();
+
+    $response = deleteJson('/status/api/components/'.$component->id);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot delete a component without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
+    $component = Component::factory()->create();
+
+    $response = deleteJson('/status/api/components/'.$component->id);
+
+    $response->assertForbidden();
+});
+
 it('can delete a component', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.delete']);
+
     $component = Component::factory()->create();
 
     $response = deleteJson('/status/api/components/'.$component->id);

--- a/tests/Feature/Api/IncidentUpdateTest.php
+++ b/tests/Feature/Api/IncidentUpdateTest.php
@@ -5,8 +5,13 @@ use Cachet\Models\Incident;
 use Cachet\Models\Update;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
+use Laravel\Sanctum\Sanctum;
+
+use Workbench\App\User;
+
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
 use function Pest\Laravel\putJson;
 
 it('can list incident updates', function () {
@@ -133,7 +138,72 @@ it('can get an incident update with incident', function () {
     ]);
 });
 
+it('cannot create an incident update if not authenticated', function () {
+    $incident = Incident::factory()->create();
+
+    $response = postJson("/status/api/incidents/{$incident->id}/updates", [
+        'status' => IncidentStatusEnum::identified->value,
+        'message' => 'This is a test message.',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot create an incident update without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $incident = Incident::factory()->create();
+
+    $response = postJson("/status/api/incidents/{$incident->id}/updates", [
+        'status' => IncidentStatusEnum::identified->value,
+        'message' => 'This is a test message.',
+    ]);
+
+    $response->assertForbidden();
+});
+
+it('can create an incident update', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incident-updates.manage']);
+
+    $incident = Incident::factory()->create();
+
+    $response = postJson("/status/api/incidents/{$incident->id}/updates", [
+        'status' => IncidentStatusEnum::identified->value,
+        'message' => 'This is a test message.',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('updates', [
+        'status' => IncidentStatusEnum::identified->value,
+        'message' => 'This is a test message.',
+    ]);
+});
+
+it('cannot update an incident update if not authenticated', function () {
+    $incidentUpdate = Update::factory()->forIncident()->create();
+
+    $response = putJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}", [
+        'message' => 'This is an updated message.',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot update an incident update without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $incidentUpdate = Update::factory()->forIncident()->create();
+
+    $response = putJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}", [
+        'message' => 'This is an updated message.',
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can update an incident update', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incident-updates.manage']);
+
     $incidentUpdate = Update::factory()->forIncident()->create();
 
     $data = [
@@ -150,7 +220,27 @@ it('can update an incident update', function () {
     ]);
 });
 
+it('cannot delete an incident update if not authenticated', function () {
+    $incidentUpdate = Update::factory()->forIncident()->create();
+
+    $response = deleteJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}");
+
+    $response->assertUnauthorized();
+});
+
+it('cannot delete an incident update without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $incidentUpdate = Update::factory()->forIncident()->create();
+
+    $response = deleteJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}");
+
+    $response->assertForbidden();
+});
+
 it('can delete an incident update', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incident-updates.delete']);
+
     $incidentUpdate = Update::factory()->forIncident()->create();
 
     $response = deleteJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}");
@@ -162,6 +252,8 @@ it('can delete an incident update', function () {
 });
 
 it('cannot delete an incident update from another incident', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.delete']);
+
     $incidentUpdate = Update::factory()->forUpdateable()->create();
 
     $response = deleteJson("/status/api/incidents/{$incidentUpdate->updateable_id}/updates/{$incidentUpdate->id}");

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -3,6 +3,9 @@
 use Cachet\Models\Component;
 use Cachet\Models\Schedule;
 
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
@@ -126,7 +129,33 @@ it('can get a schedule', function () {
     ]);
 });
 
+it('cannot create a schedule if not authenticated', function () {
+    $response = postJson('/status/api/schedules', [
+        'name' => 'New Scheduled Maintenance',
+        'message' => 'Something will go wrong.',
+        'scheduled_at' => now()->addWeek()->toDateTimeString(),
+        'completed_at' => now()->addWeek()->addDay()->toDateTimeString(),
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot create a schedule without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $response = postJson('/status/api/schedules', [
+        'name' => 'New Scheduled Maintenance',
+        'message' => 'Something will go wrong.',
+        'scheduled_at' => now()->addWeek()->toDateTimeString(),
+        'completed_at' => now()->addWeek()->addDay()->toDateTimeString(),
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can create a schedule', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     $response = postJson('/status/api/schedules', [
         'name' => 'New Scheduled Maintenance',
         'message' => 'Something will go wrong.',
@@ -152,6 +181,8 @@ it('can create a schedule', function () {
 });
 
 it('can create a schedule with components', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     [$componentA, $componentB] = Component::factory(2)->create();
 
     $response = postJson('/status/api/schedules', [
@@ -183,6 +214,8 @@ it('can create a schedule with components', function () {
 });
 
 it('cannot create a schedule with bad data', function (array $payload) {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     $response = postJson('/status/api/schedules', $payload);
 
     $response->assertUnprocessable();
@@ -193,7 +226,33 @@ it('cannot create a schedule with bad data', function (array $payload) {
     fn () => ['name' => 'Invalid Scheduled At', 'message' => 'Something', 'scheduled_at' => 'invalid'],
 ]);
 
+it('cannot update a schedule if not authenticated', function () {
+    $schedule = Schedule::factory()->create();
+
+    $response = putJson('/status/api/schedules/'.$schedule->id, [
+        'name' => 'Updated Scheduled Maintenance',
+        'message' => 'Something went wrong.',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot update a schedule without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $schedule = Schedule::factory()->create();
+
+    $response = putJson('/status/api/schedules/'.$schedule->id, [
+        'name' => 'Updated Scheduled Maintenance',
+        'message' => 'Something went wrong.',
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can update a schedule', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     $schedule = Schedule::factory()->create();
 
     $response = putJson('/status/api/schedules/'.$schedule->id, [
@@ -212,6 +271,8 @@ it('can update a schedule', function () {
 });
 
 it('can update a schedule with components', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     [$componentA, $componentB] = Component::factory(2)->create();
 
     $schedule = Schedule::factory()->create();
@@ -235,7 +296,27 @@ it('can update a schedule with components', function () {
     ]);
 });
 
+it('cannot delete a schedule if not authenticated', function () {
+    $schedule = Schedule::factory()->create();
+
+    $response = deleteJson('/status/api/schedules/'.$schedule->id);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot delete a schedule without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $schedule = Schedule::factory()->create();
+
+    $response = deleteJson('/status/api/schedules/'.$schedule->id);
+
+    $response->assertForbidden();
+});
+
 it('can delete a schedule', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.delete']);
+
     $schedule = Schedule::factory()->create();
 
     $response = deleteJson('/status/api/schedules/'.$schedule->id);

--- a/workbench/app/User.php
+++ b/workbench/app/User.php
@@ -3,8 +3,17 @@
 namespace Workbench\App;
 
 use Cachet\Models\User as CachetUser;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Workbench\Database\Factories\UserFactory;
 
 class User extends CachetUser
 {
-    //
+    /** @use HasFactory<UserFactory> */
+    use HasFactory;
+
+    protected static function newFactory(): Factory
+    {
+        return UserFactory::new();
+    }
 }

--- a/workbench/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/workbench/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};


### PR DESCRIPTION
## TL;DR
Closes #174

This PR implements the ability to generate, edit and revoke API tokens to authenticate restricted API operations.

## Details

> [!NOTE]
> In order to show the API Token to the user, I've had to implement a custom view for the`APITokenResource`'s `index` page. This page has a `<x-filament::section>` block that is shown when the session contains a value for `api-token`:

```blade
@if($token = session('api-token'))
    <x-filament::section :heading="__('cachet::api_key.show_token.heading')">
        ...
    </x-filament::section>
@endif
```


- Use Laravel Sanctum
- Add `ApiTokenResource` to interact with sanctum's `PersonalAccessToken` model
- Implement `auth:sanctum` middleware to protect `store`, `update` and `destroy` API operations for all resources in `routes/api.php`.
- Add a new `GuardsApiAbilities` trait to ensure the API Token has the correct ability to perform the requested action.
- Added test to cover authenticated and authorization
- Added `phpstan-baseline.neon` for missing properties on Sanctums `PersonalAccessToken` model

## Screens

### Create API Token

<img width="1912" alt="1  create" src="https://github.com/user-attachments/assets/c7a6d82a-956a-4805-893b-23233cc1ca11" />

### List API Tokens

<img width="1912" alt="2  list" src="https://github.com/user-attachments/assets/7f88176e-7c79-4cfb-b62a-52472616c617" />
