### PR TITLE
Fix incident status form label translation key

### DIFF
--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -52,7 +52,7 @@ class IncidentResource extends Resource
                         ->maxLength(255)
                         ->autocomplete(false),
                     ToggleButtons::make('status')
-                        ->label(__('cachet::incident.form.name_label'))
+                        ->label(__('cachet::incident.form.status_label'))
                         ->inline()
                         ->columnSpanFull()
                         ->options(IncidentStatusEnum::class)


### PR DESCRIPTION
## Summary
- The `status` ToggleButtons on the incident form used `cachet::incident.form.name_label`, the same key as the name field, so it rendered as "Name" instead of "Status".
- Switched it to `cachet::incident.form.status_label`, which already exists in the language files.

Closes #341

## Test plan
- [ ] Open the incident create/edit form in the dashboard and verify the status field is labelled "Status".

🤖 Generated with [Claude Code](https://claude.com/claude-code)