### PR TITLE
Fix themes not applying foreground colors

### DIFF
--- a/src/Data/Cachet/ThemeData.php
+++ b/src/Data/Cachet/ThemeData.php
@@ -39,11 +39,11 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Gray[800],
                 'accent-content' => Color::Gray[800],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
-                'accent' => '255, 255, 255',
-                'accent-content' => '255, 255, 255',
+                'accent' => 'oklch(1 0 0)',
+                'accent-content' => 'oklch(1 0 0)',
                 'accent-foreground' => Color::Gray[800],
             ],
         ],
@@ -51,11 +51,11 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Zinc[800],
                 'accent-content' => Color::Zinc[800],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
-                'accent' => '255, 255, 255',
-                'accent-content' => '255, 255, 255',
+                'accent' => 'oklch(1 0 0)',
+                'accent-content' => 'oklch(1 0 0)',
                 'accent-foreground' => Color::Zinc[800],
             ],
         ],
@@ -63,11 +63,11 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Neutral[800],
                 'accent-content' => Color::Neutral[800],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
-                'accent' => '255, 255, 255',
-                'accent-content' => '255, 255, 255',
+                'accent' => 'oklch(1 0 0)',
+                'accent-content' => 'oklch(1 0 0)',
                 'accent-foreground' => Color::Neutral[800],
             ],
         ],
@@ -75,11 +75,11 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Stone[800],
                 'accent-content' => Color::Stone[800],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
-                'accent' => '255, 255, 255',
-                'accent-content' => '255, 255, 255',
+                'accent' => 'oklch(1 0 0)',
+                'accent-content' => 'oklch(1 0 0)',
                 'accent-foreground' => Color::Stone[800],
             ],
         ],
@@ -87,19 +87,19 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Red[500],
                 'accent-content' => Color::Red[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Red[500],
                 'accent-content' => Color::Red[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'orange' => [
             'light' => [
                 'accent' => Color::Orange[500],
                 'accent-content' => Color::Orange[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Orange[400],
@@ -147,144 +147,144 @@ final class ThemeData extends BaseData
             'light' => [
                 'accent' => Color::Green[600],
                 'accent-content' => Color::Green[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Green[600],
                 'accent-content' => Color::Green[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'emerald' => [
             'light' => [
                 'accent' => Color::Emerald[600],
                 'accent-content' => Color::Emerald[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Emerald[600],
                 'accent-content' => Color::Emerald[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'teal' => [
             'light' => [
                 'accent' => Color::Teal[600],
                 'accent-content' => Color::Teal[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Teal[600],
                 'accent-content' => Color::Teal[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'cyan' => [
             'light' => [
                 'accent' => Color::Cyan[600],
                 'accent-content' => Color::Cyan[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Cyan[600],
                 'accent-content' => Color::Cyan[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'sky' => [
             'light' => [
                 'accent' => Color::Sky[600],
                 'accent-content' => Color::Sky[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Sky[600],
                 'accent-content' => Color::Sky[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'blue' => [
             'light' => [
                 'accent' => Color::Blue[500],
                 'accent-content' => Color::Blue[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Blue[500],
                 'accent-content' => Color::Blue[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'indigo' => [
             'light' => [
                 'accent' => Color::Indigo[500],
                 'accent-content' => Color::Indigo[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Indigo[500],
                 'accent-content' => Color::Indigo[300],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'violet' => [
             'light' => [
                 'accent' => Color::Violet[500],
                 'accent-content' => Color::Violet[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Violet[500],
                 'accent-content' => Color::Violet[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'purple' => [
             'light' => [
                 'accent' => Color::Purple[500],
                 'accent-content' => Color::Purple[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Purple[500],
                 'accent-content' => Color::Purple[300],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'fuchsia' => [
             'light' => [
                 'accent' => Color::Fuchsia[600],
                 'accent-content' => Color::Fuchsia[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Fuchsia[600],
                 'accent-content' => Color::Fuchsia[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'pink' => [
             'light' => [
                 'accent' => Color::Pink[600],
                 'accent-content' => Color::Pink[600],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Pink[600],
                 'accent-content' => Color::Pink[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
         'rose' => [
             'light' => [
                 'accent' => Color::Rose[500],
                 'accent-content' => Color::Rose[500],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
             'dark' => [
                 'accent' => Color::Rose[500],
                 'accent-content' => Color::Rose[400],
-                'accent-foreground' => '255, 255, 255',
+                'accent-foreground' => 'oklch(1 0 0)',
             ],
         ],
     ];
@@ -312,7 +312,7 @@ final class ThemeData extends BaseData
                 'light' => [
                     'accent' => $primaryColor[500],
                     'accent-content' => $primaryColor[500],
-                    'accent-foreground' => '255, 255, 255',
+                    'accent-foreground' => 'oklch(1 0 0)',
                 ],
                 'dark' => [
                     'accent' => $primaryColor[500],


### PR DESCRIPTION
Since upgrading to Tailwind 4, we weren't correctly providing foreground colors (including some background colors) in the right format.