### PR TITLE
Improve API documentation: fix for demo server path, added `403` error responses, improved schema for paginated responses 

### DIFF
--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -231,7 +231,7 @@ class CachetCoreServiceProvider extends ServiceProvider
             ->withDocumentTransformers(function (OpenApi $openApi) {
                 $openApi->info->description = 'API documentation for Cachet, the open-source, self-hosted status page system.';
 
-                $openApi->addServer(Server::make('https://v3.cachethq.io')->setDescription('The Cachet v3 demo server.'));
+                $openApi->addServer(Server::make('https://v3.cachethq.io/api')->setDescription('The Cachet v3 demo server.'));
                 $openApi->secure(SecurityScheme::http('bearer'));
             })
             ->withOperationTransformers(function (Operation $operation, RouteInfo $routeInfo) {

--- a/src/Concerns/GuardsApiAbilities.php
+++ b/src/Concerns/GuardsApiAbilities.php
@@ -9,6 +9,7 @@ use Laravel\Sanctum\Exceptions\MissingAbilityException;
 
 trait GuardsApiAbilities
 {
+    /** @throws MissingAbilityException */
     public function guard(string $ability): void
     {
         /** @var User $user */


### PR DESCRIPTION
This PR brings a few improvements to API docs.

1. By upgrading Scramble and Scramble PRO to `0.12.35` and `0.7.18`, Cachet API docs will have a more accurate pagination information schema (links are optional, but when present – they'll be strings).

2. Fixed demo server path (was `https://v3.cachethq.io` but the correct one is `https://v3.cachethq.io/api`).

3. Added `/** @throws MissingAbilityException */` annotation to the `GuardsApiAbilities` trait. This, in turn, improved documentation of endpoints that use this trait and now include a `403` response.

Altogether, this makes the documentation more accurate and consumers of this API happier 🫶