### PR TITLE
fix(locale): Added a migration to set user preferred locale value

### DIFF
--- a/database/migrations/2025_03_02_172736_add_default_to_preferred_locale_column_in_users_table.php
+++ b/database/migrations/2025_03_02_172736_add_default_to_preferred_locale_column_in_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('preferred_locale')->nullable()->default('en')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('preferred_locale')->nullable()->default(null)->change();
+        });
+    }
+};


### PR DESCRIPTION
This PR resolves #249 

When a user registers first, by default in the `users` table `preferred_locale` is set as `NULL`. Therefore if we set `default()` in `select form component` it would not work unless the user clicks the `save changes` button. The same result if we change in config.

Therefore, according to my perspective, to set English as the default language, we should do it when creating a user at the database level. That's why I added this migration.

## After adding migration
![default behavior 1](https://github.com/user-attachments/assets/c2a64f13-26f2-46d8-8172-a01b5133eafd)

![default behavior 2](https://github.com/user-attachments/assets/84ec7ad3-b1c9-4180-a21f-9ec0b573f48e)
