### PR TITLE
Require a status when creating an incident

### DIFF
--- a/src/Data/Requests/Incident/CreateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/CreateIncidentRequestData.php
@@ -20,7 +20,7 @@ final class CreateIncidentRequestData extends BaseData
         #[Max(255)]
         public readonly string $name,
         #[Enum(IncidentStatusEnum::class)]
-        public readonly ?IncidentStatusEnum $status = null,
+        public readonly IncidentStatusEnum $status,
         #[RequiredWithout('template')]
         public readonly ?string $message = null,
         #[RequiredWithout('message')]

--- a/tests/Unit/Actions/Incident/CreateIncidentTest.php
+++ b/tests/Unit/Actions/Incident/CreateIncidentTest.php
@@ -17,6 +17,7 @@ it('can create an incident', function () {
     $data = CreateIncidentRequestData::from([
         'name' => 'My Incident',
         'message' => 'This is an incident message.',
+        'status' => IncidentStatusEnum::investigating,
     ]);
 
     $incident = app(CreateIncident::class)->handle($data);
@@ -99,6 +100,7 @@ it('attaches provided components to the incident', function () {
     $data = CreateIncidentRequestData::from([
         'name' => 'My Incident',
         'message' => 'This is an incident message.',
+        'status' => IncidentStatusEnum::investigating,
         'components' => [
             ['id' => $componentA->id, 'status' => ComponentStatusEnum::performance_issues->value],
             ['id' => $componentB->id, 'status' => ComponentStatusEnum::partial_outage->value],


### PR DESCRIPTION
## Problem

The nightly test run started failing intermittently ([run 27315738081](https://github.com/cachethq/core/actions/runs/27315738081)) with:

```
FAILED  Tests\Unit\Actions\Incident\CreateIncidentTest  ValidationException
The status field is required.
```

at the two tests that created an incident **without** a status. It reproduced only under the full parallel suite, never in isolation.

## Root cause

An incident requires a status. `CreateIncidentRequestData` validates `status` as `required`, but:

1. Two `CreateIncidentTest` cases created incidents without passing one.
2. The constructor property was typed `?IncidentStatusEnum $status = null`, contradicting the `required` rule.

The omission only surfaced intermittently: the workbench sets `validation_strategy: Always` (so `from()` validates every call) and spatie/laravel-data's structure cache uses the file store, shared across the 10 parallel test workers. Depending on worker assignment and ordering, the resolved `status => required` rule got applied to the status-less payloads, failing with "The status field is required."

## Fix

- Pass an explicit `status` in the two affected tests, matching the others.
- Make the `status` constructor property required and non-nullable (`IncidentStatusEnum $status`) so the type matches the validation rule and an incident can never be constructed without a status.

## Verification

Full suite green in parallel on both dependency sets:
- `--prefer-lowest` (spatie/laravel-data 4.11): 408 passed
- `--prefer-stable` (spatie/laravel-data 4.23): 408 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)