### PR TITLE
Set incident status to fixed when incident update status is fixed

### DIFF
--- a/src/Actions/Update/CreateUpdate.php
+++ b/src/Actions/Update/CreateUpdate.php
@@ -22,6 +22,7 @@ class CreateUpdate
         $resource->updates()->save($update);
 
         if ($resource instanceof Incident && $data->status === IncidentStatusEnum::fixed) {
+            $resource->update(['status' => IncidentStatusEnum::fixed]);
             $this->updateComponentsToOperational($resource);
         }
 

--- a/tests/Unit/Actions/Update/CreateUpdateTest.php
+++ b/tests/Unit/Actions/Update/CreateUpdateTest.php
@@ -41,6 +41,38 @@ it('an incident\'s computed latest status equals the new status', function () {
         ->latestStatus->toEqual(IncidentStatusEnum::identified);
 });
 
+it('transitions parent incident status to fixed when incident update status is fixed', function () {
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::investigating,
+    ]);
+
+    $data = CreateIncidentUpdateRequestData::from([
+        'message' => 'This issue has been fixed.',
+        'status' => IncidentStatusEnum::fixed,
+    ]);
+
+    app(CreateUpdate::class)->handle($incident, $data);
+
+    expect($incident->fresh())
+        ->status->toEqual(IncidentStatusEnum::fixed);
+});
+
+it('does not change parent incident status when incident update status is not fixed', function () {
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::investigating,
+    ]);
+
+    $data = CreateIncidentUpdateRequestData::from([
+        'message' => 'Still looking into this.',
+        'status' => IncidentStatusEnum::identified,
+    ]);
+
+    app(CreateUpdate::class)->handle($incident, $data);
+
+    expect($incident->fresh())
+        ->status->toEqual(IncidentStatusEnum::investigating);
+});
+
 it('sets linked component status to operational when incident update status is fixed', function () {
     $incident = Incident::factory()->create([
         'status' => IncidentStatusEnum::investigating,


### PR DESCRIPTION
## Summary

- When an incident update has status `fixed`, also transition the parent incident's `status` column to `fixed`.
- Previously only the linked component pivots were reset (via #333), so the parent incident stayed on its last status (e.g. `investigating`) and the public banner kept reporting "Some systems are experiencing issues."
- Addresses cachethq/cachet#4516.

## Test plan

- [x] Added test: parent incident status transitions to `fixed` on a `fixed` update.
- [x] Added test: parent incident status unchanged on non-`fixed` updates.
- [x] Full suite: 382 passed.