### PR TITLE
fix: remove additional prompt for name

### DIFF
--- a/src/Commands/MakeUserCommand.php
+++ b/src/Commands/MakeUserCommand.php
@@ -59,8 +59,6 @@ class MakeUserCommand extends Command
             $this->promptName();
         }
 
-        $this->promptName();
-
         if (! $this->email) {
             $this->promptEmail();
         }


### PR DESCRIPTION
Neglected to remove this prompt to account for non-interactive mode in my prior PR https://github.com/cachethq/core/pull/216 

@jbrooksuk do you mind reviewing this again?