### PR TITLE
Set linked components to operational when incident is fixed

### DIFF
--- a/src/Actions/Update/CreateUpdate.php
+++ b/src/Actions/Update/CreateUpdate.php
@@ -4,6 +4,8 @@ namespace Cachet\Actions\Update;
 
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
 use Cachet\Models\Update;
@@ -19,8 +21,24 @@ class CreateUpdate
 
         $resource->updates()->save($update);
 
+        if ($resource instanceof Incident && $data->status === IncidentStatusEnum::fixed) {
+            $this->updateComponentsToOperational($resource);
+        }
+
         // @todo Dispatch notification that incident was updated.
 
         return $update;
+    }
+
+    /**
+     * Set all linked components back to operational when an incident is fixed.
+     */
+    private function updateComponentsToOperational(Incident $incident): void
+    {
+        $incident->components()->each(function ($component) use ($incident) {
+            $incident->components()->updateExistingPivot($component->id, [
+                'component_status' => ComponentStatusEnum::operational,
+            ]);
+        });
     }
 }

--- a/tests/Unit/Actions/Update/CreateUpdateTest.php
+++ b/tests/Unit/Actions/Update/CreateUpdateTest.php
@@ -39,6 +39,30 @@ it('an incident\'s computed latest status equals the new status', function () {
         ->latestStatus->toEqual(IncidentStatusEnum::identified);
 });
 
+it('sets linked component status to operational when incident update status is fixed', function () {
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::investigating,
+    ]);
+
+    $component = \Cachet\Models\Component::factory()->create([
+        'status' => \Cachet\Enums\ComponentStatusEnum::operational,
+    ]);
+
+    $incident->components()->attach($component->id, [
+        'component_status' => \Cachet\Enums\ComponentStatusEnum::major_outage,
+    ]);
+
+    $data = CreateIncidentUpdateRequestData::from([
+        'message' => 'This issue has been fixed.',
+        'status' => IncidentStatusEnum::fixed,
+    ]);
+
+    app(CreateUpdate::class)->handle($incident, $data);
+
+    expect($incident->components()->first()->pivot->component_status)
+        ->toEqual(\Cachet\Enums\ComponentStatusEnum::operational);
+});
+
 it('can create a schedule update', function () {
     $schedule = Schedule::factory()->create();
 


### PR DESCRIPTION
## Summary

- When an incident update sets the status to **fixed**, automatically updates all linked component pivot statuses back to **operational**
- Adds `updateComponentsToOperational` method to `CreateUpdate` action that iterates linked components and resets their pivot `component_status`
- Includes unit test verifying the behavior

## Test plan

- [x] Verify existing tests pass
- [x] Confirm that creating an incident update with status `fixed` sets linked component pivot statuses to `operational`
- [x] Confirm that incident updates with other statuses do not affect component pivot statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)