### PR TITLE
Allow setting component group collapsed state via API

### DIFF
--- a/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
@@ -3,6 +3,7 @@
 namespace Cachet\Data\Requests\ComponentGroup;
 
 use Cachet\Data\BaseData;
+use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
@@ -13,6 +14,7 @@ final class CreateComponentGroupRequestData extends BaseData
         public readonly string $name,
         public readonly ?int $order = null,
         public readonly ?ResourceVisibilityEnum $visible = null,
+        public readonly ?ComponentGroupVisibilityEnum $collapsed = null,
         public readonly ?array $components = null,
     ) {}
 
@@ -22,8 +24,24 @@ final class CreateComponentGroupRequestData extends BaseData
             'name' => ['required', 'string', 'max:255'],
             'order' => ['int', 'min:0'],
             'visible' => ['bool'],
+            'collapsed' => [Rule::enum(ComponentGroupVisibilityEnum::class)],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            'collapsed' => [
+                'description' => 'The collapsed state of the component group on the status page.',
+                'example' => '0',
+                'required' => false,
+                'schema' => [
+                    'type' => 'integer',
+                    'enum' => ComponentGroupVisibilityEnum::cases(),
+                ],
+            ],
         ];
     }
 }

--- a/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
@@ -3,6 +3,7 @@
 namespace Cachet\Data\Requests\ComponentGroup;
 
 use Cachet\Data\BaseData;
+use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
@@ -12,6 +13,7 @@ final class UpdateComponentGroupRequestData extends BaseData
         public readonly ?string $name = null,
         public readonly ?int $order = null,
         public readonly ?bool $visible = null,
+        public readonly ?ComponentGroupVisibilityEnum $collapsed = null,
         public readonly ?array $components = null,
     ) {}
 
@@ -21,8 +23,24 @@ final class UpdateComponentGroupRequestData extends BaseData
             'name' => ['string', 'max:255'],
             'order' => ['int', 'min:0'],
             'visible' => ['bool'],
+            'collapsed' => [Rule::enum(ComponentGroupVisibilityEnum::class)],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+        ];
+    }
+    
+    public function bodyParameters(): array
+    {
+        return [
+            'collapsed' => [
+                'description' => 'The collapsed state of the component group on the status page.',
+                'example' => '0',
+                'required' => false,
+                'schema' => [
+                    'type' => 'integer',
+                    'enum' => ComponentGroupVisibilityEnum::cases(),
+                ],
+            ],
         ];
     }
 }

--- a/src/Http/Resources/ComponentGroup.php
+++ b/src/Http/Resources/ComponentGroup.php
@@ -14,6 +14,7 @@ class ComponentGroup extends JsonApiResource
             'id' => $this->id,
             'name' => $this->name,
             'order' => $this->order,
+            'collapsed' => $this->collapsed,
             'visible' => $this->visible,
             'created' => [
                 'human' => $this->created_at?->diffForHumans(),

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Laravel\Sanctum\Sanctum;
@@ -103,6 +104,33 @@ it('can create a component group without components', function () {
     ]);
 });
 
+it('can create a component group with a collapsed state', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
+
+    $response = postJson('/status/api/component-groups', [
+        'name' => 'New Group',
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('component_groups', [
+        'name' => 'New Group',
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+});
+
+it('cannot create a component group with an invalid collapsed state', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
+
+    $response = postJson('/status/api/component-groups', [
+        'name' => 'New Group',
+        'collapsed' => 99,
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors('collapsed');
+});
+
 it('can create a component group and attach existing components', function () {
     Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
 
@@ -163,6 +191,37 @@ it('can update a component group', function () {
     $this->assertDatabaseHas('component_groups', [
         'name' => 'Updated Component Group Name',
     ]);
+});
+
+it('can update a component group collapsed state', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
+
+    $componentGroup = ComponentGroup::factory()->create([
+        'collapsed' => ComponentGroupVisibilityEnum::expanded->value,
+    ]);
+
+    $response = putJson('/status/api/component-groups/'.$componentGroup->id, [
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+
+    $response->assertOk();
+    $this->assertDatabaseHas('component_groups', [
+        'id' => $componentGroup->id,
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+});
+
+it('cannot update a component group with an invalid collapsed state', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
+
+    $componentGroup = ComponentGroup::factory()->create();
+
+    $response = putJson('/status/api/component-groups/'.$componentGroup->id, [
+        'collapsed' => 99,
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors('collapsed');
 });
 
 it('can update a component group with components', function () {

--- a/tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
+++ b/tests/Unit/Actions/ComponentGroup/CreateComponentGroupTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Actions\ComponentGroup\CreateComponentGroup;
 use Cachet\Data\Requests\ComponentGroup\CreateComponentGroupRequestData;
+use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 
@@ -31,6 +32,18 @@ it('can create a component group with a name, order and visibility', function ()
         ->name->toBe($data->name)
         ->order->toBe($data->order)
         ->visible->toBe(ResourceVisibilityEnum::authenticated);
+});
+
+it('can create a component group with a collapsed state', function () {
+    $data = CreateComponentGroupRequestData::from([
+        'name' => 'Services',
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+
+    $componentGroup = app(CreateComponentGroup::class)->handle($data);
+
+    expect($componentGroup)
+        ->collapsed->toBe(ComponentGroupVisibilityEnum::collapsed_unless_incident);
 });
 
 it('can create a component group and add components', function () {

--- a/tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
+++ b/tests/Unit/Actions/ComponentGroup/UpdateComponentGroupTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
 use Cachet\Data\Requests\ComponentGroup\UpdateComponentGroupRequestData;
+use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 
@@ -33,6 +34,21 @@ it('can update a component group without touching components', function () {
     $this->assertDatabaseMissing('components', [
         'component_group_id' => $componentGroup->id,
     ]);
+});
+
+it('can update a component group collapsed state', function () {
+    $componentGroup = ComponentGroup::factory()->create([
+        'collapsed' => ComponentGroupVisibilityEnum::expanded->value,
+    ]);
+
+    $data = UpdateComponentGroupRequestData::from([
+        'collapsed' => ComponentGroupVisibilityEnum::collapsed_unless_incident->value,
+    ]);
+
+    $componentGroup = app(UpdateComponentGroup::class)->handle($componentGroup, $data);
+
+    expect($componentGroup)
+        ->collapsed->toBe(ComponentGroupVisibilityEnum::collapsed_unless_incident);
 });
 
 it('can update a component group with components', function () {


### PR DESCRIPTION
A Component Group's collapsed state (`expanded`, `collapsed`, `collapsed_unless_incident`) could only be set through the dashboard until now. This PR adds it to the create and update request DTOs with `enum` validation, and exposes it in the API resource so that it is returned in responses as well.