### PR TITLE
Make Component Group sortable in dashboard

### DIFF
--- a/src/Filament/Resources/ComponentGroupResource.php
+++ b/src/Filament/Resources/ComponentGroupResource.php
@@ -84,6 +84,8 @@ class ComponentGroupResource extends Resource
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ])
+            ->reorderable('order')
+            ->defaultSort('order')
             ->emptyStateHeading(__('cachet::component_group.list.empty_state.heading'))
             ->emptyStateDescription(__('cachet::component_group.list.empty_state.description'));
     }

--- a/src/Filament/Resources/ComponentResource.php
+++ b/src/Filament/Resources/ComponentResource.php
@@ -108,6 +108,7 @@ class ComponentResource extends Resource
                 ]),
             ])
             ->reorderable('order')
+            ->defaultSort('order')
             ->emptyStateHeading(__('cachet::component.list.empty_state.heading'))
             ->emptyStateDescription(__('cachet::component.list.empty_state.description'));
     }


### PR DESCRIPTION
Fixes https://github.com/cachethq/core/issues/202

I've also made sure that the Component and Component Group resources are default sorted by the `order` column, so switching to order mode remains in the same order.