### PR TITLE
Support the `HTTP_REMOTE_USER` header

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -70,6 +70,7 @@ return [
      */
     'middleware' => [
         'web',
+//        \Cachet\Http\Middleware\AuthenticateRemoteUser::class,
     ],
 
     'api_middleware' => [

--- a/src/Cachet.php
+++ b/src/Cachet.php
@@ -3,6 +3,7 @@
 namespace Cachet;
 
 use Cachet\Http\Middleware\RedirectIfAuthenticated;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -32,6 +33,16 @@ class Cachet
         }
 
         return $request->user($guard);
+    }
+
+    /**
+     * Get the user model used by Cachet.
+     */
+    public static function userModel(): Model
+    {
+        $userModel = config('cachet.user_model');
+
+        return new $userModel;
     }
 
     /**

--- a/src/Http/Middleware/AuthenticateRemoteUser.php
+++ b/src/Http/Middleware/AuthenticateRemoteUser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Cachet\Cachet;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateRemoteUser
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($remoteUser = $request->headers->get('REMOTE_USER')) {
+            $userModel = Cachet::userModel();
+            $user = $userModel::where('email', $remoteUser)->firstOrFail();
+
+            if ($user) {
+                auth()->login($user);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/AuthenticateRemoteUser.php
+++ b/src/Http/Middleware/AuthenticateRemoteUser.php
@@ -18,7 +18,7 @@ class AuthenticateRemoteUser
     {
         if ($remoteUser = $request->headers->get('REMOTE_USER')) {
             $userModel = Cachet::userModel();
-            $user = $userModel::where('email', $remoteUser)->firstOrFail();
+            $user = $userModel::where('email', $remoteUser)->first();
 
             if ($user) {
                 auth()->login($user);

--- a/src/Http/Middleware/AuthenticateRemoteUser.php
+++ b/src/Http/Middleware/AuthenticateRemoteUser.php
@@ -3,6 +3,7 @@
 namespace Cachet\Http\Middleware;
 
 use Cachet\Cachet;
+use Cachet\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,9 +19,10 @@ class AuthenticateRemoteUser
     {
         if ($remoteUser = $request->headers->get('REMOTE_USER')) {
             $userModel = Cachet::userModel();
-            $user = $userModel::where('email', $remoteUser)->first();
+            /** @var User|null $user */
+            $user = $userModel::query()->where('email', $remoteUser)->first();
 
-            if ($user) {
+            if ($user !== null) {
                 auth()->login($user);
             }
         }

--- a/tests/Feature/Http/Middleware/AuthenticateRemoteUserTest.php
+++ b/tests/Feature/Http/Middleware/AuthenticateRemoteUserTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Cachet\Http\Middleware\AuthenticateRemoteUser;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+use Workbench\App\User;
+
+it('authenticates remote user if REMOTE_USER header is present', function () {
+    $user = User::factory()->create(['email' => 'test@example.com']);
+
+    $request = Request::create('/test', 'GET', [], [], [], ['HTTP_REMOTE_USER' => 'test@example.com']);
+
+    $next = function ($request) {
+        return new Response('OK');
+    };
+
+    $middleware = new AuthenticateRemoteUser();
+
+    $response = $middleware->handle($request, $next);
+
+    expect(Auth::check())->toBeTrue()
+        ->and(Auth::user()->email)->toBe('test@example.com')
+        ->and($response->getContent())->toBe('OK');
+});
+
+it('does not authenticate remote user if REMOTE_USER header is not present', function () {
+    $request = Request::create('/test');
+
+    $next = function ($request) {
+        return new Response('OK');
+    };
+
+    $middleware = new AuthenticateRemoteUser();
+
+    $response = $middleware->handle($request, $next);
+
+    expect(Auth::check())->toBeFalse()
+        ->and($response->getContent())->toBe('OK');
+});


### PR DESCRIPTION
Copied from v2.4 based on some feedback I received.

We should also implement something more modern like SAML.