### PR TITLE
[fix] name mapping in request data classes

### DIFF
--- a/src/Data/BaseData.php
+++ b/src/Data/BaseData.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Data;
 
+use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * @template TKey of array-key
  * @template TValue
  */
+#[MapName(SnakeCaseMapper::class)]
 abstract class BaseData extends Data
 {
     /**

--- a/workbench/config/data.php
+++ b/workbench/config/data.php
@@ -132,8 +132,8 @@ return [
      * global strategy here, or override it on a specific data object.
      */
     'name_mapping_strategy' => [
-        'input' => \Spatie\LaravelData\Mappers\SnakeCaseMapper::class,
-        'output' => \Spatie\LaravelData\Mappers\SnakeCaseMapper::class,
+        'input' => null,
+        'output' => null,
     ],
 
     /**


### PR DESCRIPTION
This PR adds a snake case name mapper PHP attribute to `BaseData`.

closes #225 

## Problem Context

As discovered in #225, the API tests are returning a false positive, because of the [Laravel Data configuration used for testbench](https://github.com/cachethq/core/blob/efcdc1ee2127f43805eec3bf1964cb8bdf633624/workbench/config/data.php#L134-L137):

```php
    'name_mapping_strategy' => [
        'input' => \Spatie\LaravelData\Mappers\SnakeCaseMapper::class,
        'output' => \Spatie\LaravelData\Mappers\SnakeCaseMapper::class,
    ],
```

Setting both of these values to `NULL` and running the test suite highlights the error. Of course, this is fine in our tests as we are specifying the Laravel app to uses these mappers. However applications consuming this package might not have Laravel Data configured this way.

## The fix
Since we have architectural tests in place to ensure that all `XyzRequestData` classes must be declared `final` and must extend `BaseData`, we are able to fix the problem by simply adding the following attribute above the class declaration for `BaseData`:


```php
#[MapName(SnakeCaseMapper::class)]
abstract class BaseData extends Data
{
   ...
}
```