### PR TITLE
feat: Add ability to pick preferred locale for a user

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -126,4 +126,17 @@ return [
             'prune_logs_after_days' => 30,
         ],
     ],
+
+    /*
+     |--------------------------------------------------------------------------
+     | Cachet Supported Locales
+     |--------------------------------------------------------------------------
+     |
+     | Configure which locales are supported by Cachet.
+     |
+     */
+    'supported_locales' => [
+        'en' => 'English',
+        'en_GB' => 'English (UK)',
+    ],
 ];

--- a/database/migrations/2025_01_16_225001_add_locale_to_user.php
+++ b/database/migrations/2025_01_16_225001_add_locale_to_user.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('preferred_locale')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('preferred_locale');
+        });
+    }
+};

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -22,6 +22,8 @@ return [
         'email_label' => 'Email Address',
         'password_label' => 'Password',
         'password_confirmation_label' => 'Confirm Password',
+        'preferred_locale' => 'Preferred Locale',
+        'preferred_locale_system_default' => 'System Default',
         'is_admin_label' => 'Admin',
     ],
 ];

--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Cachet;
 
+use Cachet\Http\Middleware\SetAppLocale;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -86,6 +87,7 @@ class CachetDashboardServiceProvider extends PanelProvider
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+                SetAppLocale::class,
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/src/Filament/Resources/UserResource.php
+++ b/src/Filament/Resources/UserResource.php
@@ -56,6 +56,14 @@ class UserResource extends Resource
                         ->same('password')
                         ->label(__('cachet::user.form.password_confirmation_label')),
 
+                    Forms\Components\Select::make('preferred_locale')
+                        ->selectablePlaceholder(false)
+                        ->options([
+                            null => __('cachet::user.form.preferred_locale_system_default'),
+                            ...config('cachet.supported_locales')
+                        ])
+                        ->label(__('cachet::user.form.preferred_locale')),
+
                     Forms\Components\Toggle::make('is_admin')
                         ->label(__('cachet::user.form.is_admin_label'))
                         ->disabled(fn (?User $record) => $record?->is(auth()->user())),

--- a/src/Http/Middleware/SetAppLocale.php
+++ b/src/Http/Middleware/SetAppLocale.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SetAppLocale
+{
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var \Cachet\Models\User */
+        $user = $request->user();
+
+        if ($user) {
+            app()->setLocale($user->preferredLocale() ?? $request->getPreferredLanguage(
+                array_keys(config('cachet.supported_locales'))
+            ));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/SetAppLocale.php
+++ b/src/Http/Middleware/SetAppLocale.php
@@ -9,7 +9,7 @@ class SetAppLocale
 {
     public function handle(Request $request, Closure $next)
     {
-        /** @var \Cachet\Models\User */
+        /** @var ?\Cachet\Models\User */
         $user = $request->user();
 
         if ($user) {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -5,6 +5,7 @@ namespace Cachet\Models;
 use Cachet\Concerns\CachetUser;
 use Cachet\Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -18,7 +19,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $password
  * @property bool $is_admin
  */
-class User extends Authenticatable implements CachetUser, MustVerifyEmail
+class User extends Authenticatable implements CachetUser, MustVerifyEmail, HasLocalePreference
 {
     /** @use HasFactory<\Cachet\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
@@ -73,5 +74,10 @@ class User extends Authenticatable implements CachetUser, MustVerifyEmail
     protected static function newFactory(): Factory
     {
         return UserFactory::new();
+    }
+
+    public function preferredLocale()
+    {
+        return $this->preferred_locale ?? config('app.locale');
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -18,6 +18,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $email
  * @property string $password
  * @property bool $is_admin
+ * @property string $preferred_locale
  */
 class User extends Authenticatable implements CachetUser, MustVerifyEmail, HasLocalePreference
 {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -34,6 +34,7 @@ class User extends Authenticatable implements CachetUser, MustVerifyEmail, HasLo
         'email',
         'password',
         'is_admin',
+        'preferred_locale',
     ];
 
     /**
@@ -78,6 +79,6 @@ class User extends Authenticatable implements CachetUser, MustVerifyEmail, HasLo
 
     public function preferredLocale()
     {
-        return $this->preferred_locale ?? config('app.locale');
+        return $this->preferred_locale;
     }
 }


### PR DESCRIPTION
This PR allows selecting the preferred locale for a user.

It also adds a middleware that sets the application locale to the user's preferred locale, or the system default (as specified by the browser in the `Accept-Language` header) if one isn't set.

I've specified the supported locales in the config file, and this will be used for:

- The options which a user can pick from
- Which locale to use when the browser sends multiple locale preferences

Changing the locale changes the language the user sees and the way in which dates and numbers are formatted in.

The application uses the fallback locale if a string doesn't have a translation defined for the given locale.

Going forward, if any new translation strings are added, the locale code should be added to the `supported_locales` config file.

This change only affects the Dashboard.