### PR TITLE
Allow configuring whether to use external dependencies

### DIFF
--- a/database/migrations/2025_05_11_141054_add_external_dependencies_setting.php
+++ b/database/migrations/2025_05_11_141054_add_external_dependencies_setting.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        rescue(fn () => $this->migrator->add('app.enable_external_dependencies', true));
+    }
+};

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -15,10 +15,12 @@ return [
             'show_timezone' => 'Show Timezone',
             'show_dashboard_link' => 'Show Dashboard Link',
             'display_graphs' => 'Display Graphs',
+            'enable_external_dependencies' => 'Enable External Dependencies',
             'only_show_disrupted_days' => 'Only Show Disrupted Days',
             'recent_incidents_only' => 'Show Recent Incidents Only',
             'recent_incidents_days' => 'Number of Days to Show Recent Incidents',
         ],
+        'display_settings_title' => 'Display Settings',
     ],
     'manage_customization' => [
         'header_label' => 'Custom Header HTML',

--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -32,7 +32,7 @@ class CachetDashboardServiceProvider extends PanelProvider
         return $panel
             ->id('cachet')
             ->when(
-                $appSettings->enable_external_dependencies,
+                ! app()->runningInConsole() && $appSettings->enable_external_dependencies,
                 fn ($panel) => $panel->font('switzer', 'https://fonts.cdnfonts.com/css/switzer'),
                 fn ($panel) => $panel->font('ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" ', provider: LocalFontProvider::class),
             )

--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -4,6 +4,8 @@ namespace Cachet;
 
 use Cachet\Filament\Pages\EditProfile;
 use Cachet\Http\Middleware\SetAppLocale;
+use Cachet\Settings\AppSettings;
+use Filament\FontProviders\LocalFontProvider;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -25,9 +27,15 @@ class CachetDashboardServiceProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
+        $appSettings = app(AppSettings::class);
+
         return $panel
             ->id('cachet')
-            ->font('switzer', 'https://fonts.cdnfonts.com/css/switzer')
+            ->when(
+                $appSettings->enable_external_dependencies,
+                fn ($panel) => $panel->font('switzer', 'https://fonts.cdnfonts.com/css/switzer'),
+                fn ($panel) => $panel->font('ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" ', provider: LocalFontProvider::class),
+            )
             ->default()
             ->login()
             ->passwordReset()

--- a/src/Filament/Pages/Settings/ManageCachet.php
+++ b/src/Filament/Pages/Settings/ManageCachet.php
@@ -7,6 +7,7 @@ use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Illuminate\Support\Str;
+use function __;
 
 class ManageCachet extends SettingsPage
 {
@@ -71,13 +72,6 @@ class ManageCachet extends SettingsPage
                         ->step(1)
                         ->suffix(__('cachet::settings.manage_cachet.refresh_rate_label_input_suffix_seconds')),
 
-                    Forms\Components\Grid::make(2)
-                        ->schema([
-                            Forms\Components\Toggle::make('show_support')
-                                ->label(__('cachet::settings.manage_cachet.toggles.support_cachet')),
-                            Forms\Components\Toggle::make('display_graphs')
-                                ->label(__('cachet::settings.manage_cachet.toggles.display_graphs')),
-                        ]),
                     Forms\Components\Toggle::make('show_timezone')
                         ->label(__('cachet::settings.manage_cachet.toggles.show_timezone')),
                     Forms\Components\Toggle::make('only_disrupted_days')
@@ -99,6 +93,15 @@ class ManageCachet extends SettingsPage
                                 ->hidden(fn (Get $get) => $get('recent_incidents_only') !== true),
                         ]),
                 ]),
+                Forms\Components\Section::make(__('cachet::settings.manage_cachet.display_settings_title'))
+                    ->schema([
+                        Forms\Components\Toggle::make('show_support')
+                            ->label(__('cachet::settings.manage_cachet.toggles.support_cachet')),
+                        Forms\Components\Toggle::make('display_graphs')
+                            ->label(__('cachet::settings.manage_cachet.toggles.display_graphs')),
+                        Forms\Components\Toggle::make('enable_external_dependencies')
+                            ->label(__('cachet::settings.manage_cachet.toggles.enable_external_dependencies')),
+                    ]),
             ]);
     }
 }

--- a/src/Settings/AppSettings.php
+++ b/src/Settings/AppSettings.php
@@ -34,6 +34,8 @@ class AppSettings extends Settings
 
     public bool $display_graphs = true;
 
+    public bool $enable_external_dependencies = true;
+
     public static function group(): string
     {
         return 'app';


### PR DESCRIPTION
Closes #267 

- Switzer will no longer be used in the dashboard when external assets are disabled.
- Grouped some similar view settings together.
- To configure avatars, you will need to manually change the `User` model.