### PR TITLE
ci: add PHP 8.5 matrix as allowed failures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,6 +70,12 @@ jobs:
           - php: 8.3
             laravel: 11.x
             stability: prefer-lowest
+          # PHP 8.5 (allowed failure)
+          - php: '8.5'
+            laravel: 13.x
+            stability: prefer-stable
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
 
     name: Static Analysis - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -113,6 +119,13 @@ jobs:
         php: [8.4, 8.3]
         laravel: [13.x, 12.x, 11.x]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          # PHP 8.5 (allowed failure)
+          - php: '8.5'
+            laravel: 13.x
+            stability: prefer-stable
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
 
     name: Tests - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - SQLite
 
@@ -184,6 +197,12 @@ jobs:
           - php: 8.3
             laravel: 11.x
             stability: prefer-lowest
+          # PHP 8.5 (allowed failure)
+          - php: '8.5'
+            laravel: 13.x
+            stability: prefer-stable
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
 
     name: Tests - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - MySQL 8.0
 
@@ -260,6 +279,12 @@ jobs:
           - php: 8.3
             laravel: 11.x
             stability: prefer-lowest
+          # PHP 8.5 (allowed failure)
+          - php: '8.5'
+            laravel: 13.x
+            stability: prefer-stable
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure || false }}
 
     name: Tests - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - PostgreSQL 15
 

--- a/src/Filament/Resources/Users/UserResource.php
+++ b/src/Filament/Resources/Users/UserResource.php
@@ -89,7 +89,7 @@ class UserResource extends Resource
                     Select::make('preferred_locale')
                         ->selectablePlaceholder(false)
                         ->options([
-                            null => __('cachet::user.form.preferred_locale_system_default'),
+                            '' => __('cachet::user.form.preferred_locale_system_default'),
                             ...config('cachet.supported_locales'),
                         ])
                         ->label(__('cachet::user.form.preferred_locale')),

--- a/src/View/ViewManager.php
+++ b/src/View/ViewManager.php
@@ -24,7 +24,7 @@ class ViewManager
         }
 
         foreach ($scopes as $scopeName) {
-            $this->renderHooks[$name][$scopeName][] = $hook;
+            $this->renderHooks[$name][$scopeName ?? ''][] = $hook;
         }
     }
 
@@ -51,7 +51,7 @@ class ViewManager
 
         $hooks = array_map(
             $renderHook,
-            $this->renderHooks[$name][null] ?? [],
+            $this->renderHooks[$name][''] ?? [],
         );
 
         foreach ($scopes as $scopeName) {


### PR DESCRIPTION
## Summary
- add PHP 8.5 matrix entries to  jobs
- mark only the PHP 8.5 entries as allowed failure using 
