### PR TITLE
Fix schedule API update silently dropping completed_at

### DIFF
--- a/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
@@ -5,8 +5,11 @@ namespace Cachet\Data\Requests\Schedule;
 use Cachet\Data\BaseData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
+use Carbon\Carbon;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 final class UpdateScheduleRequestData extends BaseData
@@ -15,7 +18,10 @@ final class UpdateScheduleRequestData extends BaseData
         public readonly ?string $name = null,
         public readonly ?string $message = null,
         public readonly ?ScheduleStatusEnum $status = null,
-        public readonly ?string $scheduledAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        public readonly ?Carbon $scheduledAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        public readonly ?Carbon $completedAt = null,
         #[DataCollectionOf(ScheduleComponentRequestData::class)]
         public readonly ?array $components = null,
     ) {}
@@ -26,6 +32,7 @@ final class UpdateScheduleRequestData extends BaseData
             'name' => ['string', 'max:255'],
             'message' => ['string'],
             'scheduled_at' => ['nullable', 'date'],
+            'completed_at' => ['nullable', 'date'],
             'components' => ['array'],
             'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
             'components.*.status' => ['required_with:components', Rule::enum(ComponentStatusEnum::class)],

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -336,6 +336,20 @@ it('can update a schedule', function () {
     ]);
 });
 
+it('can update a schedule completed_at', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $schedule = Schedule::factory()->create(['completed_at' => null]);
+
+    $response = putJson('/status/api/schedules/'.$schedule->id, [
+        'completed_at' => '2026-06-11 10:00:00',
+    ]);
+
+    $response->assertOk();
+
+    expect($schedule->fresh()->completed_at->toDateTimeString())->toBe('2026-06-11 10:00:00');
+});
+
 it('can update a schedule with components', function () {
     Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
 


### PR DESCRIPTION
UpdateScheduleRequestData was missing the `completedAt` property (which was present in CreateScheduleRequestData), so the field was silently dropped on a schedule update via the API. This PR fixes it by mirroring it to the create DTO.

Fixes https://github.com/cachethq/cachet/issues/4619