### PR TITLE
Add option to show metrics even when empty

### DIFF
--- a/database/migrations/2025_09_13_124815_add_show_when_empty_column_to_metrics_table.php
+++ b/database/migrations/2025_09_13_124815_add_show_when_empty_column_to_metrics_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('metrics', function (Blueprint $table) {
+            $table->boolean('show_when_empty')->after('display_chart')->default(false);
+        });
+    }
+};

--- a/resources/lang/en/metric.php
+++ b/resources/lang/en/metric.php
@@ -35,6 +35,7 @@ return [
 
         'visible_label' => 'Visible',
         'display_chart_label' => 'Display Chart',
+        'show_when_empty_label' => 'Show when empty',
     ],
     'overview' => [
         'metric_points_label' => 'Metric Points',

--- a/src/Filament/Resources/Metrics/MetricResource.php
+++ b/src/Filament/Resources/Metrics/MetricResource.php
@@ -91,6 +91,10 @@ class MetricResource extends Resource
                         ->label(__('cachet::metric.form.display_chart_label'))
                         ->default(true)
                         ->required(),
+                    Toggle::make('show_when_empty')
+                        ->label(__('cachet::metric.form.show_when_empty_label'))
+                        ->default(true)
+                        ->required(),
 
                 ])->columnSpan(1),
             ])->columns(4);

--- a/src/Models/Metric.php
+++ b/src/Models/Metric.php
@@ -48,6 +48,7 @@ class Metric extends Model
     protected $casts = [
         'calc_type' => MetricTypeEnum::class,
         'display_chart' => 'bool',
+        'show_when_empty' => 'bool',
         'places' => 'int',
         'default_view' => MetricViewEnum::class,
         'visible' => ResourceVisibilityEnum::class,
@@ -68,6 +69,7 @@ class Metric extends Model
         'description',
         'calc_type',
         'display_chart',
+        'show_when_empty',
         'places',
         'default_value',
         'default_view',

--- a/src/View/Components/Metrics.php
+++ b/src/View/Components/Metrics.php
@@ -47,7 +47,7 @@ class Metrics extends Component
                 'metricPoints' => fn ($query) => $query->orderBy('created_at'),
             ])
             ->where('display_chart', true)
-            ->whereHas('metricPoints', fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->where(fn (Builder $query) => $query->where('show_when_empty', true)->orWhereHas('metricPoints', fn (Builder $query) => $query->where('created_at', '>=', $startDate)))
             ->orderBy('places')
             ->get();
     }


### PR DESCRIPTION
Metrics previously needed to have data before they would be shown. We now offer an option to show the metric even when it is empty (has no data).

<img width="2548" height="1784" alt="CleanShot 2025-09-13 at 13 51 01@2x" src="https://github.com/user-attachments/assets/8d1016c8-f569-4b8f-931d-127f3f62ebd3" />
