### PR TITLE
Fix (metrics) - duplicate chart rendering caused by shared Alpine states

### DIFF
--- a/resources/views/components/metric.blade.php
+++ b/resources/views/components/metric.blade.php
@@ -4,7 +4,7 @@
 
 @use('\Cachet\Enums\MetricViewEnum')
 
-<div x-data="chart">
+<div x-data="chart_{{ $metric->id }}">
     <div class="flex flex-col gap-2">
         <div class="flex items-center gap-1.5">
             <div class="font-semibold leading-6">{{ $metric->name }}</div>
@@ -32,7 +32,7 @@
 
 <script>
     document.addEventListener('alpine:init', () => {
-        Alpine.data('chart', () => ({
+        Alpine.data('chart_{{ $metric->id }}', () => ({
             metric: {{ Js::from($metric) }},
             period: {{ Js::from($metric->default_view) }},
             points: [[], [], [], []],


### PR DESCRIPTION
Self explanatory - fixes a bug where all components share the same metrics results.

Tested myself on PHP 8.4, Debian 13, Apache 2.4.66

<img width="991" height="888" alt="{ED1F80AC-81B5-4F10-AFB1-88EC03D15BBF}" src="https://github.com/user-attachments/assets/f49b8cbd-a7c4-4cdd-b46d-f471a19ab822" />
