### PR TITLE
Add Psalm taint (security) analysis

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,73 @@
+# Psalm taint (security) analysis. Type analysis is left to Larastan; this adds only taint/dataflow
+# scanning (SQLi, XSS, SSRF, shell injection, file traversal, open redirects), which PHPStan can't do.
+#
+# Findings upload to Code Scanning. continue-on-error keeps first-time findings from blocking PRs;
+# drop it (and add a baseline: ./vendor/bin/psalm --taint-analysis --set-baseline=psalm-baseline.xml) to gate.
+
+name: Psalm (security)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: psalm-security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    name: Psalm taint analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden the runner (block unexpected egress)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          # Covers checkout, setup-php, Composer (public Packagist) and the SARIF upload endpoint.
+          # Extend it if the project reaches other hosts (private Composer registry, VCS/path repos).
+          # A blocked call shows in the step log; use egress-policy: audit to discover endpoints.
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            github.com:443
+            packagist.org:443
+            release-assets.githubusercontent.com:443
+            repo.packagist.org:443
+            results-receiver.actions.githubusercontent.com:443
+
+      # No git operations run after checkout, so drop the persisted token. Defense in depth: a
+      # compromised later step (a malicious Composer dependency or Psalm plugin) cannot reuse the
+      # token to push. The SARIF upload uses the Actions token (security-events: write), not git.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      # --taint-analysis switches Psalm to taint mode. continue-on-error keeps first-time findings
+      # from blocking PRs; they still upload to Code Scanning below.
+      - name: Run Psalm taint analysis
+        run: ./vendor/bin/psalm --taint-analysis --report=psalm-security.sarif
+        continue-on-error: true
+
+      # Guard with hashFiles so the step skips (rather than fails) if Psalm crashed before writing
+      # the report.
+      - name: Upload SARIF to GitHub Code Scanning
+        if: ${{ always() && hashFiles('psalm-security.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: psalm-security.sarif
+          category: psalm-security

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Thumbs.db
 
 !.claude/README.md
 !.cursor/rules.md
+# Psalm taint analysis report (generated in CI)
+/psalm-security.sarif

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "pestphp/pest": "^3.8",
         "pestphp/pest-plugin-laravel": "^3.0",
         "pestphp/pest-plugin-livewire": "*",
-        "pestphp/pest-plugin-type-coverage": "^3.3"
+        "pestphp/pest-plugin-type-coverage": "^3.3",
+        "psalm/plugin-laravel": "^3.14"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="3"
+    findUnusedCode="false"
+    ensureOverrideAttribute="false"
+    runTaintAnalysis="true"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="database/factories"/>
+        <directory name="database/seeders"/>
+        <directory name="config"/>
+        <!-- composer require psalm/plugin-phpunit psalm/plugin-mockery for the full tests support -->
+        <!-- <directory name="tests"/>-->
+
+        <ignoreFiles allowMissingFiles="true">
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <plugins>
+        <!-- All Psalm Laravel options: https://github.com/psalm/psalm-plugin-laravel/blob/master/docs/config.md -->
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <resolveDynamicWhereClauses value="true" />
+            <findMissingTranslations value="false" />
+            <findMissingViews value="false" />
+        </pluginClass>
+    </plugins>
+
+    <issueHandlers>
+        <ClassMustBeFinal errorLevel="info"/>
+        <ImplicitToStringCast errorLevel="info"/>
+        <MissingClosureReturnType errorLevel="info"/>
+        <MissingImmutableAnnotation errorLevel="info"/>
+        <MissingOverrideAttribute errorLevel="info"/>
+        <RedundantCast errorLevel="info"/>
+        <RedundantCondition errorLevel="info"/>
+        <UnnecessaryVarAnnotation errorLevel="suppress"/>
+    </issueHandlers>
+
+    <forbiddenFunctions>
+        <function name="var_dump" />
+        <function name="dd" />
+    </forbiddenFunctions>
+</psalm>


### PR DESCRIPTION
## Add Psalm taint (security) analysis

This adds [Psalm](https://psalm.dev) with [`psalm-plugin-laravel`](https://github.com/psalm/psalm-plugin-laravel) **purely for security (taint) analysis**, wired into CI and uploading to GitHub Code Scanning.

This project already uses **Larastan (PHPStan)** for type analysis, so type checking is intentionally left to it. psalm-plugin-laravel is **complementary**: it adds taint analysis that PHPStan structurally cannot do.

- **Larastan (PHPStan)** — type safety, model-property validation, view existence, collection optimization. Already running.
- **psalm-plugin-laravel (this PR)** — dataflow **taint analysis**: SQL injection, XSS, SSRF, shell injection, file traversal, open redirects, tracked across function boundaries.

### What it catches

Taint analysis is **dataflow analysis**: it follows untrusted input from where it enters (request data, route params, headers, uploaded file names...) through every assignment, function call, and return, and flags it when it reaches a dangerous sink **without being sanitized first**. The vulnerability and the user input are often in different methods or files — exactly the cross-function flow that grep- and pattern-based scanners miss.

Sinks it reports for Laravel apps:

- **SQL injection** — tainted input reaching raw queries / `DB::raw` / `whereRaw`
- **Command injection** — input flowing into `Process` / `exec` / shell
- **Path traversal & arbitrary file ops** — input into file paths / `Storage` / `file_get_contents`
- **SSRF** — input into outbound HTTP / URL fetchers
- **Open redirect** — input into `redirect()` targets
- **Code injection** — input into `eval` / dynamic includes

Each finding ships the **full source→sink trace**, so you see exactly how the input reaches the sink.

### Notes

- The taint scan currently reports **no findings** — this PR adds the capability for ongoing coverage, it is not prompted by a specific issue.
- No baseline is shipped (nothing to suppress).
- Taint findings land in Code Scanning under **Other → Error** (Psalm does not yet emit a `security-severity` score, [vimeo/psalm#11885](https://github.com/vimeo/psalm/issues/11885)); they still carry the `security` tag and full taint trace.

### Next steps for maintainers

- Once you've reviewed any findings, drop `continue-on-error` (and optionally add a taint baseline with `./vendor/bin/psalm --taint-analysis --set-baseline=psalm-baseline.xml`) to make the job gate PRs.
- Tune the plugin options in `psalm.xml` to taste.

Docs: https://github.com/psalm/psalm-plugin-laravel
