### PR TITLE
fix: make user command does not accept a name argument

### DIFF
--- a/src/Commands/MakeUserCommand.php
+++ b/src/Commands/MakeUserCommand.php
@@ -16,7 +16,7 @@ class MakeUserCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cachet:make:user {email?} {--password= : The user\'s password} {--admin : Whether the user is an admin}';
+        protected $signature = 'cachet:make:user {email?} {--password= : The user\'s password} {--admin : Whether the user is an admin} {--name= : The name of the user }';
 
     /**
      * The console command description.
@@ -53,6 +53,11 @@ class MakeUserCommand extends Command
         $this->email = $this->argument('email');
         $this->isAdmin = $this->option('admin');
         $this->password = $this->option('password');
+        $this->data['name'] = $this->option('name');
+
+        if (! $this->data['name']) {
+            $this->promptName();
+        }
 
         $this->promptName();
 


### PR DESCRIPTION
When trying to create a user with the `--no-interaction` flag the following error occurs

```
php artisan cachet:make:user test@test.com --password="password" --admin --no-interaction

   Laravel\Prompts\Exceptions\NonInteractiveValidationException

  Required.

  at vendor/laravel/prompts/src/Concerns/Interactivity.php:32
     28▕
     29▕         $this->validate($default);
     30▕
     31▕         if ($this->state === 'error') {
  ➜  32▕             throw new NonInteractiveValidationException($this->error);
     33▕         }
     34▕
     35▕         return $default;
     36▕     }

      +17 vendor frames

  18  artisan:13
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
```

There is currently no `--name` flag available

```
php artisan cachet:make:user test@test.com --password="password" --admin --name="test" --no-interaction


  The "--name" option does not exist.
```

This will provide the option to supply `name` as an argument 

```
php artisan cachet:make:user --help
Description:
  Create a new user

Usage:
  cachet:make:user [options] [--] [<email>]

Arguments:
  email

Options:
      --password[=PASSWORD]  The user's password
      --admin                Whether the user is an admin
      --name[=NAME]          The name of the user
  -h, --help                 Display help for the given command. When no command is given display help for the list command
      --silent               Do not output any message
  -q, --quiet                Only errors are displayed. All other output is suppressed
  -V, --version              Display this application version
      --ansi|--no-ansi       Force (or disable --no-ansi) ANSI output
  -n, --no-interaction       Do not ask any interactive question
      --env[=ENV]            The environment the command should run under
  -v|vv|vvv, --verbose       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

```
php artisan cachet:make:user test@test.com --password="password" --admin --name='test'  --no-interaction

   INFO  User created successfully.
```