### PR TITLE
Set completed_at to be nullable in Schedule creation API

### DIFF
--- a/src/Data/Requests/Schedule/CreateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/CreateScheduleRequestData.php
@@ -20,7 +20,7 @@ final class CreateScheduleRequestData extends BaseData
         #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
         public readonly Carbon $scheduledAt,
         #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
-        public readonly Carbon $completedAt,
+        public readonly ?Carbon $completedAt = null,
         public readonly ?ScheduleStatusEnum $status = null,
         #[DataCollectionOf(ScheduleComponentRequestData::class)]
         public readonly ?array $components = null,
@@ -32,6 +32,7 @@ final class CreateScheduleRequestData extends BaseData
             'name' => ['required', 'string', 'max:255'],
             'message' => ['required', 'string'],
             'scheduled_at' => ['required', 'date'],
+            'completed_at' => ['nullable', 'date'],
             'components' => ['array'],
             'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
             'components.*.status' => ['required_with:components', 'int', Rule::enum(ComponentStatusEnum::class)],


### PR DESCRIPTION
While it was possible to create a schedule with a empty completed at date, this wasn't possible during API creation as an end date was explicitly required. And of course setting that means the schedule won't show up under the status page in the first place.

With this change API creation mode mirrors what's possible via the interface as well.