### PR TITLE
Optionally display the metric graphs

### DIFF
--- a/resources/views/status-page/index.blade.php
+++ b/resources/views/status-page/index.blade.php
@@ -13,7 +13,9 @@
             <x-cachet::component-ungrouped :component="$component" />
         @endforeach
 
+        @if ($display_graphs)
         <x-cachet::metrics />
+        @endif
 
         @if ($schedules->isNotEmpty())
             <x-cachet::schedules :schedules="$schedules" />

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -6,11 +6,20 @@ use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
+use Cachet\Settings\AppSettings;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\View\View;
 
 class StatusPageController
 {
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(protected AppSettings $appSettings)
+    {
+        //
+    }
+
     /**
      * Show the status page.
      */
@@ -31,6 +40,8 @@ class StatusPageController
                 ->get(),
 
             'schedules' => Schedule::query()->with('updates')->incomplete()->orderBy('scheduled_at')->get(),
+
+            'display_graphs' => $this->appSettings->display_graphs,
         ]);
     }
 

--- a/src/Settings/AppSettings.php
+++ b/src/Settings/AppSettings.php
@@ -32,6 +32,8 @@ class AppSettings extends Settings
 
     public int $recent_incidents_days = 7;
 
+    public bool $display_graphs = true;
+
     public static function group(): string
     {
         return 'app';


### PR DESCRIPTION
The "Display Graphs" option wasn't correctly wired up and the setting had no bearing on whether graphs were displayed or not.