### PR TITLE
Tests for MakeUserCommand

### DIFF
--- a/src/Commands/MakeUserCommand.php
+++ b/src/Commands/MakeUserCommand.php
@@ -16,7 +16,7 @@ class MakeUserCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cachet:make:user {email?} {--password= : The user\'s password} {--admin : Whether the user is an admin} {--name= : The name of the user }';
+    protected $signature = 'cachet:make:user {email?} {--password= : The user\'s password} {--admin= : Whether the user is an admin} {--name= : The name of the user }';
 
     /**
      * The console command description.
@@ -63,7 +63,7 @@ class MakeUserCommand extends Command
             $this->promptEmail();
         }
 
-        if (! $this->isAdmin) {
+        if ($this->isAdmin === null) {
             $this->promptIsAdmin();
         }
 

--- a/src/Commands/MakeUserCommand.php
+++ b/src/Commands/MakeUserCommand.php
@@ -51,7 +51,7 @@ class MakeUserCommand extends Command
     public function handle(): int
     {
         $this->email = $this->argument('email');
-        $this->isAdmin = $this->option('admin');
+        $this->isAdmin = $this->option('admin') !== null ? (bool) $this->option('admin') : null;
         $this->password = $this->option('password');
         $this->data['name'] = $this->option('name');
 

--- a/tests/Unit/Commands/MakeUserCommandTest.php
+++ b/tests/Unit/Commands/MakeUserCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+it('creates the admin user', function () {
+    $this->artisan('cachet:make:user', [
+        'email' => 'dan@example.com',
+        '--name' => 'Dan',
+        '--admin' => true,
+        '--password' => 'password',
+    ]);
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'dan@example.com',
+        'name' => 'Dan',
+        'is_admin' => true,
+    ]);
+});
+
+it('creates the standard user', function () {
+    $this->artisan('cachet:make:user', [
+        'email' => 'dan@example.com',
+        '--name' => 'Dan',
+        '--admin' => false,
+        '--password' => 'password',
+    ]);
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'dan@example.com',
+        'name' => 'Dan',
+        'is_admin' => false,
+    ]);
+});
+
+it('creates the standard user using prompts', function () {
+    $this->artisan('cachet:make:user')
+        ->expectsQuestion('What is the user\'s name?', 'Dan')
+        ->expectsQuestion('What is the user\'s email?', 'dan@example.com')
+        ->expectsConfirmation('Is the user an admin?', 'No')
+        ->expectsQuestion('What is the user\'s password?', 'password');
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'dan@example.com',
+        'name' => 'Dan',
+        'is_admin' => false,
+    ]);
+});
+
+it('creates the admin user using prompts', function () {
+    $this->artisan('cachet:make:user')
+        ->expectsQuestion('What is the user\'s name?', 'Dan')
+        ->expectsQuestion('What is the user\'s email?', 'dan@example.com')
+        ->expectsConfirmation('Is the user an admin?', 'Yes')
+        ->expectsQuestion('What is the user\'s password?', 'password');
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'dan@example.com',
+        'name' => 'Dan',
+        'is_admin' => true,
+    ]);
+});


### PR DESCRIPTION
This is based off a recent conversation in Discord - frank42 mentioned that a user is being created as a non-admin even when they said "Yes" to the admin prompt.

I can't replicate that particular bug, but I thought it'd be good to have some tests on this command anyway.

This also fixes a bug where if the arguments are passed directly to the command, and you're creating a non-admin user, the command would still ask if the user should be an admin.