### PR TITLE
Add ability to attach components to schedules

### DIFF
--- a/resources/views/components/schedule.blade.php
+++ b/resources/views/components/schedule.blade.php
@@ -13,6 +13,11 @@
                         <span class="text-xs text-zinc-500 dark:text-zinc-400">
                             {{ $schedule->scheduled_at->diffForHumans() }} — <time datetime="{{ $schedule->scheduled_at->toW3cString()}}" x-text="timestamp.toLocaleString(@if($appSettings->timezone !== '-')undefined, {timeZone: '{{$appSettings->timezone}}'}@endif )"></time>
                         </span>
+                        @if ($schedule->components->isNotEmpty())
+                        <div class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 mt-1">
+                            {{ __('Affected Components') }}: {{ $schedule->components->pluck('name')->join(', ', ' and ') }}
+                        </div>
+                        @endif
                     </div>
 
                     <div class="flex justify-start sm:justify-end">

--- a/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Cachet\Filament\Resources\Schedules\RelationManagers;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Filament\Actions\AttachAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DetachAction;
+use Filament\Actions\DetachBulkAction;
+use Filament\Forms\Components\Select;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+
+class ComponentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'components';
+
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return __('Components');
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                // No form editing needed - components are only attached/detached
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('name')
+            ->modelLabel(__('Component'))
+            ->pluralModelLabel(__('Components'))
+            ->columns([
+                TextColumn::make('name')
+                    ->label(__('Name')),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                AttachAction::make()
+                    ->preloadRecordSelect()
+                    ->recordSelect(
+                        fn (Select $select) => $select->placeholder(__('Select a component')),
+                    )
+                    ->multiple()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        // Set a default component_status value (Operational)
+                        $data['component_status'] = ComponentStatusEnum::operational->value;
+                        return $data;
+                    }),
+            ])
+            ->recordActions([
+                DetachAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DetachBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -4,10 +4,12 @@ namespace Cachet\Filament\Resources\Schedules;
 
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Filament\Resources\Schedules\Pages\CreateSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\EditSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\ListSchedules;
+use Cachet\Filament\Resources\Schedules\RelationManagers\ComponentsRelationManager;
 use Cachet\Filament\Resources\Updates\RelationManagers\UpdatesRelationManager;
 use Cachet\Models\Schedule;
 use Filament\Actions\Action;
@@ -15,7 +17,10 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\MarkdownEditor;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -40,6 +45,23 @@ class ScheduleResource extends Resource
                         ->required(),
                     MarkdownEditor::make('message')
                         ->label(__('cachet::schedule.form.message_label'))
+                        ->columnSpanFull(),
+                    Repeater::make('scheduleComponents')
+                        ->visibleOn('create')
+                        ->relationship()
+                        ->defaultItems(0)
+                        ->addActionLabel(__('Add Component'))
+                        ->schema([
+                            Select::make('component_id')
+                                ->preload()
+                                ->required()
+                                ->relationship('component', 'name')
+                                ->disableOptionsWhenSelectedInSiblingRepeaterItems()
+                                ->label(__('Component')),
+                            Hidden::make('component_status')
+                                ->default(ComponentStatusEnum::operational->value),
+                        ])
+                        ->label(__('Affected Components'))
                         ->columnSpanFull(),
                 ])->columnSpan(3),
                 Section::make()->schema([
@@ -146,6 +168,7 @@ class ScheduleResource extends Resource
     public static function getRelations(): array
     {
         return [
+            ComponentsRelationManager::class,
             UpdatesRelationManager::class,
         ];
     }

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -39,7 +39,7 @@ class StatusPageController
                 ->withCount('incidents')
                 ->get(),
 
-            'schedules' => Schedule::query()->with('updates')->incomplete()->orderBy('scheduled_at')->get(),
+            'schedules' => Schedule::query()->with(['updates', 'components'])->incomplete()->orderBy('scheduled_at')->get(),
 
             'display_graphs' => $this->appSettings->display_graphs,
         ]);

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -94,6 +94,18 @@ class Component extends Model
     }
 
     /**
+     * Get the schedules for the component.
+     *
+     * @return BelongsToMany<Schedule, $this>
+     */
+    public function schedules(): BelongsToMany
+    {
+        return $this->belongsToMany(Schedule::class, 'schedule_components')
+            ->withTimestamps()
+            ->withPivot('component_status');
+    }
+
+    /**
      * Get the subscribers for this component.
      */
     public function subscribers(): BelongsToMany

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
@@ -87,7 +88,18 @@ class Schedule extends Model
         return $this->belongsToMany(
             Component::class,
             'schedule_components',
-        );
+        )->withPivot(['component_status'])
+            ->withTimestamps();
+    }
+
+    /**
+     * Get the schedule components pivot entries.
+     *
+     * @return HasMany<ScheduleComponent, $this>
+     */
+    public function scheduleComponents(): HasMany
+    {
+        return $this->hasMany(ScheduleComponent::class);
     }
 
     /**


### PR DESCRIPTION
Addresses #192 

It was always possible to attach components to specific incidents, but it was not possible to do the same with schedules in v3.

Meanwhile this was seemingly already possible with v2, and hence the tables migrated to v3 already supported this, so it was just a matter of adapting the templates.

Please note that in the current iteration, components when attached to schedules are set with a default value of 1 (Operational) which is un-editable, since there's no capability currently in the app to flip the component to the intended status when the set schedule begins.