### PR TITLE
Ability to GET each component's group nested under its relationships, when querying schedules or incidents via the API

### DIFF
--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -28,6 +28,7 @@ class IncidentController extends Controller
      */
     public const ALLOWED_INCLUDES = [
         'components',
+        'components.group',
         'updates',
         'user',
     ];

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -34,7 +34,7 @@ class ScheduleController extends Controller
     public function index()
     {
         $schedules = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'updates', 'user'])
+            ->allowedIncludes(['components', 'components.group', 'updates', 'user'])
             ->allowedFilters(['name', AllowedFilter::custom('status', new ScheduleStatusFilter)])
             ->allowedSorts(['name', 'id', 'scheduled_at', 'completed_at'])
             ->simplePaginate(request('per_page', 15));
@@ -60,7 +60,7 @@ class ScheduleController extends Controller
     public function show(Schedule $schedule)
     {
         $scheduleQuery = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'updates', 'user'])
+            ->allowedIncludes(['components', 'components.group', 'updates', 'user'])
             ->find($schedule->id);
 
         return ScheduleResource::make($scheduleQuery)

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -3,6 +3,7 @@
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Models\IncidentTemplate;
 use Laravel\Sanctum\Sanctum;
@@ -186,6 +187,22 @@ it('can get an incident with updates', function () {
     $response->assertJsonFragment([
         'id' => $incident->id,
     ]);
+});
+
+it('can get an incident with components and their groups', function () {
+    $group = ComponentGroup::factory()->create();
+    $component = Component::factory()->for($group, 'group')->create();
+    $incident = Incident::factory()->create();
+    $incident->components()->attach($component, ['component_status' => ComponentStatusEnum::partial_outage->value]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id.'?include=components.group');
+
+    $response->assertOk();
+
+    $included = collect($response->json('included'));
+
+    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+        ->and($included->firstWhere('attributes.name', $group->name))->not->toBeNull();
 });
 
 it('cannot create an incident if not authenticated', function () {

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Schedule;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -193,6 +195,22 @@ it('can get a schedule', function () {
     $response->assertJsonFragment([
         'id' => $schedule->id,
     ]);
+});
+
+it('can get a schedule with components and their groups', function () {
+    $group = ComponentGroup::factory()->create();
+    $component = Component::factory()->for($group, 'group')->create();
+    $schedule = Schedule::factory()->create();
+    $schedule->components()->attach($component, ['component_status' => ComponentStatusEnum::partial_outage->value]);
+
+    $response = getJson('/status/api/schedules/'.$schedule->id.'?include=components.group');
+
+    $response->assertOk();
+
+    $included = collect($response->json('included'));
+
+    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+        ->and($included->firstWhere('attributes.name', $group->name))->not->toBeNull();
 });
 
 it('cannot create a schedule if not authenticated', function () {


### PR DESCRIPTION
Added 'components.group' to `ALLOWED_INCLUDES` allowlist under schedule and incident controllers.

Consumers can now hit GET `/status/api/incidents?include=components.group` (and the same for schedules) to get each component's group nested under its relationships.group, with the full group resources in the top-level included array.