### PR TITLE
Applies various fixes to API endoints

### DIFF
--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -12,6 +12,7 @@ use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
 /**
@@ -48,7 +49,11 @@ class ComponentController extends Controller
     {
         $components = QueryBuilder::for(Component::class)
             ->allowedIncludes(self::ALLOWED_INCLUDES)
-            ->allowedFilters(['name', 'status', 'enabled'])
+            ->allowedFilters([
+                'name',
+                AllowedFilter::exact('status'),
+                AllowedFilter::exact('enabled'),
+            ])
             ->allowedSorts(['name', 'order', 'id'])
             ->simplePaginate(request('per_page', 15));
 

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -13,6 +13,7 @@ use Cachet\Models\Incident;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
 /**
@@ -52,7 +53,11 @@ class IncidentController extends Controller
 
         $incidents = QueryBuilder::for($query)
             ->allowedIncludes(self::ALLOWED_INCLUDES)
-            ->allowedFilters(['name', 'status', 'occurred_at'])
+            ->allowedFilters([
+                'name',
+                AllowedFilter::exact('status'),
+                'occurred_at'
+            ])
             ->allowedSorts(['name', 'status', 'id'])
             ->simplePaginate(request('per_page', 15));
 

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -13,6 +13,7 @@ use Cachet\Models\Incident;
 use Cachet\Models\Update;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -42,7 +43,7 @@ class IncidentUpdateController extends Controller
             ->where('updateable_type', 'incident');
 
         $updates = QueryBuilder::for($query)
-            ->allowedFilters(['status'])
+            ->allowedFilters([AllowedFilter::exact('status'),])
             ->allowedIncludes(['incident'])
             ->allowedSorts(['status', 'created_at'])
             ->simplePaginate(request('per_page', 15));

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -12,6 +12,7 @@ use Cachet\Http\Resources\Schedule as ScheduleResource;
 use Cachet\Models\Schedule;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
 /**
@@ -32,13 +33,14 @@ class ScheduleController extends Controller
      * @queryParam page int Which page to show. Example: 2
      * @queryParam sort Field to sort by. Enum: name, id, scheduled_at, completed_at, enabled. Example: name
      * @queryParam include Include related resources. Enum: components, updates, user. Example: components
-     * @queryParam filters[name] string Filter the resources. Example: name=api
+     * @queryParam filters[name] string Filter the resources by name. Example: api
+     * @queryParam filters[status] string Filter the resources by status. Example: 1
      */
     public function index()
     {
         $schedules = QueryBuilder::for(Schedule::class)
             ->allowedIncludes(['components', 'updates', 'user'])
-            ->allowedFilters(['name'])
+            ->allowedFilters(['name', AllowedFilter::exact('status'),])
             ->allowedSorts(['name', 'id', 'scheduled_at', 'completed_at'])
             ->simplePaginate(request('per_page', 15));
 

--- a/src/Http/Resources/Component.php
+++ b/src/Http/Resources/Component.php
@@ -16,7 +16,10 @@ class Component extends JsonApiResource
             'description' => $this->description,
             'link' => $this->link,
             'order' => $this->order,
-            'status' => $this->status,
+            'status' => [
+                'human' => $this->status?->getLabel(),
+                'value' => $this->status?->value,
+            ],
             'enabled' => $this->enabled,
             'meta' => $this->meta,
             'created' => [

--- a/src/Http/Resources/Incident.php
+++ b/src/Http/Resources/Incident.php
@@ -22,8 +22,8 @@ class Incident extends JsonApiResource
             'stickied' => $this->stickied,
             'notifications' => $this->notifications,
             'status' => [
-                'human' => $this->latestStatus->getLabel(),
-                'value' => $this->latestStatus->value,
+                'human' => $this->latestStatus?->getLabel(),
+                'value' => $this->latestStatus?->value,
             ],
             'occurred' => [
                 'human' => $this->occurred_at?->diffForHumans(),


### PR DESCRIPTION
This PR:
- Uses `AllowedFilter::exact()` filters for `status` and `enabled` filters for components, incidents, incident updates and schedules -  this fixes a bug when applying the filter errors if using Postgres
- Fixes `status` in the component resource to now have a human readable value (like the rest)