### PR TITLE
Add event sourcing with Verbs for audit trail and replay capability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "filament/filament": "^4.0",
         "filament/spatie-laravel-settings-plugin": "^4.0",
         "guzzlehttp/guzzle": "^7.8",
+        "hirethunk/verbs": "^0.7.0",
         "illuminate/cache": "^11.35.0",
         "illuminate/console": "^11.35.0",
         "illuminate/database": "^11.35.0",

--- a/database/migrations/2026_01_12_000000_initialize_verbs_events.php
+++ b/database/migrations/2026_01_12_000000_initialize_verbs_events.php
@@ -1,0 +1,154 @@
+<?php
+
+use Cachet\Enums\ComponentGroupVisibilityEnum;
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
+use Cachet\Models\Incident;
+use Cachet\Models\Schedule;
+use Cachet\Verbs\Events\ComponentGroups\ComponentGroupCreated;
+use Cachet\Verbs\Events\ComponentGroups\ComponentGroupDeleted;
+use Cachet\Verbs\Events\Components\ComponentCreated;
+use Cachet\Verbs\Events\Components\ComponentDeleted;
+use Cachet\Verbs\Events\Incidents\IncidentCreated;
+use Cachet\Verbs\Events\Incidents\IncidentDeleted;
+use Cachet\Verbs\Events\Incidents\IncidentUpdateRecorded;
+use Cachet\Verbs\Events\Schedules\ScheduleCreated;
+use Cachet\Verbs\Events\Schedules\ScheduleDeleted;
+use Cachet\Verbs\Events\Schedules\ScheduleUpdateRecorded;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Thunk\Verbs\Facades\Verbs;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Skip if events already exist
+        if (DB::table('verb_events')->exists()) {
+            return;
+        }
+
+        $this->migrateComponentGroups();
+        $this->migrateComponents();
+        $this->migrateIncidents();
+        $this->migrateSchedules();
+
+        Verbs::commit();
+    }
+
+    public function down(): void
+    {
+        // Truncate Verbs tables to remove migrated events
+        DB::table('verb_state_events')->truncate();
+        DB::table('verb_snapshots')->truncate();
+        DB::table('verb_events')->truncate();
+    }
+
+    private function migrateComponentGroups(): void
+    {
+        ComponentGroup::each(function (ComponentGroup $group) {
+            ComponentGroupCreated::fire(
+                component_group_id: $group->id,
+                name: $group->name,
+                order: $group->order ?? 0,
+                collapsed: $group->collapsed ?? ComponentGroupVisibilityEnum::expanded,
+                visible: $group->visible ?? ResourceVisibilityEnum::guest,
+            );
+        });
+    }
+
+    private function migrateComponents(): void
+    {
+        Component::withTrashed()->each(function (Component $component) {
+            ComponentCreated::fire(
+                component_id: $component->id,
+                name: $component->name,
+                status: $component->status ?? ComponentStatusEnum::operational,
+                description: $component->description,
+                link: $component->link,
+                order: $component->order ?? 0,
+                component_group_id: $component->component_group_id,
+                enabled: $component->enabled ?? true,
+                meta: $component->meta ?? [],
+            );
+
+            if ($component->deleted_at) {
+                ComponentDeleted::fire(component_id: $component->id);
+            }
+        });
+    }
+
+    private function migrateIncidents(): void
+    {
+        Incident::withTrashed()->with(['components', 'updates'])->each(function (Incident $incident) {
+            $components = $incident->components->map(fn ($c) => [
+                'id' => $c->id,
+                'status' => $c->pivot->component_status ?? ComponentStatusEnum::operational,
+            ])->all();
+
+            IncidentCreated::fire(
+                incident_id: $incident->id,
+                name: $incident->name,
+                status: $incident->status ?? IncidentStatusEnum::investigating,
+                message: $incident->message ?? '',
+                visible: $incident->visible ?? ResourceVisibilityEnum::guest,
+                stickied: $incident->stickied ?? false,
+                notifications: boolval($incident->notifications) ?? false,
+                occurred_at: $incident->occurred_at?->toIso8601String(),
+                user_id: $incident->user_id,
+                external_provider: $incident->external_provider,
+                external_id: $incident->external_id,
+                components: $components,
+                guid: $incident->guid,
+            );
+
+            foreach ($incident->updates as $update) {
+                IncidentUpdateRecorded::fire(
+                    incident_id: $incident->id,
+                    status: $update->status ?? IncidentStatusEnum::investigating,
+                    message: $update->message ?? '',
+                    user_id: $update->user_id,
+                );
+            }
+
+            if ($incident->deleted_at) {
+                IncidentDeleted::fire(incident_id: $incident->id);
+            }
+        });
+    }
+
+    private function migrateSchedules(): void
+    {
+        Schedule::withTrashed()->with(['components', 'updates'])->each(function (Schedule $schedule) {
+            $components = $schedule->components->map(fn ($c) => [
+                'id' => $c->id,
+                'status' => $c->pivot->component_status ?? ComponentStatusEnum::operational,
+            ])->all();
+
+            ScheduleCreated::fire(
+                schedule_id: $schedule->id,
+                name: $schedule->name,
+                message: $schedule->message,
+                scheduled_at: $schedule->scheduled_at?->toIso8601String(),
+                completed_at: $schedule->completed_at?->toIso8601String(),
+                components: $components,
+            );
+
+            foreach ($schedule->updates as $update) {
+                ScheduleUpdateRecorded::fire(
+                    schedule_id: $schedule->id,
+                    message: $update->message ?? '',
+                    status: $update->status,
+                    user_id: $update->user_id,
+                );
+            }
+
+            if ($schedule->deleted_at) {
+                ScheduleDeleted::fire(schedule_id: $schedule->id);
+            }
+        });
+    }
+};

--- a/src/Actions/Component/CreateComponent.php
+++ b/src/Actions/Component/CreateComponent.php
@@ -3,15 +3,26 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Data\Requests\Component\CreateComponentRequestData;
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
+use Cachet\Verbs\Events\Components\ComponentCreated;
 
 class CreateComponent
 {
     /**
      * Handle the action.
      */
-    public function handle(CreateComponentRequestData $component): Component
+    public function handle(CreateComponentRequestData $data): Component
     {
-        return Component::create($component->toArray());
+        return ComponentCreated::commit(
+            name: $data->name,
+            status: $data->status ?? ComponentStatusEnum::operational,
+            description: $data->description,
+            link: $data->link,
+            order: $data->order ?? 0,
+            component_group_id: $data->componentGroupId,
+            enabled: $data->enabled,
+            meta: [],
+        );
     }
 }

--- a/src/Actions/Component/DeleteComponent.php
+++ b/src/Actions/Component/DeleteComponent.php
@@ -3,6 +3,7 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Models\Component;
+use Cachet\Verbs\Events\Components\ComponentDeleted;
 
 class DeleteComponent
 {
@@ -11,8 +12,6 @@ class DeleteComponent
      */
     public function handle(Component $component): void
     {
-        $component->subscribers()->detach();
-
-        $component->delete();
+        ComponentDeleted::commit(component_id: $component->id);
     }
 }

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -3,8 +3,9 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
-use Cachet\Events\Components\ComponentStatusWasChanged;
 use Cachet\Models\Component;
+use Cachet\Verbs\Events\Components\ComponentStatusChanged;
+use Cachet\Verbs\Events\Components\ComponentUpdated;
 
 class UpdateComponent
 {
@@ -14,17 +15,32 @@ class UpdateComponent
     public function handle(Component $component, UpdateComponentRequestData $data): Component
     {
         $oldStatus = $component->status;
+        $hasStatusChange = $data->status !== null && $data->status !== $oldStatus;
 
-        $component->update($data->toArray());
-
-        if ($component->wasChanged('status')) {
-            ComponentStatusWasChanged::dispatch(
-                $component,
-                $oldStatus,
-                $component->status
+        // Fire status change event if status is changing
+        if ($hasStatusChange) {
+            ComponentStatusChanged::commit(
+                component_id: $component->id,
+                old_status: $oldStatus,
+                new_status: $data->status,
             );
         }
 
-        return $component->fresh();
+        // Fire general update event for other changes
+        ComponentUpdated::commit(
+            component_id: $component->id,
+            name: $data->name,
+            status: $hasStatusChange ? null : $data->status, // Skip status if already handled
+            description: $data->description,
+            link: $data->link,
+            order: $data->order,
+            component_group_id: $data->componentGroupId,
+            enabled: $data->enabled,
+        );
+
+        // Refresh the original model with updated data
+        $component->refresh();
+
+        return $component;
     }
 }

--- a/src/Actions/Incident/DeleteIncident.php
+++ b/src/Actions/Incident/DeleteIncident.php
@@ -3,6 +3,7 @@
 namespace Cachet\Actions\Incident;
 
 use Cachet\Models\Incident;
+use Cachet\Verbs\Events\Incidents\IncidentDeleted;
 
 class DeleteIncident
 {
@@ -11,8 +12,6 @@ class DeleteIncident
      */
     public function handle(Incident $incident): void
     {
-        $incident->updates()->delete();
-
-        $incident->delete();
+        IncidentDeleted::commit(incident_id: $incident->id);
     }
 }

--- a/src/Actions/Incident/UpdateIncident.php
+++ b/src/Actions/Incident/UpdateIncident.php
@@ -3,8 +3,8 @@
 namespace Cachet\Actions\Incident;
 
 use Cachet\Data\Requests\Incident\UpdateIncidentRequestData;
-use Cachet\Events\Incidents\IncidentUpdated;
 use Cachet\Models\Incident;
+use Cachet\Verbs\Events\Incidents\IncidentUpdated;
 
 class UpdateIncident
 {
@@ -13,10 +13,20 @@ class UpdateIncident
      */
     public function handle(Incident $incident, UpdateIncidentRequestData $data): Incident
     {
-        $incident->update($data->toArray());
+        IncidentUpdated::commit(
+            incident_id: $incident->id,
+            name: $data->name,
+            status: $data->status,
+            message: $data->message,
+            visible: $data->visible,
+            stickied: $data->stickied,
+            notifications: $data->notifications,
+            occurred_at: $data->occurredAt,
+        );
 
-        IncidentUpdated::dispatch($incident);
+        // Refresh the original model with updated data
+        $incident->refresh();
 
-        return $incident->fresh();
+        return $incident;
     }
 }

--- a/src/Actions/Schedule/DeleteSchedule.php
+++ b/src/Actions/Schedule/DeleteSchedule.php
@@ -3,6 +3,7 @@
 namespace Cachet\Actions\Schedule;
 
 use Cachet\Models\Schedule;
+use Cachet\Verbs\Events\Schedules\ScheduleDeleted;
 
 class DeleteSchedule
 {
@@ -11,6 +12,6 @@ class DeleteSchedule
      */
     public function handle(Schedule $schedule): void
     {
-        $schedule->delete();
+        ScheduleDeleted::commit(schedule_id: $schedule->id);
     }
 }

--- a/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
@@ -2,10 +2,20 @@
 
 namespace Cachet\Filament\Resources\ComponentGroups\Pages;
 
+use Cachet\Actions\ComponentGroup\CreateComponentGroup as CreateComponentGroupAction;
+use Cachet\Data\Requests\ComponentGroup\CreateComponentGroupRequestData;
 use Cachet\Filament\Resources\ComponentGroups\ComponentGroupResource;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateComponentGroup extends CreateRecord
 {
     protected static string $resource = ComponentGroupResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $requestData = CreateComponentGroupRequestData::from($data);
+
+        return app(CreateComponentGroupAction::class)->handle($requestData);
+    }
 }

--- a/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
@@ -2,9 +2,13 @@
 
 namespace Cachet\Filament\Resources\ComponentGroups\Pages;
 
+use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
+use Cachet\Data\Requests\ComponentGroup\UpdateComponentGroupRequestData;
 use Cachet\Filament\Resources\ComponentGroups\ComponentGroupResource;
+use Cachet\Models\ComponentGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditComponentGroup extends EditRecord
 {
@@ -15,5 +19,15 @@ class EditComponentGroup extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var ComponentGroup $record */
+        $requestData = UpdateComponentGroupRequestData::from($data);
+
+        app(UpdateComponentGroup::class)->handle($record, $requestData);
+
+        return $record;
     }
 }

--- a/src/Filament/Resources/Components/Pages/CreateComponent.php
+++ b/src/Filament/Resources/Components/Pages/CreateComponent.php
@@ -2,10 +2,20 @@
 
 namespace Cachet\Filament\Resources\Components\Pages;
 
+use Cachet\Actions\Component\CreateComponent as CreateComponentAction;
+use Cachet\Data\Requests\Component\CreateComponentRequestData;
 use Cachet\Filament\Resources\Components\ComponentResource;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateComponent extends CreateRecord
 {
     protected static string $resource = ComponentResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $requestData = CreateComponentRequestData::from($data);
+
+        return app(CreateComponentAction::class)->handle($requestData);
+    }
 }

--- a/src/Filament/Resources/Components/Pages/EditComponent.php
+++ b/src/Filament/Resources/Components/Pages/EditComponent.php
@@ -2,9 +2,13 @@
 
 namespace Cachet\Filament\Resources\Components\Pages;
 
+use Cachet\Actions\Component\UpdateComponent;
+use Cachet\Data\Requests\Component\UpdateComponentRequestData;
 use Cachet\Filament\Resources\Components\ComponentResource;
+use Cachet\Models\Component;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditComponent extends EditRecord
 {
@@ -15,5 +19,15 @@ class EditComponent extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var Component $record */
+        $requestData = UpdateComponentRequestData::from($data);
+
+        app(UpdateComponent::class)->handle($record, $requestData);
+
+        return $record;
     }
 }

--- a/src/Filament/Resources/Incidents/Pages/CreateIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/CreateIncident.php
@@ -2,10 +2,20 @@
 
 namespace Cachet\Filament\Resources\Incidents\Pages;
 
+use Cachet\Actions\Incident\CreateIncident as CreateIncidentAction;
+use Cachet\Data\Requests\Incident\CreateIncidentRequestData;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateIncident extends CreateRecord
 {
     protected static string $resource = IncidentResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $requestData = CreateIncidentRequestData::from($data);
+
+        return app(CreateIncidentAction::class)->handle($requestData);
+    }
 }

--- a/src/Filament/Resources/Incidents/Pages/EditIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/EditIncident.php
@@ -2,9 +2,13 @@
 
 namespace Cachet\Filament\Resources\Incidents\Pages;
 
+use Cachet\Actions\Incident\UpdateIncident;
+use Cachet\Data\Requests\Incident\UpdateIncidentRequestData;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Models\Incident;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditIncident extends EditRecord
 {
@@ -15,5 +19,15 @@ class EditIncident extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        /** @var Incident $record */
+        $requestData = UpdateIncidentRequestData::from($data);
+
+        app(UpdateIncident::class)->handle($record, $requestData);
+
+        return $record;
     }
 }

--- a/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
@@ -2,10 +2,37 @@
 
 namespace Cachet\Filament\Resources\Schedules\Pages;
 
+use Cachet\Actions\Schedule\CreateSchedule as CreateScheduleAction;
+use Cachet\Data\Requests\Schedule\CreateScheduleRequestData;
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Filament\Resources\Schedules\ScheduleResource;
+use Carbon\Carbon;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateSchedule extends CreateRecord
 {
     protected static string $resource = ScheduleResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        // Transform scheduleComponents to the format expected by the action
+        $components = null;
+        if (! empty($data['scheduleComponents'])) {
+            $components = collect($data['scheduleComponents'])->map(fn ($item) => [
+                'id' => $item['component_id'],
+                'status' => ComponentStatusEnum::from($item['component_status']),
+            ])->all();
+        }
+
+        $requestData = CreateScheduleRequestData::from([
+            'name' => $data['name'],
+            'message' => $data['message'],
+            'scheduled_at' => $data['scheduled_at'],
+            'completed_at' => $data['completed_at'] ?? null,
+            'components' => $components,
+        ]);
+
+        return app(CreateScheduleAction::class)->handle($requestData);
+    }
 }

--- a/src/Filament/Resources/Schedules/Pages/EditSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/EditSchedule.php
@@ -2,9 +2,13 @@
 
 namespace Cachet\Filament\Resources\Schedules\Pages;
 
+use Cachet\Actions\Schedule\UpdateSchedule;
+use Cachet\Data\Requests\Schedule\UpdateScheduleRequestData;
 use Cachet\Filament\Resources\Schedules\ScheduleResource;
+use Cachet\Models\Schedule;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditSchedule extends EditRecord
 {
@@ -17,10 +21,13 @@ class EditSchedule extends EditRecord
         ];
     }
 
-    protected function mutateFormDataBeforeSave(array $data): array
+    protected function handleRecordUpdate(Model $record, array $data): Model
     {
-        $data['completed_at'] = $data['completed_at'] ?? null;
+        /** @var Schedule $record */
+        $requestData = UpdateScheduleRequestData::from($data);
 
-        return $data;
+        app(UpdateSchedule::class)->handle($record, $requestData);
+
+        return $record;
     }
 }

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -6,6 +6,7 @@ use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
+use Cachet\Verbs\Events\Schedules\ScheduleCompleted;
 use Cachet\Filament\Resources\Schedules\Pages\CreateSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\EditSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\ListSchedules;
@@ -144,7 +145,10 @@ class ScheduleResource extends Resource
                             ->required(),
                     ])
                     ->color('success')
-                    ->action(fn (Schedule $record, array $data) => $record->update(['completed_at' => $data['completed_at']])),
+                    ->action(fn (Schedule $record, array $data) => ScheduleCompleted::commit(
+                        schedule_id: $record->id,
+                        completed_at: $data['completed_at'],
+                    )),
                 EditAction::make(),
             ])
             ->toolbarActions([

--- a/src/Filament/Widgets/Components.php
+++ b/src/Filament/Widgets/Components.php
@@ -5,6 +5,7 @@ namespace Cachet\Filament\Widgets;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
+use Cachet\Verbs\Events\Components\ComponentStatusChanged;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
@@ -80,7 +81,15 @@ class Components extends Widget implements HasSchemas
             ->inline()
             ->live()
             ->options(ComponentStatusEnum::class)
-            ->afterStateUpdated(fn (ComponentStatusEnum $state) => $component->update(['status' => $state]));
+            ->afterStateUpdated(function (ComponentStatusEnum $state) use ($component) {
+                if ($component->status !== $state) {
+                    ComponentStatusChanged::commit(
+                        component_id: $component->id,
+                        old_status: $component->status,
+                        new_status: $state,
+                    );
+                }
+            });
     }
 
     protected function loadVisibleComponentGroups(): Collection

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -4,9 +4,6 @@ namespace Cachet\Models;
 
 use Cachet\Database\Factories\ComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
-use Cachet\Events\Components\ComponentCreated;
-use Cachet\Events\Components\ComponentDeleted;
-use Cachet\Events\Components\ComponentUpdated;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -65,12 +62,6 @@ class Component extends Model
         'component_group_id',
         'enabled',
         'meta',
-    ];
-
-    protected $dispatchesEvents = [
-        'created' => ComponentCreated::class,
-        'deleted' => ComponentDeleted::class,
-        'updated' => ComponentUpdated::class,
     ];
 
     /**

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -6,9 +6,6 @@ use Cachet\Concerns\HasVisibility;
 use Cachet\Database\Factories\IncidentFactory;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
-use Cachet\Events\Incidents\IncidentCreated;
-use Cachet\Events\Incidents\IncidentDeleted;
-use Cachet\Events\Incidents\IncidentUpdated;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
 use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -73,12 +70,8 @@ class Incident extends Model
         'occurred_at' => 'datetime',
     ];
 
-    /** @var array<string, class-string> */
-    protected $dispatchesEvents = [
-        'created' => IncidentCreated::class,
-        'deleted' => IncidentDeleted::class,
-        'updated' => IncidentUpdated::class,
-    ];
+    // Webhook events are now dispatched from Verbs event handlers
+    // See: src/Verbs/Events/Incidents/
 
     /** @var list<string> */
     protected $fillable = [

--- a/src/Verbs/Events/ComponentGroups/ComponentGroupCreated.php
+++ b/src/Verbs/Events/ComponentGroups/ComponentGroupCreated.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Cachet\Verbs\Events\ComponentGroups;
+
+use Cachet\Enums\ComponentGroupVisibilityEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\ComponentGroup;
+use Cachet\Verbs\States\ComponentGroupState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentGroupCreated extends Event
+{
+    #[StateId(ComponentGroupState::class)]
+    public ?int $component_group_id = null;
+
+    public function __construct(
+        public string $name,
+        public int $order = 0,
+        public ComponentGroupVisibilityEnum $collapsed = ComponentGroupVisibilityEnum::expanded,
+        public ResourceVisibilityEnum $visible = ResourceVisibilityEnum::guest,
+    ) {}
+
+    public function apply(ComponentGroupState $state): void
+    {
+        $state->id = $this->component_group_id;
+        $state->name = $this->name;
+        $state->order = $this->order;
+        $state->collapsed = $this->collapsed;
+        $state->visible = $this->visible;
+        $state->deleted = false;
+        $state->component_ids = [];
+    }
+
+    public function handle(ComponentGroupState $state): ComponentGroup
+    {
+        if (config('verbs.migration_mode', false)) {
+            return ComponentGroup::find($this->component_group_id);
+        }
+
+        $group = ComponentGroup::create([
+            'name' => $this->name,
+            'order' => $this->order,
+            'collapsed' => $this->collapsed,
+            'visible' => $this->visible,
+        ]);
+
+        $this->component_group_id = $group->id;
+
+        return $group;
+    }
+}

--- a/src/Verbs/Events/ComponentGroups/ComponentGroupDeleted.php
+++ b/src/Verbs/Events/ComponentGroups/ComponentGroupDeleted.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Cachet\Verbs\Events\ComponentGroups;
+
+use Cachet\Models\ComponentGroup;
+use Cachet\Verbs\States\ComponentGroupState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentGroupDeleted extends Event
+{
+    #[StateId(ComponentGroupState::class)]
+    public int $component_group_id;
+
+    public function __construct(int $component_group_id)
+    {
+        $this->component_group_id = $component_group_id;
+    }
+
+    public function validate(ComponentGroupState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ComponentGroupState $state): void
+    {
+        $state->deleted = true;
+    }
+
+    public function handle(): void
+    {
+        $group = ComponentGroup::findOrFail($this->component_group_id);
+        $group->delete();
+    }
+}

--- a/src/Verbs/Events/ComponentGroups/ComponentGroupUpdated.php
+++ b/src/Verbs/Events/ComponentGroups/ComponentGroupUpdated.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Cachet\Verbs\Events\ComponentGroups;
+
+use Cachet\Enums\ComponentGroupVisibilityEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\ComponentGroup;
+use Cachet\Verbs\States\ComponentGroupState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentGroupUpdated extends Event
+{
+    #[StateId(ComponentGroupState::class)]
+    public int $component_group_id;
+
+    public function __construct(
+        int $component_group_id,
+        public ?string $name = null,
+        public ?int $order = null,
+        public ?ComponentGroupVisibilityEnum $collapsed = null,
+        public ?ResourceVisibilityEnum $visible = null,
+    ) {
+        $this->component_group_id = $component_group_id;
+    }
+
+    public function validate(ComponentGroupState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ComponentGroupState $state): void
+    {
+        if ($this->name !== null) {
+            $state->name = $this->name;
+        }
+        if ($this->order !== null) {
+            $state->order = $this->order;
+        }
+        if ($this->collapsed !== null) {
+            $state->collapsed = $this->collapsed;
+        }
+        if ($this->visible !== null) {
+            $state->visible = $this->visible;
+        }
+    }
+
+    public function handle(ComponentGroupState $state): ComponentGroup
+    {
+        $group = ComponentGroup::findOrFail($this->component_group_id);
+
+        $updates = array_filter([
+            'name' => $this->name,
+            'order' => $this->order,
+            'collapsed' => $this->collapsed,
+            'visible' => $this->visible,
+        ], fn ($value) => $value !== null);
+
+        if (! empty($updates)) {
+            $group->update($updates);
+        }
+
+        return $group->fresh();
+    }
+}

--- a/src/Verbs/Events/Components/ComponentCreated.php
+++ b/src/Verbs/Events/Components/ComponentCreated.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Cachet\Verbs\Events\Components;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Events\Components\ComponentCreated as WebhookComponentCreated;
+use Cachet\Models\Component;
+use Cachet\Verbs\States\ComponentGroupState;
+use Cachet\Verbs\States\ComponentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class ComponentCreated extends Event
+{
+    #[StateId(ComponentState::class)]
+    public ?int $component_id = null;
+
+    public function __construct(
+        public string $name,
+        public ComponentStatusEnum $status,
+        public ?string $description = null,
+        public ?string $link = null,
+        public int $order = 0,
+        public ?int $component_group_id = null,
+        public bool $enabled = true,
+        public array $meta = [],
+    ) {}
+
+    public function apply(ComponentState $state): void
+    {
+        $state->id = $this->component_id;
+        $state->name = $this->name;
+        $state->description = $this->description;
+        $state->link = $this->link;
+        $state->status = $this->status;
+        $state->order = $this->order;
+        $state->component_group_id = $this->component_group_id;
+        $state->enabled = $this->enabled;
+        $state->meta = $this->meta;
+        $state->deleted = false;
+
+        $state->status_history[] = [
+            'status' => $this->status,
+            'at' => now()->toIso8601String(),
+        ];
+
+        if ($this->component_group_id) {
+            $groupState = ComponentGroupState::load($this->component_group_id);
+            if (! in_array($this->component_id, $groupState->component_ids)) {
+                $groupState->component_ids[] = $this->component_id;
+            }
+        }
+    }
+
+    public function handle(ComponentState $state): Component
+    {
+        if (config('verbs.migration_mode', false)) {
+            return Component::find($this->component_id);
+        }
+
+        $component = Component::create([
+            'name' => $this->name,
+            'description' => $this->description,
+            'link' => $this->link,
+            'status' => $this->status,
+            'order' => $this->order,
+            'component_group_id' => $this->component_group_id,
+            'enabled' => $this->enabled,
+            'meta' => $this->meta,
+        ]);
+
+        $this->component_id = $component->id;
+
+        Verbs::unlessReplaying(fn () => event(new WebhookComponentCreated($component)));
+
+        return $component;
+    }
+}

--- a/src/Verbs/Events/Components/ComponentDeleted.php
+++ b/src/Verbs/Events/Components/ComponentDeleted.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Cachet\Verbs\Events\Components;
+
+use Cachet\Events\Components\ComponentDeleted as WebhookComponentDeleted;
+use Cachet\Models\Component;
+use Cachet\Verbs\States\ComponentGroupState;
+use Cachet\Verbs\States\ComponentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class ComponentDeleted extends Event
+{
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(int $component_id)
+    {
+        $this->component_id = $component_id;
+    }
+
+    public function validate(ComponentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ComponentState $state): void
+    {
+        $state->deleted = true;
+
+        // Remove from group
+        if (isset($state->component_group_id) && $state->component_group_id) {
+            $groupState = ComponentGroupState::load($state->component_group_id);
+            $groupState->component_ids = array_values(
+                array_filter($groupState->component_ids, fn ($id) => $id !== $this->component_id)
+            );
+        }
+    }
+
+    public function handle(ComponentState $state): void
+    {
+        $component = Component::findOrFail($this->component_id);
+
+        // Detach all subscribers before deleting
+        $component->subscribers()->detach();
+
+        Verbs::unlessReplaying(fn () => event(new WebhookComponentDeleted($component)));
+
+        $component->delete();
+    }
+}

--- a/src/Verbs/Events/Components/ComponentStatusChanged.php
+++ b/src/Verbs/Events/Components/ComponentStatusChanged.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Cachet\Verbs\Events\Components;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Events\Components\ComponentStatusWasChanged;
+use Cachet\Models\Component;
+use Cachet\Verbs\States\ComponentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class ComponentStatusChanged extends Event
+{
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $component_id,
+        public ComponentStatusEnum $old_status,
+        public ComponentStatusEnum $new_status,
+    ) {
+        $this->component_id = $component_id;
+    }
+
+    public function validate(ComponentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted) && $this->old_status !== $this->new_status;
+    }
+
+    public function apply(ComponentState $state): void
+    {
+        $state->status = $this->new_status;
+        $state->status_history[] = [
+            'status' => $this->new_status,
+            'at' => now()->toIso8601String(),
+        ];
+    }
+
+    public function handle(ComponentState $state): Component
+    {
+        $component = Component::findOrFail($this->component_id);
+
+        $component->update(['status' => $this->new_status]);
+
+        Verbs::unlessReplaying(fn () => event(new ComponentStatusWasChanged(
+            $component,
+            $this->old_status,
+            $this->new_status
+        )));
+
+        return $component->fresh();
+    }
+}

--- a/src/Verbs/Events/Components/ComponentUpdated.php
+++ b/src/Verbs/Events/Components/ComponentUpdated.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Cachet\Verbs\Events\Components;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Events\Components\ComponentUpdated as WebhookComponentUpdated;
+use Cachet\Models\Component;
+use Cachet\Verbs\States\ComponentGroupState;
+use Cachet\Verbs\States\ComponentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class ComponentUpdated extends Event
+{
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $component_id,
+        public ?string $name = null,
+        public ?ComponentStatusEnum $status = null,
+        public ?string $description = null,
+        public ?string $link = null,
+        public ?int $order = null,
+        public ?int $component_group_id = null,
+        public bool $clear_component_group = false,
+        public ?bool $enabled = null,
+        public ?array $meta = null,
+    ) {
+        $this->component_id = $component_id;
+    }
+
+    public function validate(ComponentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ComponentState $state): void
+    {
+        $oldGroupId = isset($state->component_group_id) ? $state->component_group_id : null;
+
+        if ($this->name !== null) {
+            $state->name = $this->name;
+        }
+        if ($this->description !== null) {
+            $state->description = $this->description;
+        }
+        if ($this->link !== null) {
+            $state->link = $this->link;
+        }
+        if ($this->status !== null) {
+            $previousStatus = isset($state->status) ? $state->status : null;
+            if ($previousStatus !== $this->status) {
+                $state->status_history[] = [
+                    'status' => $this->status,
+                    'at' => now()->toIso8601String(),
+                ];
+                $state->status = $this->status;
+            }
+        }
+        if ($this->order !== null) {
+            $state->order = $this->order;
+        }
+        if ($this->component_group_id !== null) {
+            $state->component_group_id = $this->component_group_id;
+        }
+        if ($this->clear_component_group) {
+            $state->component_group_id = null;
+        }
+        if ($this->enabled !== null) {
+            $state->enabled = $this->enabled;
+        }
+        if ($this->meta !== null) {
+            $state->meta = $this->meta;
+        }
+
+        // Update group membership if group changed
+        $newGroupId = $this->clear_component_group ? null : $this->component_group_id;
+        if (($newGroupId !== null || $this->clear_component_group) && $oldGroupId !== $newGroupId) {
+            // Remove from old group
+            if ($oldGroupId) {
+                $oldGroupState = ComponentGroupState::load($oldGroupId);
+                $oldGroupState->component_ids = array_values(
+                    array_filter($oldGroupState->component_ids ?? [], fn ($id) => $id !== $this->component_id)
+                );
+            }
+            // Add to new group
+            if ($newGroupId) {
+                $newGroupState = ComponentGroupState::load($newGroupId);
+                if (! in_array($this->component_id, $newGroupState->component_ids ?? [])) {
+                    $newGroupState->component_ids[] = $this->component_id;
+                }
+            }
+        }
+    }
+
+    public function handle(ComponentState $state): Component
+    {
+        $component = Component::findOrFail($this->component_id);
+
+        $updates = array_filter([
+            'name' => $this->name,
+            'description' => $this->description,
+            'link' => $this->link,
+            'status' => $this->status,
+            'order' => $this->order,
+            'component_group_id' => $this->component_group_id,
+            'enabled' => $this->enabled,
+            'meta' => $this->meta,
+        ], fn ($value) => $value !== null);
+
+        // Handle explicit clearing of component group
+        if ($this->clear_component_group) {
+            $updates['component_group_id'] = null;
+        }
+
+        if (! empty($updates)) {
+            $component->update($updates);
+        }
+
+        Verbs::unlessReplaying(fn () => event(new WebhookComponentUpdated($component)));
+
+        return $component->fresh();
+    }
+}

--- a/src/Verbs/Events/Incidents/ComponentAttachedToIncident.php
+++ b/src/Verbs/Events/Incidents/ComponentAttachedToIncident.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Incident;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\IncidentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentAttachedToIncident extends Event
+{
+    #[StateId(IncidentState::class)]
+    public int $incident_id;
+
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $incident_id,
+        int $component_id,
+        public ComponentStatusEnum $component_status,
+    ) {
+        $this->incident_id = $incident_id;
+        $this->component_id = $component_id;
+    }
+
+    public function validate(IncidentState $incidentState, ComponentState $componentState): bool
+    {
+        return ! $incidentState->deleted
+            && ! $componentState->deleted
+            && ! isset($incidentState->affected_components[$this->component_id]);
+    }
+
+    public function apply(IncidentState $incidentState, ComponentState $componentState): void
+    {
+        $incidentState->affected_components[$this->component_id] = $this->component_status;
+
+        if (! in_array($this->incident_id, $componentState->incident_ids)) {
+            $componentState->incident_ids[] = $this->incident_id;
+        }
+    }
+
+    public function handle(): void
+    {
+        $incident = Incident::findOrFail($this->incident_id);
+        $incident->components()->attach($this->component_id, [
+            'component_status' => $this->component_status,
+        ]);
+    }
+}

--- a/src/Verbs/Events/Incidents/ComponentDetachedFromIncident.php
+++ b/src/Verbs/Events/Incidents/ComponentDetachedFromIncident.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Models\Incident;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\IncidentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentDetachedFromIncident extends Event
+{
+    #[StateId(IncidentState::class)]
+    public int $incident_id;
+
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $incident_id,
+        int $component_id,
+    ) {
+        $this->incident_id = $incident_id;
+        $this->component_id = $component_id;
+    }
+
+    public function validate(IncidentState $incidentState, ComponentState $componentState): bool
+    {
+        return ! $incidentState->deleted
+            && isset($incidentState->affected_components[$this->component_id]);
+    }
+
+    public function apply(IncidentState $incidentState, ComponentState $componentState): void
+    {
+        unset($incidentState->affected_components[$this->component_id]);
+
+        $componentState->incident_ids = array_values(
+            array_filter($componentState->incident_ids, fn ($id) => $id !== $this->incident_id)
+        );
+    }
+
+    public function handle(): void
+    {
+        $incident = Incident::findOrFail($this->incident_id);
+        $incident->components()->detach($this->component_id);
+    }
+}

--- a/src/Verbs/Events/Incidents/IncidentCreated.php
+++ b/src/Verbs/Events/Incidents/IncidentCreated.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Events\Incidents\IncidentCreated as WebhookIncidentCreated;
+use Cachet\Models\Incident;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\IncidentState;
+use Illuminate\Support\Str;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class IncidentCreated extends Event
+{
+    #[StateId(IncidentState::class)]
+    public ?int $incident_id = null;
+
+    /**
+     * @param  array<int, array{id: int, status: ComponentStatusEnum}>  $components
+     */
+    public function __construct(
+        public string $name,
+        public IncidentStatusEnum $status,
+        public string $message,
+        public ResourceVisibilityEnum $visible = ResourceVisibilityEnum::guest,
+        public bool $stickied = false,
+        public bool $notifications = false,
+        public ?string $occurred_at = null,
+        public ?int $user_id = null,
+        public ?string $external_provider = null,
+        public ?string $external_id = null,
+        public array $components = [],
+        public ?string $guid = null,
+    ) {}
+
+    public function apply(IncidentState $state): void
+    {
+        $state->id = $this->incident_id;
+        $state->guid = $this->guid ?? (string) Str::uuid();
+        $state->name = $this->name;
+        $state->status = $this->status;
+        $state->message = $this->message;
+        $state->visible = $this->visible;
+        $state->stickied = $this->stickied;
+        $state->notifications = $this->notifications;
+        $state->occurred_at = $this->occurred_at;
+        $state->user_id = $this->user_id;
+        $state->external_provider = $this->external_provider;
+        $state->external_id = $this->external_id;
+        $state->deleted = false;
+
+        foreach ($this->components as $component) {
+            $state->affected_components[$component['id']] = $component['status'];
+
+            $componentState = ComponentState::load($component['id']);
+            if (! in_array($this->incident_id, $componentState->incident_ids)) {
+                $componentState->incident_ids[] = $this->incident_id;
+            }
+        }
+
+        $state->status_history[] = [
+            'from' => null,
+            'to' => $this->status,
+            'at' => now()->toIso8601String(),
+        ];
+    }
+
+    public function handle(IncidentState $state): Incident
+    {
+        if (config('verbs.migration_mode', false)) {
+            return Incident::find($this->incident_id);
+        }
+
+        $incident = Incident::create([
+            'guid' => $state->guid,
+            'name' => $this->name,
+            'status' => $this->status,
+            'message' => $this->message,
+            'visible' => $this->visible,
+            'stickied' => $this->stickied,
+            'notifications' => $this->notifications,
+            'occurred_at' => $this->occurred_at,
+            'user_id' => $this->user_id,
+            'external_provider' => $this->external_provider,
+            'external_id' => $this->external_id,
+        ]);
+
+        $this->incident_id = $incident->id;
+
+        if (! empty($this->components)) {
+            $pivotData = collect($this->components)->mapWithKeys(fn ($c) => [
+                $c['id'] => ['component_status' => $c['status']],
+            ])->all();
+            $incident->components()->sync($pivotData);
+        }
+
+        Verbs::unlessReplaying(fn () => event(new WebhookIncidentCreated($incident)));
+
+        return $incident;
+    }
+}

--- a/src/Verbs/Events/Incidents/IncidentDeleted.php
+++ b/src/Verbs/Events/Incidents/IncidentDeleted.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Events\Incidents\IncidentDeleted as WebhookIncidentDeleted;
+use Cachet\Models\Incident;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\IncidentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class IncidentDeleted extends Event
+{
+    #[StateId(IncidentState::class)]
+    public int $incident_id;
+
+    public function __construct(int $incident_id)
+    {
+        $this->incident_id = $incident_id;
+    }
+
+    public function validate(IncidentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(IncidentState $state): void
+    {
+        $state->deleted = true;
+
+        // Remove incident from component states
+        $affectedComponents = isset($state->affected_components) ? $state->affected_components : [];
+        foreach (array_keys($affectedComponents) as $componentId) {
+            $componentState = ComponentState::load($componentId);
+            $componentState->incident_ids = array_values(
+                array_filter($componentState->incident_ids ?? [], fn ($id) => $id !== $this->incident_id)
+            );
+        }
+    }
+
+    public function handle(IncidentState $state): void
+    {
+        $incident = Incident::findOrFail($this->incident_id);
+
+        Verbs::unlessReplaying(fn () => event(new WebhookIncidentDeleted($incident)));
+
+        // Delete related updates first
+        $incident->updates()->delete();
+
+        $incident->delete();
+    }
+}

--- a/src/Verbs/Events/Incidents/IncidentUpdateRecorded.php
+++ b/src/Verbs/Events/Incidents/IncidentUpdateRecorded.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Models\Incident;
+use Cachet\Models\Update;
+use Cachet\Verbs\States\IncidentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class IncidentUpdateRecorded extends Event
+{
+    #[StateId(IncidentState::class)]
+    public int $incident_id;
+
+    public function __construct(
+        int $incident_id,
+        public IncidentStatusEnum $status,
+        public string $message,
+        public ?int $user_id = null,
+    ) {
+        $this->incident_id = $incident_id;
+    }
+
+    public function validate(IncidentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(IncidentState $state): void
+    {
+        $state->updates[] = [
+            'status' => $this->status,
+            'message' => $this->message,
+            'user_id' => $this->user_id,
+            'at' => now()->toIso8601String(),
+        ];
+
+        $previousStatus = isset($state->status) ? $state->status : null;
+        if ($previousStatus !== $this->status) {
+            $state->status_history[] = [
+                'from' => $previousStatus,
+                'to' => $this->status,
+                'at' => now()->toIso8601String(),
+            ];
+            $state->status = $this->status;
+        }
+    }
+
+    public function handle(IncidentState $state): Update
+    {
+        $incident = Incident::findOrFail($this->incident_id);
+
+        $update = new Update([
+            'status' => $this->status,
+            'message' => $this->message,
+            'user_id' => $this->user_id,
+        ]);
+
+        $incident->updates()->save($update);
+
+        return $update;
+    }
+}

--- a/src/Verbs/Events/Incidents/IncidentUpdated.php
+++ b/src/Verbs/Events/Incidents/IncidentUpdated.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Cachet\Verbs\Events\Incidents;
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Events\Incidents\IncidentUpdated as WebhookIncidentUpdated;
+use Cachet\Models\Incident;
+use Cachet\Verbs\States\IncidentState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+use Thunk\Verbs\Facades\Verbs;
+
+class IncidentUpdated extends Event
+{
+    #[StateId(IncidentState::class)]
+    public int $incident_id;
+
+    public function __construct(
+        int $incident_id,
+        public ?string $name = null,
+        public ?IncidentStatusEnum $status = null,
+        public ?string $message = null,
+        public ?ResourceVisibilityEnum $visible = null,
+        public ?bool $stickied = null,
+        public ?bool $notifications = null,
+        public ?string $occurred_at = null,
+        public ?int $user_id = null,
+    ) {
+        $this->incident_id = $incident_id;
+    }
+
+    public function validate(IncidentState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(IncidentState $state): void
+    {
+        if ($this->name !== null) {
+            $state->name = $this->name;
+        }
+        if ($this->message !== null) {
+            $state->message = $this->message;
+        }
+        if ($this->visible !== null) {
+            $state->visible = $this->visible;
+        }
+        if ($this->stickied !== null) {
+            $state->stickied = $this->stickied;
+        }
+        if ($this->notifications !== null) {
+            $state->notifications = $this->notifications;
+        }
+        if ($this->occurred_at !== null) {
+            $state->occurred_at = $this->occurred_at;
+        }
+        if ($this->user_id !== null) {
+            $state->user_id = $this->user_id;
+        }
+        if ($this->status !== null) {
+            $previousStatus = isset($state->status) ? $state->status : null;
+            if ($previousStatus !== $this->status) {
+                $state->status_history[] = [
+                    'from' => $previousStatus,
+                    'to' => $this->status,
+                    'at' => now()->toIso8601String(),
+                ];
+                $state->status = $this->status;
+            }
+        }
+    }
+
+    public function handle(IncidentState $state): Incident
+    {
+        $incident = Incident::findOrFail($this->incident_id);
+
+        $updates = array_filter([
+            'name' => $this->name,
+            'status' => $this->status,
+            'message' => $this->message,
+            'visible' => $this->visible,
+            'stickied' => $this->stickied,
+            'notifications' => $this->notifications,
+            'occurred_at' => $this->occurred_at,
+            'user_id' => $this->user_id,
+        ], fn ($value) => $value !== null);
+
+        if (! empty($updates)) {
+            $incident->update($updates);
+        }
+
+        Verbs::unlessReplaying(fn () => event(new WebhookIncidentUpdated($incident)));
+
+        return $incident->fresh();
+    }
+}

--- a/src/Verbs/Events/Schedules/ComponentAttachedToSchedule.php
+++ b/src/Verbs/Events/Schedules/ComponentAttachedToSchedule.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentAttachedToSchedule extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $schedule_id,
+        int $component_id,
+        public ComponentStatusEnum $component_status,
+    ) {
+        $this->schedule_id = $schedule_id;
+        $this->component_id = $component_id;
+    }
+
+    public function validate(ScheduleState $scheduleState, ComponentState $componentState): bool
+    {
+        return ! $scheduleState->deleted
+            && ! $componentState->deleted
+            && ! isset($scheduleState->affected_components[$this->component_id]);
+    }
+
+    public function apply(ScheduleState $scheduleState, ComponentState $componentState): void
+    {
+        $scheduleState->affected_components[$this->component_id] = $this->component_status;
+
+        if (! in_array($this->schedule_id, $componentState->schedule_ids)) {
+            $componentState->schedule_ids[] = $this->schedule_id;
+        }
+    }
+
+    public function handle(): void
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+        $schedule->components()->attach($this->component_id, [
+            'component_status' => $this->component_status,
+        ]);
+    }
+}

--- a/src/Verbs/Events/Schedules/ComponentDetachedFromSchedule.php
+++ b/src/Verbs/Events/Schedules/ComponentDetachedFromSchedule.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ComponentDetachedFromSchedule extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    #[StateId(ComponentState::class)]
+    public int $component_id;
+
+    public function __construct(
+        int $schedule_id,
+        int $component_id,
+    ) {
+        $this->schedule_id = $schedule_id;
+        $this->component_id = $component_id;
+    }
+
+    public function validate(ScheduleState $scheduleState, ComponentState $componentState): bool
+    {
+        return ! $scheduleState->deleted
+            && isset($scheduleState->affected_components[$this->component_id]);
+    }
+
+    public function apply(ScheduleState $scheduleState, ComponentState $componentState): void
+    {
+        unset($scheduleState->affected_components[$this->component_id]);
+
+        $componentState->schedule_ids = array_values(
+            array_filter($componentState->schedule_ids, fn ($id) => $id !== $this->schedule_id)
+        );
+    }
+
+    public function handle(): void
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+        $schedule->components()->detach($this->component_id);
+    }
+}

--- a/src/Verbs/Events/Schedules/ScheduleCompleted.php
+++ b/src/Verbs/Events/Schedules/ScheduleCompleted.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ScheduleCompleted extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    public function __construct(
+        int $schedule_id,
+        public string $completed_at,
+    ) {
+        $this->schedule_id = $schedule_id;
+    }
+
+    public function validate(ScheduleState $state): bool
+    {
+        $isDeleted = isset($state->deleted) && $state->deleted;
+        $isCompleted = isset($state->completed_at) && $state->completed_at !== null;
+
+        return ! $isDeleted && ! $isCompleted;
+    }
+
+    public function apply(ScheduleState $state): void
+    {
+        $state->completed_at = $this->completed_at;
+    }
+
+    public function handle(ScheduleState $state): Schedule
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+
+        $schedule->update(['completed_at' => $this->completed_at]);
+
+        return $schedule->fresh();
+    }
+}

--- a/src/Verbs/Events/Schedules/ScheduleCreated.php
+++ b/src/Verbs/Events/Schedules/ScheduleCreated.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ScheduleCreated extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public ?int $schedule_id = null;
+
+    /**
+     * @param  array<int, array{id: int, status: ComponentStatusEnum}>  $components
+     */
+    public function __construct(
+        public string $name,
+        public ?string $message = null,
+        public ?string $scheduled_at = null,
+        public ?string $completed_at = null,
+        public array $components = [],
+    ) {}
+
+    public function apply(ScheduleState $state): void
+    {
+        $state->id = $this->schedule_id;
+        $state->name = $this->name;
+        $state->message = $this->message;
+        $state->scheduled_at = $this->scheduled_at;
+        $state->completed_at = $this->completed_at;
+        $state->deleted = false;
+
+        foreach ($this->components as $component) {
+            $state->affected_components[$component['id']] = $component['status'];
+
+            $componentState = ComponentState::load($component['id']);
+            if (! in_array($this->schedule_id, $componentState->schedule_ids)) {
+                $componentState->schedule_ids[] = $this->schedule_id;
+            }
+        }
+    }
+
+    public function handle(ScheduleState $state): Schedule
+    {
+        if (config('verbs.migration_mode', false)) {
+            return Schedule::find($this->schedule_id);
+        }
+
+        $schedule = Schedule::create([
+            'name' => $this->name,
+            'message' => $this->message,
+            'scheduled_at' => $this->scheduled_at,
+            'completed_at' => $this->completed_at,
+        ]);
+
+        $this->schedule_id = $schedule->id;
+
+        if (! empty($this->components)) {
+            $pivotData = collect($this->components)->mapWithKeys(fn ($c) => [
+                $c['id'] => ['component_status' => $c['status']],
+            ])->all();
+            $schedule->components()->sync($pivotData);
+        }
+
+        return $schedule;
+    }
+}

--- a/src/Verbs/Events/Schedules/ScheduleDeleted.php
+++ b/src/Verbs/Events/Schedules/ScheduleDeleted.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ComponentState;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ScheduleDeleted extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    public function __construct(int $schedule_id)
+    {
+        $this->schedule_id = $schedule_id;
+    }
+
+    public function validate(ScheduleState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ScheduleState $state): void
+    {
+        $state->deleted = true;
+
+        // Remove schedule from component states
+        $affectedComponents = isset($state->affected_components) ? $state->affected_components : [];
+        foreach (array_keys($affectedComponents) as $componentId) {
+            $componentState = ComponentState::load($componentId);
+            $componentState->schedule_ids = array_values(
+                array_filter($componentState->schedule_ids ?? [], fn ($id) => $id !== $this->schedule_id)
+            );
+        }
+    }
+
+    public function handle(): void
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+
+        // Delete related updates first
+        $schedule->updates()->delete();
+
+        $schedule->delete();
+    }
+}

--- a/src/Verbs/Events/Schedules/ScheduleUpdateRecorded.php
+++ b/src/Verbs/Events/Schedules/ScheduleUpdateRecorded.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Models\Schedule;
+use Cachet\Models\Update;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ScheduleUpdateRecorded extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    public function __construct(
+        int $schedule_id,
+        public string $message,
+        public ?IncidentStatusEnum $status = null,
+        public ?int $user_id = null,
+    ) {
+        $this->schedule_id = $schedule_id;
+    }
+
+    public function validate(ScheduleState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ScheduleState $state): void
+    {
+        $state->updates[] = [
+            'status' => $this->status,
+            'message' => $this->message,
+            'user_id' => $this->user_id,
+            'at' => now()->toIso8601String(),
+        ];
+    }
+
+    public function handle(ScheduleState $state): Update
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+
+        $update = new Update([
+            'status' => $this->status,
+            'message' => $this->message,
+            'user_id' => $this->user_id,
+        ]);
+
+        $schedule->updates()->save($update);
+
+        return $update;
+    }
+}

--- a/src/Verbs/Events/Schedules/ScheduleUpdated.php
+++ b/src/Verbs/Events/Schedules/ScheduleUpdated.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Cachet\Verbs\Events\Schedules;
+
+use Cachet\Models\Schedule;
+use Cachet\Verbs\States\ScheduleState;
+use Thunk\Verbs\Attributes\Autodiscovery\StateId;
+use Thunk\Verbs\Event;
+
+class ScheduleUpdated extends Event
+{
+    #[StateId(ScheduleState::class)]
+    public int $schedule_id;
+
+    public function __construct(
+        int $schedule_id,
+        public ?string $name = null,
+        public ?string $message = null,
+        public ?string $scheduled_at = null,
+        public ?string $completed_at = null,
+    ) {
+        $this->schedule_id = $schedule_id;
+    }
+
+    public function validate(ScheduleState $state): bool
+    {
+        return ! (isset($state->deleted) && $state->deleted);
+    }
+
+    public function apply(ScheduleState $state): void
+    {
+        if ($this->name !== null) {
+            $state->name = $this->name;
+        }
+        if ($this->message !== null) {
+            $state->message = $this->message;
+        }
+        if ($this->scheduled_at !== null) {
+            $state->scheduled_at = $this->scheduled_at;
+        }
+        if ($this->completed_at !== null) {
+            $state->completed_at = $this->completed_at;
+        }
+    }
+
+    public function handle(ScheduleState $state): Schedule
+    {
+        $schedule = Schedule::findOrFail($this->schedule_id);
+
+        $updates = array_filter([
+            'name' => $this->name,
+            'message' => $this->message,
+            'scheduled_at' => $this->scheduled_at,
+            'completed_at' => $this->completed_at,
+        ], fn ($value) => $value !== null);
+
+        if (! empty($updates)) {
+            $schedule->update($updates);
+        }
+
+        return $schedule->fresh();
+    }
+}

--- a/src/Verbs/States/ComponentGroupState.php
+++ b/src/Verbs/States/ComponentGroupState.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cachet\Verbs\States;
+
+use Cachet\Enums\ComponentGroupVisibilityEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Thunk\Verbs\State;
+
+class ComponentGroupState extends State
+{
+    public string $name;
+
+    public int $order = 0;
+
+    public ComponentGroupVisibilityEnum $collapsed;
+
+    public ResourceVisibilityEnum $visible;
+
+    public bool $deleted = false;
+
+    /** @var list<int> */
+    public array $component_ids = [];
+}

--- a/src/Verbs/States/ComponentState.php
+++ b/src/Verbs/States/ComponentState.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Cachet\Verbs\States;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Thunk\Verbs\State;
+
+class ComponentState extends State
+{
+    public string $name;
+
+    public ?string $description = null;
+
+    public ?string $link = null;
+
+    public ComponentStatusEnum $status;
+
+    public int $order = 0;
+
+    public ?int $component_group_id = null;
+
+    public bool $enabled = true;
+
+    public array $meta = [];
+
+    public bool $deleted = false;
+
+    /** @var array<int, array{status: ComponentStatusEnum, at: string}> */
+    public array $status_history = [];
+
+    /** @var list<int> */
+    public array $incident_ids = [];
+
+    /** @var list<int> */
+    public array $schedule_ids = [];
+}

--- a/src/Verbs/States/IncidentState.php
+++ b/src/Verbs/States/IncidentState.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Cachet\Verbs\States;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Thunk\Verbs\State;
+
+class IncidentState extends State
+{
+    public string $guid;
+
+    public string $name;
+
+    public IncidentStatusEnum $status;
+
+    public string $message;
+
+    public ResourceVisibilityEnum $visible;
+
+    public bool $stickied = false;
+
+    public bool $notifications = false;
+
+    public ?string $occurred_at = null;
+
+    public ?int $user_id = null;
+
+    public ?string $external_provider = null;
+
+    public ?string $external_id = null;
+
+    public bool $deleted = false;
+
+    /** @var array<int, ComponentStatusEnum> Component ID => status during incident */
+    public array $affected_components = [];
+
+    /** @var array<int, array{status: IncidentStatusEnum, message: string, user_id: ?int, at: string}> */
+    public array $updates = [];
+
+    /** @var array<int, array{from: ?IncidentStatusEnum, to: IncidentStatusEnum, at: string}> */
+    public array $status_history = [];
+}

--- a/src/Verbs/States/ScheduleState.php
+++ b/src/Verbs/States/ScheduleState.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cachet\Verbs\States;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Thunk\Verbs\State;
+
+class ScheduleState extends State
+{
+    public string $name;
+
+    public ?string $message = null;
+
+    public ?string $scheduled_at = null;
+
+    public ?string $completed_at = null;
+
+    public bool $deleted = false;
+
+    /** @var array<int, ComponentStatusEnum> Component ID => status during maintenance */
+    public array $affected_components = [];
+
+    /** @var array<int, array{status: ?IncidentStatusEnum, message: string, user_id: ?int, at: string}> */
+    public array $updates = [];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
 use Dedoc\Scramble\ScrambleServiceProvider;
 use Filament\FilamentServiceProvider;
+use Glhd\Bits\Support\BitsServiceProvider;
+use Thunk\Verbs\VerbsServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
@@ -41,6 +43,8 @@ abstract class TestCase extends Orchestra
             BladeHeroiconsServiceProvider::class,
             WidgetsServiceProvider::class,
             ScrambleServiceProvider::class,
+            BitsServiceProvider::class,
+            VerbsServiceProvider::class,
         ]);
 
         // Laravel apps register providers in alphabetical order, so we do the same here for consistency.


### PR DESCRIPTION
## Summary

- Implements hybrid event sourcing using [Verbs by Thunk](https://verbs.thunk.dev/)
- Eloquent remains the source of truth for reads (Filament, API, status page)
- Verbs captures all state changes for audit trails and replay capability
- Includes migration to initialize events for existing data

## Changes

### New Dependencies
- `hirethunk/verbs` - Event sourcing package

### New State Classes (4)
Track current state of each resource:
- `ComponentState` - status history, incident/schedule associations
- `ComponentGroupState` - component memberships
- `IncidentState` - status history, affected components, updates
- `ScheduleState` - affected components, updates

### New Event Classes (20)
Capture all state changes:
- **Components**: Created, Updated, Deleted, StatusChanged
- **ComponentGroups**: Created, Updated, Deleted
- **Incidents**: Created, Updated, Deleted, UpdateRecorded, ComponentAttached/Detached
- **Schedules**: Created, Updated, Deleted, Completed, UpdateRecorded, ComponentAttached/Detached

### Modified Action Classes
All create/update/delete actions now fire Verbs events. Events handle:
1. State updates via `apply()`
2. Eloquent persistence via `handle()`
3. Webhook dispatch via `Verbs::unlessReplaying()`

### Modified Filament Pages
All create/edit pages route through action classes to ensure Verbs captures changes:
- Component, ComponentGroup, Incident, Schedule pages
- Components widget status toggle

### Migration
`2026_01_12_000000_initialize_verbs_events.php` creates initial events for existing data:
- Runs automatically on `php artisan migrate`
- Skips if events already exist (idempotent)
- Supports rollback via `down()` method

## Test plan

- [x] All 356 existing tests pass
- [ ] Verify events are created when using API endpoints
- [ ] Verify events are created when using Filament dashboard
- [ ] Verify webhook events still fire correctly
- [ ] Test migration on database with existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)