### PR TITLE
Fix/component status report

### DIFF
--- a/resources/views/components/component.blade.php
+++ b/resources/views/components/component.blade.php
@@ -19,7 +19,7 @@
                 <div>
                     @if ($component->incidents_count > 0)
                         <a href="{{ route('cachet.status-page.incident', [$component->incidents->first()]) }}">
-                            <x-cachet::badge :status="$component->status" />
+                            <x-cachet::badge :status="$component->latest_status" />
                         </a>
                     @else
                         <x-cachet::badge :status="$status" />

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -82,10 +82,15 @@ class Component extends Model
 
     /**
      * Get the incidents for the component.
+     *
+     * @return BelongsToMany<Incident, $this>
      */
     public function incidents(): BelongsToMany
     {
-        return $this->belongsToMany(Incident::class, 'incident_components')->withPivot('component_status');
+        return $this->belongsToMany(Incident::class, 'incident_components')
+            ->using(IncidentComponent::class)
+            ->withTimestamps()
+            ->withPivot('component_status');
     }
 
     /**
@@ -130,11 +135,7 @@ class Component extends Model
      */
     public function latestStatus(): Attribute
     {
-        return Attribute::get(fn () => ComponentStatusEnum::tryFrom($this->incidents()
-            ->latest()
-            ->first()
-            ?->pivot
-            ->component_status) ?? $this->status);
+        return Attribute::get(fn () => $this->incidents()->latest()->first()?->pivot->component_status ?? $this->status);
     }
 
     /**

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property ?string $description
  * @property ?string $link
  * @property ?ComponentStatusEnum $status
+ * @property ComponentStatusEnum $latest_status
  * @property ?int $order
  * @property ?int $component_group_id
  * @property ?Carbon $created_at

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -9,6 +9,7 @@ use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -121,6 +122,18 @@ class Component extends Model
     public function scopeOutage(Builder $query): void
     {
         $query->whereIn('status', ComponentStatusEnum::outage());
+    }
+
+    /**
+     * Get the latest status for the component.
+     */
+    public function latestStatus(): Attribute
+    {
+        return Attribute::get(fn () => ComponentStatusEnum::tryFrom($this->incidents()
+            ->latest()
+            ->first()
+            ?->pivot
+            ->component_status) ?? $this->status);
     }
 
     /**

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -49,6 +49,7 @@ use Illuminate\Support\Str;
  * @property Collection<int, Component> $components
  * @property Collection<int, Update> $updates
  * @property-read Carbon $timestamp
+ * @property-read IncidentComponent $pivot
  *
  * @method static IncidentFactory factory($count = null, $state = [])
  * @method static Builder<static>|static status(IncidentStatusEnum $status)

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -5,6 +5,7 @@ providers:
   - Spatie\LaravelSettings\LaravelSettingsServiceProvider
   - Spatie\LaravelData\LaravelDataServiceProvider
   - Laravel\Sanctum\SanctumServiceProvider
+  - Filament\FilamentServiceProvider
 
 env:
   - AUTH_MODEL=\Workbench\App\User

--- a/tests/Unit/Views/ComponentTest.php
+++ b/tests/Unit/Views/ComponentTest.php
@@ -3,7 +3,6 @@
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 
 uses(InteractsWithViews::class);
@@ -47,13 +46,13 @@ it('shows the latest status for a component multiple linked incidents', function
         'status' => ComponentStatusEnum::operational->value,
     ]);
 
-    $this->travelTo(now()->subMinutes(2), function () use ($component) {
+    $this->travelTo(now()->subSeconds(2), function () use ($component) {
         $component->incidents()->attach(Incident::factory()->create(), [
             'component_status' => ComponentStatusEnum::unknown->value,
         ]);
     });
 
-    $this->travelTo(now()->subMinutes(1), function () use ($component) {
+    $this->travelTo(now()->subSeconds(1), function () use ($component) {
         $component->incidents()->attach(Incident::factory()->create(), [
             'component_status' => ComponentStatusEnum::performance_issues->value,
         ]);

--- a/tests/Unit/Views/ComponentTest.php
+++ b/tests/Unit/Views/ComponentTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\View\Components\Component as ComponentView;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+
+uses(InteractsWithViews::class);
+
+it('shows the current status for a component with no linked incidents', function () {
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational->value
+    ]);
+
+    $view = $this->view('cachet::components.component', ['component' => $component, 'status' => $component->status]);
+
+    $view->assertSee('Operational');
+});
+
+it('shows the latest status for a component with linked incidents', function () {
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational->value,
+    ]);
+    $incident = Incident::factory()->create();
+
+    $incident->components()->attach($component, ['component_status' => ComponentStatusEnum::performance_issues->value]);
+
+    $view = $this->view('cachet::components.component', ['component' => $component, 'status' => $component->status]);
+
+    $view
+        ->assertSee(ComponentStatusEnum::performance_issues->getLabel())
+        ->assertDontSee(ComponentStatusEnum::operational->getLabel());
+})->todo();

--- a/tests/Unit/Views/ComponentTest.php
+++ b/tests/Unit/Views/ComponentTest.php
@@ -3,7 +3,7 @@
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
-use Cachet\View\Components\Component as ComponentView;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 
 uses(InteractsWithViews::class);
@@ -13,22 +13,66 @@ it('shows the current status for a component with no linked incidents', function
         'status' => ComponentStatusEnum::operational->value
     ]);
 
-    $view = $this->view('cachet::components.component', ['component' => $component, 'status' => $component->status]);
+    $view = $this->view('cachet::components.component', [
+        'component' => $component,
+        'status' => $component->status,
+    ]);
 
     $view->assertSee('Operational');
 });
 
-it('shows the latest status for a component with linked incidents', function () {
-    $component = Component::factory()->create([
+it('shows the latest status for a component one linked incident', function () {
+    Component::factory()->create([
         'status' => ComponentStatusEnum::operational->value,
+    ])
+        ->incidents()
+        ->attach(Incident::factory()->create(), [
+            'component_status' => ComponentStatusEnum::performance_issues->value,
+        ]);
+
+    $component = Component::query()->withCount('incidents')->first();
+
+    $view = $this->view('cachet::components.component', [
+        'component' => $component,
+        'status' => $component->status,
     ]);
-    $incident = Incident::factory()->create();
-
-    $incident->components()->attach($component, ['component_status' => ComponentStatusEnum::performance_issues->value]);
-
-    $view = $this->view('cachet::components.component', ['component' => $component, 'status' => $component->status]);
 
     $view
         ->assertSee(ComponentStatusEnum::performance_issues->getLabel())
         ->assertDontSee(ComponentStatusEnum::operational->getLabel());
-})->todo();
+});
+
+it('shows the latest status for a component multiple linked incidents', function () {
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational->value,
+    ]);
+
+    $this->travelTo(now()->subMinutes(2), function () use ($component) {
+        $component->incidents()->attach(Incident::factory()->create(), [
+            'component_status' => ComponentStatusEnum::unknown->value,
+        ]);
+    });
+
+    $this->travelTo(now()->subMinutes(1), function () use ($component) {
+        $component->incidents()->attach(Incident::factory()->create(), [
+            'component_status' => ComponentStatusEnum::performance_issues->value,
+        ]);
+    });
+
+    $component->incidents()->attach(Incident::factory()->create(), [
+        'component_status' => ComponentStatusEnum::partial_outage->value,
+    ]);
+
+    $component = Component::query()->withCount('incidents')->first();
+
+    $view = $this->view('cachet::components.component', [
+        'component' => $component,
+        'status' => $component->status,
+    ]);
+
+    $view
+        ->assertSee(ComponentStatusEnum::partial_outage->getLabel())
+        ->assertDontSee(ComponentStatusEnum::unknown->getLabel())
+        ->assertDontSee(ComponentStatusEnum::performance_issues->getLabel())
+        ->assertDontSee(ComponentStatusEnum::operational->getLabel());
+});


### PR DESCRIPTION
This PR:
- Adds a `latest_status` attribute to the `Component` model, which:
  - Pull the latest status from the attached incidents
  - Defaults to the status of the component
- Updates `component.blade.php` to pull `latest_status` if there are any attached incidents, instead of the status of the component itself
- Adds two test cases
  - ✅ Check that components **without incidents** render the status on the component
  - ✅ Check that components with **one incident** render the status on the attached pivot
  - ✅ Check that components with **more than one incident** render the status on the **latest** attached pivot

Fixes https://github.com/cachethq/core/issues/196