### PR TITLE
Scope public API endpoints to caller visibility (GHSA-6ghm-wf22-pvx5)

### DIFF
--- a/database/factories/ComponentGroupFactory.php
+++ b/database/factories/ComponentGroupFactory.php
@@ -2,9 +2,9 @@
 
 namespace Cachet\Database\Factories;
 
-use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ResourceOrderColumnEnum;
 use Cachet\Enums\ResourceOrderDirectionEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\ComponentGroup;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -27,7 +27,7 @@ class ComponentGroupFactory extends Factory
             'order' => 0,
             'order_column' => ResourceOrderColumnEnum::Manual,
             'order_direction' => null,
-            'visible' => ComponentGroupVisibilityEnum::expanded->value,
+            'visible' => ResourceVisibilityEnum::guest->value,
         ];
     }
 

--- a/src/Concerns/ChecksApiAuthentication.php
+++ b/src/Concerns/ChecksApiAuthentication.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cachet\Concerns;
+
+trait ChecksApiAuthentication
+{
+    /**
+     * Determine whether the API caller is authenticated.
+     *
+     * The API's read routes carry no auth middleware, so the application's
+     * default guard never sees bearer tokens. The Sanctum guard resolves
+     * both API tokens and first-party sessions.
+     */
+    protected function isAuthenticated(): bool
+    {
+        return auth('sanctum')->check();
+    }
+}

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -12,8 +12,10 @@ use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -47,18 +49,36 @@ class ComponentController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $components = QueryBuilder::for(Component::class)
+        $components = QueryBuilder::for($this->visibleComponents())
             ->allowedIncludes(self::ALLOWED_INCLUDES)
             ->allowedFilters([
                 'name',
                 AllowedFilter::exact('status'),
-                AllowedFilter::exact('enabled'),
+                AllowedFilter::exact('enabled')->default(true),
                 AllowedFilter::custom('meta', new MetaFilter),
             ])
             ->allowedSorts(['name', 'order', 'id'])
             ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return ComponentResource::collection($components);
+    }
+
+    /**
+     * Base query scoping components to those visible to the current caller.
+     *
+     * Components have no visibility of their own; they inherit it from their
+     * group. Ungrouped components are always public, matching the status page.
+     *
+     * @return Builder<Component>
+     */
+    protected function visibleComponents(): Builder
+    {
+        $visibleGroups = ComponentGroup::query()->visible(auth()->check())->select('id');
+
+        return Component::query()->where(function ($query) use ($visibleGroups): void {
+            $query->whereNull('component_group_id')
+                ->orWhereIn('component_group_id', $visibleGroups);
+        });
     }
 
     /**
@@ -81,10 +101,9 @@ class ComponentController extends Controller
     #[QueryParameter('include', 'Include related data (group, incidents, meta).', example: 'meta')]
     public function show(Component $component)
     {
-
-        $componentQuery = QueryBuilder::for(Component::class)
+        $componentQuery = QueryBuilder::for($this->visibleComponents()->enabled())
             ->allowedIncludes(self::ALLOWED_INCLUDES)
-            ->find($component->id);
+            ->findOrFail($component->id);
 
         return ComponentResource::make($componentQuery)
             ->response()

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Component\CreateComponent;
 use Cachet\Actions\Component\DeleteComponent;
 use Cachet\Actions\Component\UpdateComponent;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Component\CreateComponentRequestData;
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
@@ -13,29 +14,25 @@ use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
+use Cachet\Models\Incident;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Components', weight: 1)]
 class ComponentController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
-
-    /**
-     * The list of allowed includes.
-     */
-    public const ALLOWED_INCLUDES = [
-        'group',
-        'incidents',
-        'meta',
-    ];
 
     /**
      * List Components
@@ -50,7 +47,7 @@ class ComponentController extends Controller
     public function index(Request $request)
     {
         $components = QueryBuilder::for($this->visibleComponents())
-            ->allowedIncludes(self::ALLOWED_INCLUDES)
+            ->allowedIncludes($this->allowedIncludes())
             ->allowedFilters([
                 'name',
                 AllowedFilter::exact('status'),
@@ -64,21 +61,41 @@ class ComponentController extends Controller
     }
 
     /**
+     * The list of allowed includes, scoped to the current caller.
+     *
+     * @return array<int, string|Collection<int, AllowedInclude>>
+     */
+    protected function allowedIncludes(): array
+    {
+        return [
+            'group',
+            AllowedInclude::callback('incidents', function (BelongsToMany $query): void {
+                /** @var BelongsToMany<Incident, Component> $query */
+                $query->visible($this->isAuthenticated());
+            }),
+            'meta',
+        ];
+    }
+
+    /**
      * Base query scoping components to those visible to the current caller.
      *
      * Components have no visibility of their own; they inherit it from their
-     * group. Ungrouped components are always public, matching the status page.
+     * group. Ungrouped components are always public and disabled components
+     * are hidden from guests, matching the status page.
      *
      * @return Builder<Component>
      */
     protected function visibleComponents(): Builder
     {
-        $visibleGroups = ComponentGroup::query()->visible(auth()->check())->select('id');
+        $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
 
-        return Component::query()->where(function ($query) use ($visibleGroups): void {
-            $query->whereNull('component_group_id')
-                ->orWhereIn('component_group_id', $visibleGroups);
-        });
+        return Component::query()
+            ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
+            ->where(function ($query) use ($visibleGroups): void {
+                $query->whereNull('component_group_id')
+                    ->orWhereIn('component_group_id', $visibleGroups);
+            });
     }
 
     /**
@@ -101,8 +118,8 @@ class ComponentController extends Controller
     #[QueryParameter('include', 'Include related data (group, incidents, meta).', example: 'meta')]
     public function show(Component $component)
     {
-        $componentQuery = QueryBuilder::for($this->visibleComponents()->enabled())
-            ->allowedIncludes(self::ALLOWED_INCLUDES)
+        $componentQuery = QueryBuilder::for($this->visibleComponents())
+            ->allowedIncludes($this->allowedIncludes())
             ->findOrFail($component->id);
 
         return ComponentResource::make($componentQuery)

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -34,7 +34,7 @@ class ComponentGroupController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $componentGroups = QueryBuilder::for(ComponentGroup::class)
+        $componentGroups = QueryBuilder::for(ComponentGroup::query()->visible(auth()->check()))
             ->allowedIncludes(['components', 'meta'])
             ->allowedFilters([
                 AllowedFilter::custom('meta', new MetaFilter),
@@ -63,10 +63,9 @@ class ComponentGroupController extends Controller
     #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     public function show(ComponentGroup $componentGroup)
     {
-
-        $componentQuery = QueryBuilder::for(ComponentGroup::class)
+        $componentQuery = QueryBuilder::for(ComponentGroup::query()->visible(auth()->check()))
             ->allowedIncludes(['components', 'meta'])
-            ->find($componentGroup->id);
+            ->findOrFail($componentGroup->id);
 
         return ComponentGroupResource::make($componentQuery)
             ->response()

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -5,25 +5,51 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\ComponentGroup\CreateComponentGroup;
 use Cachet\Actions\ComponentGroup\DeleteComponentGroup;
 use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\ComponentGroup\CreateComponentGroupRequestData;
 use Cachet\Data\Requests\ComponentGroup\UpdateComponentGroupRequestData;
 use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\ComponentGroup as ComponentGroupResource;
+use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Component Groups', weight: 2)]
 class ComponentGroupController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
+
+    /**
+     * The list of allowed includes, scoped to the current caller.
+     *
+     * Disabled components are hidden from guests, matching the status page.
+     *
+     * @return array<int, string|Collection<int, AllowedInclude>>
+     */
+    protected function allowedIncludes(): array
+    {
+        return [
+            AllowedInclude::callback('components', function (HasMany $query): void {
+                /** @var HasMany<Component, ComponentGroup> $query */
+                if (! $this->isAuthenticated()) {
+                    $query->enabled();
+                }
+            }),
+            'meta',
+        ];
+    }
 
     /**
      * List Component Groups
@@ -34,8 +60,8 @@ class ComponentGroupController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $componentGroups = QueryBuilder::for(ComponentGroup::query()->visible(auth()->check()))
-            ->allowedIncludes(['components', 'meta'])
+        $componentGroups = QueryBuilder::for(ComponentGroup::query()->visible($this->isAuthenticated()))
+            ->allowedIncludes($this->allowedIncludes())
             ->allowedFilters([
                 AllowedFilter::custom('meta', new MetaFilter),
             ])
@@ -63,8 +89,8 @@ class ComponentGroupController extends Controller
     #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     public function show(ComponentGroup $componentGroup)
     {
-        $componentQuery = QueryBuilder::for(ComponentGroup::query()->visible(auth()->check()))
-            ->allowedIncludes(['components', 'meta'])
+        $componentQuery = QueryBuilder::for(ComponentGroup::query()->visible($this->isAuthenticated()))
+            ->allowedIncludes($this->allowedIncludes())
             ->findOrFail($componentGroup->id);
 
         return ComponentGroupResource::make($componentQuery)

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -5,36 +5,54 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Incident\CreateIncident;
 use Cachet\Actions\Incident\DeleteIncident;
 use Cachet\Actions\Incident\UpdateIncident;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Incident\CreateIncidentRequestData;
 use Cachet\Data\Requests\Incident\UpdateIncidentRequestData;
 use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Incident as IncidentResource;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Incidents', weight: 3)]
 class IncidentController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
 
     /**
-     * The list of allowed includes.
+     * The list of allowed includes, scoped to the current caller.
+     *
+     * Component groups hidden from the caller are excluded from the nested
+     * include so a visible incident cannot reveal them.
+     *
+     * @return array<int, string|Collection<int, AllowedInclude>>
      */
-    public const ALLOWED_INCLUDES = [
-        'components',
-        'components.group',
-        'updates',
-        'user',
-        'meta',
-    ];
+    protected function allowedIncludes(): array
+    {
+        return [
+            'components',
+            AllowedInclude::callback('components.group', function (BelongsTo $query): void {
+                /** @var BelongsTo<ComponentGroup, Component> $query */
+                $query->visible($this->isAuthenticated());
+            }),
+            'updates',
+            'user',
+            'meta',
+        ];
+    }
 
     /**
      * List Incidents
@@ -45,8 +63,8 @@ class IncidentController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $incidents = QueryBuilder::for(Incident::query()->with('updates')->visible(auth()->check()))
-            ->allowedIncludes(self::ALLOWED_INCLUDES)
+        $incidents = QueryBuilder::for(Incident::query()->with('updates')->visible($this->isAuthenticated()))
+            ->allowedIncludes($this->allowedIncludes())
             ->allowedFilters([
                 'name',
                 AllowedFilter::exact('status'),
@@ -80,8 +98,8 @@ class IncidentController extends Controller
     #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     public function show(Incident $incident)
     {
-        $incidentQuery = QueryBuilder::for(Incident::query()->visible(auth()->check()))
-            ->allowedIncludes(self::ALLOWED_INCLUDES)
+        $incidentQuery = QueryBuilder::for(Incident::query()->visible($this->isAuthenticated()))
+            ->allowedIncludes($this->allowedIncludes())
             ->findOrFail($incident->id);
 
         return IncidentResource::make($incidentQuery)

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -45,7 +45,7 @@ class IncidentController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $incidents = QueryBuilder::for(Incident::query()->with('updates'))
+        $incidents = QueryBuilder::for(Incident::query()->with('updates')->visible(auth()->check()))
             ->allowedIncludes(self::ALLOWED_INCLUDES)
             ->allowedFilters([
                 'name',
@@ -80,10 +80,9 @@ class IncidentController extends Controller
     #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     public function show(Incident $incident)
     {
-
-        $incidentQuery = QueryBuilder::for(Incident::class)
+        $incidentQuery = QueryBuilder::for(Incident::query()->visible(auth()->check()))
             ->allowedIncludes(self::ALLOWED_INCLUDES)
-            ->find($incident->id);
+            ->findOrFail($incident->id);
 
         return IncidentResource::make($incidentQuery)
             ->response()

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -33,6 +33,8 @@ class IncidentUpdateController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request, Incident $incident)
     {
+        $this->ensureIncidentVisible($incident);
+
         $query = Update::query()
             ->where('updateable_id', $incident->id)
             ->where('updateable_type', 'incident');
@@ -65,6 +67,8 @@ class IncidentUpdateController extends Controller
      */
     public function show(Incident $incident, Update $update)
     {
+        $this->ensureIncidentVisible($incident);
+
         $updateQuery = QueryBuilder::for(Update::class)
             ->allowedIncludes([
                 AllowedInclude::relationship('incident', 'updateable'),
@@ -74,6 +78,17 @@ class IncidentUpdateController extends Controller
         return UpdateResource::make($updateQuery)
             ->response()
             ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Abort with a 404 when the parent incident is not visible to the caller.
+     */
+    protected function ensureIncidentVisible(Incident $incident): void
+    {
+        abort_unless(
+            Incident::query()->visible(auth()->check())->whereKey($incident->getKey())->exists(),
+            Response::HTTP_NOT_FOUND,
+        );
     }
 
     /**

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Actions\Update\DeleteUpdate;
 use Cachet\Actions\Update\EditUpdate;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Data\Requests\IncidentUpdate\EditIncidentUpdateRequestData;
@@ -24,6 +25,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 #[Group('Incident Updates', weight: 4)]
 class IncidentUpdateController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
 
     /**
@@ -86,7 +88,7 @@ class IncidentUpdateController extends Controller
     protected function ensureIncidentVisible(Incident $incident): void
     {
         abort_unless(
-            Incident::query()->visible(auth()->check())->whereKey($incident->getKey())->exists(),
+            Incident::query()->visible($this->isAuthenticated())->whereKey($incident->getKey())->exists(),
             Response::HTTP_NOT_FOUND,
         );
     }

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -36,6 +36,7 @@ class MetricController extends Controller
     public function index(Request $request)
     {
         $query = Metric::query()
+            ->visible(auth()->check())
             ->when(! $request->input('sort'), function (Builder $builder) {
                 $builder->orderByDesc('created_at');
             });
@@ -68,11 +69,11 @@ class MetricController extends Controller
      */
     public function show(Metric $metric)
     {
-        $metricQuery = QueryBuilder::for(Metric::class)
+        $metricQuery = QueryBuilder::for(Metric::query()->visible(auth()->check()))
             ->allowedIncludes([
                 AllowedInclude::relationship('points', 'metricPoints'),
             ])
-            ->find($metric->id);
+            ->findOrFail($metric->id);
 
         return MetricResource::make($metricQuery)
             ->response()

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Metric\CreateMetric;
 use Cachet\Actions\Metric\DeleteMetric;
 use Cachet\Actions\Metric\UpdateMetric;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Metric\CreateMetricRequestData;
 use Cachet\Data\Requests\Metric\UpdateMetricRequestData;
@@ -24,6 +25,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 #[Group('Metrics', weight: 6)]
 class MetricController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
 
     /**
@@ -36,7 +38,7 @@ class MetricController extends Controller
     public function index(Request $request)
     {
         $query = Metric::query()
-            ->visible(auth()->check())
+            ->visible($this->isAuthenticated())
             ->when(! $request->input('sort'), function (Builder $builder) {
                 $builder->orderByDesc('created_at');
             });
@@ -69,7 +71,7 @@ class MetricController extends Controller
      */
     public function show(Metric $metric)
     {
-        $metricQuery = QueryBuilder::for(Metric::query()->visible(auth()->check()))
+        $metricQuery = QueryBuilder::for(Metric::query()->visible($this->isAuthenticated()))
             ->allowedIncludes([
                 AllowedInclude::relationship('points', 'metricPoints'),
             ])

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -29,6 +29,8 @@ class MetricPointController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request, Metric $metric)
     {
+        $this->ensureMetricVisible($metric);
+
         $query = MetricPoint::query()
             ->where('metric_id', $metric->id);
 
@@ -59,6 +61,7 @@ class MetricPointController extends Controller
      */
     public function show(Metric $metric, MetricPoint $metricPoint)
     {
+        $this->ensureMetricVisible($metric);
 
         $metricPointQuery = QueryBuilder::for(MetricPoint::class)
             ->allowedIncludes(['metric'])
@@ -67,6 +70,17 @@ class MetricPointController extends Controller
         return MetricPointResource::make($metricPointQuery)
             ->response()
             ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Abort with a 404 when the parent metric is not visible to the caller.
+     */
+    protected function ensureMetricVisible(Metric $metric): void
+    {
+        abort_unless(
+            Metric::query()->visible(auth()->check())->whereKey($metric->getKey())->exists(),
+            Response::HTTP_NOT_FOUND,
+        );
     }
 
     /**

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -4,6 +4,7 @@ namespace Cachet\Http\Controllers\Api;
 
 use Cachet\Actions\Metric\CreateMetricPoint;
 use Cachet\Actions\Metric\DeleteMetricPoint;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Metric\CreateMetricPointRequestData;
 use Cachet\Http\Resources\MetricPoint as MetricPointResource;
@@ -20,6 +21,7 @@ use Spatie\QueryBuilder\QueryBuilder;
 #[Group('Metric Points', weight: 7)]
 class MetricPointController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
 
     /**
@@ -78,7 +80,7 @@ class MetricPointController extends Controller
     protected function ensureMetricVisible(Metric $metric): void
     {
         abort_unless(
-            Metric::query()->visible(auth()->check())->whereKey($metric->getKey())->exists(),
+            Metric::query()->visible($this->isAuthenticated())->whereKey($metric->getKey())->exists(),
             Response::HTTP_NOT_FOUND,
         );
     }

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Schedule\CreateSchedule;
 use Cachet\Actions\Schedule\DeleteSchedule;
 use Cachet\Actions\Schedule\UpdateSchedule;
+use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Schedule\CreateScheduleRequestData;
 use Cachet\Data\Requests\Schedule\UpdateScheduleRequestData;
@@ -12,20 +13,48 @@ use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Filters\MetaFilter;
 use Cachet\Filters\ScheduleStatusFilter;
 use Cachet\Http\Resources\Schedule as ScheduleResource;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Schedule;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Schedules', weight: 8)]
 class ScheduleController extends Controller
 {
+    use ChecksApiAuthentication;
     use GuardsApiAbilities;
+
+    /**
+     * The list of allowed includes, scoped to the current caller.
+     *
+     * Component groups hidden from the caller are excluded from the nested
+     * include so a schedule cannot reveal them.
+     *
+     * @return array<int, string|Collection<int, AllowedInclude>>
+     */
+    protected function allowedIncludes(): array
+    {
+        return [
+            'components',
+            AllowedInclude::callback('components.group', function (BelongsTo $query): void {
+                /** @var BelongsTo<ComponentGroup, Component> $query */
+                $query->visible($this->isAuthenticated());
+            }),
+            'updates',
+            'user',
+            'meta',
+        ];
+    }
 
     /**
      * List Schedules
@@ -39,7 +68,7 @@ class ScheduleController extends Controller
     public function index(Request $request)
     {
         $schedules = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'components.group', 'updates', 'user', 'meta'])
+            ->allowedIncludes($this->allowedIncludes())
             ->allowedFilters([
                 'name',
                 AllowedFilter::custom('status', new ScheduleStatusFilter),
@@ -70,7 +99,7 @@ class ScheduleController extends Controller
     public function show(Schedule $schedule)
     {
         $scheduleQuery = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'components.group', 'updates', 'user', 'meta'])
+            ->allowedIncludes($this->allowedIncludes())
             ->find($schedule->id);
 
         return ScheduleResource::make($scheduleQuery)

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -100,7 +100,7 @@ class ScheduleController extends Controller
     {
         $scheduleQuery = QueryBuilder::for(Schedule::class)
             ->allowedIncludes($this->allowedIncludes())
-            ->find($schedule->id);
+            ->findOrFail($schedule->id);
 
         return ScheduleResource::make($scheduleQuery)
             ->response()

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -3,6 +3,7 @@
 use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ResourceOrderColumnEnum;
 use Cachet\Enums\ResourceOrderDirectionEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Laravel\Sanctum\Sanctum;
@@ -483,4 +484,47 @@ it('can update an unrelated attribute without supplying an order direction', fun
         'id' => $componentGroup->id,
         'name' => 'Renamed Group',
     ]);
+});
+
+it('does not list component groups hidden from guests', function () {
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/component-groups');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+});
+
+it('lists authenticated component groups to authenticated users but never hidden ones', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/component-groups');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not show a hidden component group to guests', function () {
+    $componentGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/component-groups/'.$componentGroup->id);
+
+    $response->assertNotFound();
+});
+
+it('shows an authenticated component group to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $componentGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson('/status/api/component-groups/'.$componentGroup->id);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.id', $componentGroup->id);
 });

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -528,3 +528,41 @@ it('shows an authenticated component group to authenticated users', function () 
     $response->assertOk();
     $response->assertJsonPath('data.attributes.id', $componentGroup->id);
 });
+
+it('does not include disabled components in a group to guests', function () {
+    $group = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Component::factory()->enabled()->create(['component_group_id' => $group->id]);
+    Component::factory()->disabled()->create(['component_group_id' => $group->id]);
+
+    $response = getJson('/status/api/component-groups/'.$group->id.'?include=components');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'included');
+});
+
+it('includes disabled components in a group to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $group = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Component::factory()->enabled()->create(['component_group_id' => $group->id]);
+    Component::factory()->disabled()->create(['component_group_id' => $group->id]);
+
+    $response = getJson('/status/api/component-groups/'.$group->id.'?include=components');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'included');
+});
+
+it('lists authenticated component groups to callers presenting a bearer token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('api')->plainTextToken;
+
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/component-groups', ['Authorization' => 'Bearer '.$token]);
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Laravel\Sanctum\Sanctum;
@@ -487,4 +488,73 @@ it('can delete a component', function () {
     $this->assertSoftDeleted('components', [
         'id' => $component->id,
     ]);
+});
+
+it('does not list components belonging to groups hidden from guests', function () {
+    $guestGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    $authGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    Component::factory()->create(['component_group_id' => $guestGroup->id]);
+    Component::factory()->create(['component_group_id' => $authGroup->id]);
+    Component::factory()->create(['component_group_id' => $hiddenGroup->id]);
+    Component::factory()->create(['component_group_id' => null]);
+
+    $response = getJson('/status/api/components?per_page=50');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('lists components in authenticated groups to authenticated users but never hidden ones', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $authGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    Component::factory()->create(['component_group_id' => $authGroup->id]);
+    Component::factory()->create(['component_group_id' => $hiddenGroup->id]);
+    Component::factory()->create(['component_group_id' => null]);
+
+    $response = getJson('/status/api/components?per_page=50');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not show a component in a hidden group to guests', function () {
+    $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $component = Component::factory()->create(['component_group_id' => $hiddenGroup->id]);
+
+    $response = getJson('/status/api/components/'.$component->id);
+
+    $response->assertNotFound();
+});
+
+it('does not list disabled components by default', function () {
+    Component::factory(3)->enabled()->create();
+    Component::factory(2)->disabled()->create();
+
+    $response = getJson('/status/api/components?per_page=50');
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+});
+
+it('lists disabled components when explicitly filtered', function () {
+    Component::factory(3)->enabled()->create();
+    Component::factory(2)->disabled()->create();
+
+    $response = getJson('/status/api/components?per_page=50&filter[enabled]=false');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not show a disabled component by default', function () {
+    $component = Component::factory()->disabled()->create();
+
+    $response = getJson('/status/api/components/'.$component->id);
+
+    $response->assertNotFound();
 });

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -4,6 +4,7 @@ use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
+use Cachet\Models\Incident;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
 
@@ -140,6 +141,8 @@ it('can filter components by enabled', function () {
 });
 
 it('can filter components by disabled', function () {
+    Sanctum::actingAs(User::factory()->create());
+
     Component::factory(20)->disabled()->create();
     $component = Component::factory()->enabled()->create();
 
@@ -541,7 +544,19 @@ it('does not list disabled components by default', function () {
     $response->assertJsonCount(3, 'data');
 });
 
-it('lists disabled components when explicitly filtered', function () {
+it('does not list disabled components to guests even when explicitly filtered', function () {
+    Component::factory(3)->enabled()->create();
+    Component::factory(2)->disabled()->create();
+
+    $response = getJson('/status/api/components?per_page=50&filter[enabled]=false');
+
+    $response->assertOk();
+    $response->assertJsonCount(0, 'data');
+});
+
+it('lists disabled components to authenticated users when explicitly filtered', function () {
+    Sanctum::actingAs(User::factory()->create());
+
     Component::factory(3)->enabled()->create();
     Component::factory(2)->disabled()->create();
 
@@ -551,10 +566,45 @@ it('lists disabled components when explicitly filtered', function () {
     $response->assertJsonCount(2, 'data');
 });
 
-it('does not show a disabled component by default', function () {
+it('does not show a disabled component to guests', function () {
     $component = Component::factory()->disabled()->create();
 
     $response = getJson('/status/api/components/'.$component->id);
 
     $response->assertNotFound();
+});
+
+it('shows a disabled component to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $component = Component::factory()->disabled()->create();
+
+    $response = getJson('/status/api/components/'.$component->id);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.id', $component->id);
+});
+
+it('does not include incidents hidden from guests on visible components', function () {
+    $component = Component::factory()->enabled()->create();
+    $component->incidents()->attach(Incident::factory()->create(['visible' => ResourceVisibilityEnum::guest]));
+    $component->incidents()->attach(Incident::factory()->create(['visible' => ResourceVisibilityEnum::hidden]));
+
+    $response = getJson('/status/api/components/'.$component->id.'?include=incidents');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'included');
+});
+
+it('lists components in authenticated groups to callers presenting a bearer token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('api')->plainTextToken;
+
+    $authGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Component::factory()->create(['component_group_id' => $authGroup->id]);
+
+    $response = getJson('/status/api/components', ['Authorization' => 'Bearer '.$token]);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
 });

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -576,7 +576,8 @@ it('does not reveal component groups hidden from guests through incident include
 
     $included = collect($response->json('included'));
 
-    expect($included->firstWhere('attributes.name', $hiddenGroup->name))->toBeNull();
+    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+        ->and($included->firstWhere('type', 'componentGroups'))->toBeNull();
 });
 
 it('lists authenticated incidents to callers presenting a bearer token', function () {

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
@@ -509,4 +510,56 @@ it('can delete an incident', function () {
     $response = deleteJson('/status/api/incidents/'.$incident->id);
 
     $response->assertNoContent();
+});
+
+it('does not list incidents hidden from guests', function () {
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/incidents');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.visible', ResourceVisibilityEnum::guest->value);
+});
+
+it('lists authenticated incidents to authenticated users but never hidden ones', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/incidents');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not show a hidden incident to guests', function () {
+    $incident = Incident::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id);
+
+    $response->assertNotFound();
+});
+
+it('does not show an authenticated incident to guests', function () {
+    $incident = Incident::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id);
+
+    $response->assertNotFound();
+});
+
+it('shows an authenticated incident to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $incident = Incident::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.id', $incident->id);
 });

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -563,3 +563,32 @@ it('shows an authenticated incident to authenticated users', function () {
     $response->assertOk();
     $response->assertJsonPath('data.attributes.id', $incident->id);
 });
+
+it('does not reveal component groups hidden from guests through incident includes', function () {
+    $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $component = Component::factory()->for($hiddenGroup, 'group')->create();
+    $incident = Incident::factory()->create();
+    $incident->components()->attach($component, ['component_status' => ComponentStatusEnum::partial_outage->value]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id.'?include=components.group');
+
+    $response->assertOk();
+
+    $included = collect($response->json('included'));
+
+    expect($included->firstWhere('attributes.name', $hiddenGroup->name))->toBeNull();
+});
+
+it('lists authenticated incidents to callers presenting a bearer token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('api')->plainTextToken;
+
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Incident::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/incidents', ['Authorization' => 'Bearer '.$token]);
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});

--- a/tests/Feature/Api/IncidentUpdateTest.php
+++ b/tests/Feature/Api/IncidentUpdateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Incident;
 use Cachet\Models\Update;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -273,4 +274,32 @@ it('cannot delete an incident update from another incident', function () {
         'updateable_type' => Relation::getMorphAlias(Incident::class),
         'updateable_id' => $incidentUpdate->updateable_id,
     ]);
+});
+
+it('does not list updates of an incident hidden from guests', function () {
+    $incident = Incident::factory()->hasUpdates(2)->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates");
+
+    $response->assertNotFound();
+});
+
+it('does not show an update of an incident hidden from guests', function () {
+    $incident = Incident::factory()->hasUpdates(1)->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $update = $incident->updates()->first();
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates/{$update->id}");
+
+    $response->assertNotFound();
+});
+
+it('lists updates of an authenticated incident to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $incident = Incident::factory()->hasUpdates(2)->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson("/status/api/incidents/{$incident->id}/updates");
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
 });

--- a/tests/Feature/Api/MetricPointTest.php
+++ b/tests/Feature/Api/MetricPointTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Metric;
 use Cachet\Models\MetricPoint;
 use Laravel\Sanctum\Sanctum;
@@ -164,4 +165,23 @@ it('can delete a metric point', function () {
     $this->assertDatabaseMissing('metric_points', [
         'metric_id' => $metricPoint->metric_id,
     ]);
+});
+
+it('does not list points of a metric hidden from guests', function () {
+    $metric = Metric::factory()->hasMetricPoints(2)->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/metrics/'.$metric->id.'/points');
+
+    $response->assertNotFound();
+});
+
+it('lists points of an authenticated metric to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $metric = Metric::factory()->hasMetricPoints(2)->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson('/status/api/metrics/'.$metric->id.'/points');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
 });

--- a/tests/Feature/Api/MetricPointTest.php
+++ b/tests/Feature/Api/MetricPointTest.php
@@ -185,3 +185,12 @@ it('lists points of an authenticated metric to authenticated users', function ()
     $response->assertOk();
     $response->assertJsonCount(2, 'data');
 });
+
+it('does not show a point of a metric hidden from guests', function () {
+    $metric = Metric::factory()->hasMetricPoints(1)->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $point = $metric->metricPoints()->first();
+
+    $response = getJson('/status/api/metrics/'.$metric->id.'/points/'.$point->id);
+
+    $response->assertNotFound();
+});

--- a/tests/Feature/Api/MetricTest.php
+++ b/tests/Feature/Api/MetricTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\MetricTypeEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Metric;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -328,4 +329,47 @@ it('can delete metric', function () {
     $this->assertDatabaseMissing('metric_points', [
         'metric_id' => $metric->id,
     ]);
+});
+
+it('does not list metrics hidden from guests', function () {
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/metrics');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+});
+
+it('lists authenticated metrics to authenticated users but never hidden ones', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/metrics');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not show a hidden metric to guests', function () {
+    $metric = Metric::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/metrics/'.$metric->id);
+
+    $response->assertNotFound();
+});
+
+it('shows an authenticated metric to authenticated users', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $metric = Metric::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+
+    $response = getJson('/status/api/metrics/'.$metric->id);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.id', $metric->id);
 });

--- a/tests/Feature/Api/MetricTest.php
+++ b/tests/Feature/Api/MetricTest.php
@@ -373,3 +373,17 @@ it('shows an authenticated metric to authenticated users', function () {
     $response->assertOk();
     $response->assertJsonPath('data.attributes.id', $metric->id);
 });
+
+it('lists authenticated metrics to callers presenting a bearer token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('api')->plainTextToken;
+
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::guest]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::authenticated]);
+    Metric::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+
+    $response = getJson('/status/api/metrics', ['Authorization' => 'Bearer '.$token]);
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
@@ -480,4 +481,19 @@ it('can delete a schedule', function () {
     $this->assertSoftDeleted('schedules', [
         'id' => $schedule->id,
     ]);
+});
+
+it('does not reveal component groups hidden from guests through schedule includes', function () {
+    $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $component = Component::factory()->for($hiddenGroup, 'group')->create();
+    $schedule = Schedule::factory()->create();
+    $schedule->components()->attach($component, ['component_status' => ComponentStatusEnum::under_maintenance->value]);
+
+    $response = getJson('/status/api/schedules/'.$schedule->id.'?include=components.group');
+
+    $response->assertOk();
+
+    $included = collect($response->json('included'));
+
+    expect($included->firstWhere('attributes.name', $hiddenGroup->name))->toBeNull();
 });

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -495,5 +495,6 @@ it('does not reveal component groups hidden from guests through schedule include
 
     $included = collect($response->json('included'));
 
-    expect($included->firstWhere('attributes.name', $hiddenGroup->name))->toBeNull();
+    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+        ->and($included->firstWhere('type', 'componentGroups'))->toBeNull();
 });


### PR DESCRIPTION
## Summary

The public JSON API `index`/`show` endpoints never applied the `HasVisibility` scopes that the web status page and RSS feed use. Any unauthenticated caller could list and read incidents, metrics and component groups marked `authenticated`-only or `hidden`. Fixes **GHSA-6ghm-wf22-pvx5** (CWE-862, CVSS 7.5).

## What changed

- **Incident / Metric / ComponentGroup** `index` + `show`: apply `->visible(auth()->check())`; `show` now returns **404** for out-of-scope records instead of leaking them.
- **Component** `index` + `show`: components have no visibility column — they inherit it from their group. Scoped by group visibility (`whereNull('component_group_id')` OR group is visible), so ungrouped components stay public, matching the status page. Also **hides `disabled` components by default** with an opt-in `filter[enabled]=false`; `show` 404s disabled components.
- **Nested controllers** (`IncidentUpdate`, `MetricPoint`): gated on the parent's visibility so children of hidden/auth-only parents 404.
- **`ComponentGroupFactory`**: fixed a latent bug where `visible` was set from `ComponentGroupVisibilityEnum::expanded` (value `0`), which under the `ResourceVisibilityEnum` cast means `authenticated`. Default is now `guest`.
- **Tests**: added API visibility regression coverage (none existed) across every affected endpoint — guest sees only `guest`; authenticated sees `authenticated`+`guest`; `hidden` never; ungrouped components stay public; disabled hidden-by-default but reachable via filter; nested children respect parent visibility.

## Not affected

`Schedule` / `ScheduleUpdateController` have no visibility concept and are unchanged. The advisory's inclusion of `components`/`schedules` in the "identical pattern" list is partially inaccurate: Schedule has no `visible` column, and Component's leak is via its group rather than a column of its own.

## Verification

- Full suite green (476 tests), PHPStan clean, Pint clean.

> [!WARNING]
> Draft: this is a public PR for an unpatched advisory, so the diff discloses the vulnerability. Coordinate with the release/advisory before marking ready.