### PR TITLE
Display latest_status in Incident table

### DIFF
--- a/src/Filament/Resources/IncidentResource.php
+++ b/src/Filament/Resources/IncidentResource.php
@@ -109,7 +109,7 @@ class IncidentResource extends Resource
                 Tables\Columns\TextColumn::make('name')
                     ->label(__('cachet::incident.list.headers.name'))
                     ->searchable(),
-                Tables\Columns\TextColumn::make('status')
+                Tables\Columns\TextColumn::make('latest_status')
                     ->label(__('cachet::incident.list.headers.status'))
                     ->sortable()
                     ->badge(),


### PR DESCRIPTION
`latest_status` will display either the incident's status or the latest incident update's status.

Fixes #195