### PR TITLE
Fix issue with postgresql

### DIFF
--- a/src/Status.php
+++ b/src/Status.php
@@ -80,8 +80,8 @@ class Status
         return $this->incidents ??= Incident::query()
             ->toBase()
             ->selectRaw('count(*) as total')
-            ->selectRaw('sum(case when ? in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as resolved', [IncidentStatusEnum::fixed->value, ''])
-            ->selectRaw('sum(case when ? not in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as unresolved', [IncidentStatusEnum::fixed->value, ''])
+            ->selectRaw('sum(case when ? in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as resolved', [IncidentStatusEnum::fixed->value, 0])
+            ->selectRaw('sum(case when ? not in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as unresolved', [IncidentStatusEnum::fixed->value, 0])
             ->joinSub(function (Builder $query) {
                 $query
                     ->select('iu1.updateable_id', 'iu1.status')


### PR DESCRIPTION
Fix the following issue with postgresql:

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type integer: "" CONTEXT: unnamed portal parameter $2 = '' (Connection: pgsql, SQL: select count(*) as total, sum(case when 4 in (incidents.status, coalesce(latest_update.status, )) then 1 else 0 end) as resolved, sum(case when 4 not in (incidents.status, coalesce(latest_update.status, )) then 1 else 0 end) as unresolved from "incidents" left join (select "iu1"."updateable_id", "iu1"."status" from "updates" as "iu1" left join (select "updateable_id", max(id) as max_id from "updates" where "updates"."updateable_type" = incident group by "updateable_id") as "iu2" on "iu1"."id" = "iu2"."max_id") as "latest_update" on "latest_update"."updateable_id" = "incidents"."id" where "incidents"."deleted_at" is null limit 1)
```