### PR TITLE
Redesign the dashboard

### DIFF
--- a/resources/lang/de/cachet.php
+++ b/resources/lang/de/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Cachet unterstützen',
         'consider_supporting' => 'Bitte erwäge, Cachet über GitHub-Sponsoren zu unterstützen.',
         'keep_up_to_date' => 'Bleibe über die aktuellsten Nachrichten und Veröffentlichungen auf dem Laufenden, indem Du dem *Cachet-Blog* folgst.',
-        'work_in_progress_text' => 'Cachet befindet sich in der aktiven Entwicklung. Änderungen sind noch vorbehalten.',
     ],
     'feed' => [
         'section_heading' => 'Aktuellste Blogbeiträge',

--- a/resources/lang/de/component.php
+++ b/resources/lang/de/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => 'Wartungsarbeiten',
         'unknown' => 'Unbekannt',
     ],
+    'overview' => [
+        'operational_components_label' => 'Funktionsfähige Komponenten',
+        'operational_components_description' => 'Komponenten, die voll funktionsfähig sind.',
+    ],
 
 ];

--- a/resources/lang/de/dashboard.php
+++ b/resources/lang/de/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Es wurden noch keine Komponenten konfiguriert.',
+        'add_component' => 'Komponente hinzufügen',
+    ],
+    'open_incidents' => [
+        'heading' => 'Offene Vorfälle',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'occurred_at' => 'Aufgetreten',
+            'components' => 'Betroffene Komponenten',
+        ],
+        'actions' => [
+            'create' => 'Vorfall erstellen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine offenen Vorfälle',
+            'description' => 'Alles in Ordnung. Vorfälle, die noch nicht behoben wurden, werden hier angezeigt.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Wartung',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'scheduled_at' => 'Terminiert für',
+        ],
+        'actions' => [
+            'create' => 'Wartung planen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine geplante Wartung',
+            'description' => 'Anstehende und laufende Wartungsfenster werden hier angezeigt.',
+        ],
+    ],
+];

--- a/resources/lang/de/incident.php
+++ b/resources/lang/de/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Vorfälle insgesamt',
-        'total_incidents_description' => 'Anzahl aller Vorfälle',
+        'open_incidents_label' => 'Offene Vorfälle',
+        'open_incidents_description' => 'Vorfälle, die noch nicht behoben wurden.',
     ],
 ];

--- a/resources/lang/de/subscriber.php
+++ b/resources/lang/de/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Abonnenten insgesamt',
-        'total_subscribers_description' => 'Anzahl aller Abonnenten',
+        'verified_subscribers_description' => ':count verifiziert',
     ],
 ];

--- a/resources/lang/de_AT/cachet.php
+++ b/resources/lang/de_AT/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Cachet unterstützen',
         'consider_supporting' => 'Bitte erwäge, Cachet über GitHub-Sponsoren zu unterstützen.',
         'keep_up_to_date' => 'Bleibe über die aktuellsten Nachrichten und Veröffentlichungen auf dem Laufenden, indem Du dem *Cachet-Blog* folgst.',
-        'work_in_progress_text' => 'Cachet befindet sich in der aktiven Entwicklung. Änderungen sind noch vorbehalten.',
     ],
     'feed' => [
         'section_heading' => 'Aktuellste Blogbeiträge',

--- a/resources/lang/de_AT/component.php
+++ b/resources/lang/de_AT/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => 'Wartungsarbeiten',
         'unknown' => 'Unbekannt',
     ],
+    'overview' => [
+        'operational_components_label' => 'Funktionsfähige Komponenten',
+        'operational_components_description' => 'Komponenten, die voll funktionsfähig sind.',
+    ],
 
 ];

--- a/resources/lang/de_AT/dashboard.php
+++ b/resources/lang/de_AT/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Es wurden noch keine Komponenten konfiguriert.',
+        'add_component' => 'Komponente hinzufügen',
+    ],
+    'open_incidents' => [
+        'heading' => 'Offene Vorfälle',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'occurred_at' => 'Aufgetreten',
+            'components' => 'Betroffene Komponenten',
+        ],
+        'actions' => [
+            'create' => 'Vorfall erstellen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine offenen Vorfälle',
+            'description' => 'Alles in Ordnung. Vorfälle, die noch nicht behoben wurden, werden hier angezeigt.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Wartung',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'scheduled_at' => 'Terminiert für',
+        ],
+        'actions' => [
+            'create' => 'Wartung planen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine geplante Wartung',
+            'description' => 'Anstehende und laufende Wartungsfenster werden hier angezeigt.',
+        ],
+    ],
+];

--- a/resources/lang/de_AT/incident.php
+++ b/resources/lang/de_AT/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Vorfälle insgesamt',
-        'total_incidents_description' => 'Anzahl aller Vorfälle',
+        'open_incidents_label' => 'Offene Vorfälle',
+        'open_incidents_description' => 'Vorfälle, die noch nicht behoben wurden.',
     ],
 ];

--- a/resources/lang/de_AT/subscriber.php
+++ b/resources/lang/de_AT/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Abonnenten insgesamt',
-        'total_subscribers_description' => 'Anzahl aller Abonnenten',
+        'verified_subscribers_description' => ':count verifiziert',
     ],
 ];

--- a/resources/lang/de_CH/cachet.php
+++ b/resources/lang/de_CH/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Cachet unterstützen',
         'consider_supporting' => 'Bitte erwäge, Cachet über GitHub-Sponsoren zu unterstützen.',
         'keep_up_to_date' => 'Bleibe über die aktuellsten Nachrichten und Veröffentlichungen auf dem Laufenden, indem Du dem *Cachet-Blog* folgst.',
-        'work_in_progress_text' => 'Cachet befindet sich in der aktiven Entwicklung. Änderungen sind noch vorbehalten.',
     ],
     'feed' => [
         'section_heading' => 'Aktuellste Blogbeiträge',

--- a/resources/lang/de_CH/component.php
+++ b/resources/lang/de_CH/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => 'Wartungsarbeiten',
         'unknown' => 'Unbekannt',
     ],
+    'overview' => [
+        'operational_components_label' => 'Funktionsfähige Komponenten',
+        'operational_components_description' => 'Komponenten, die voll funktionsfähig sind.',
+    ],
 
 ];

--- a/resources/lang/de_CH/dashboard.php
+++ b/resources/lang/de_CH/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Es wurden noch keine Komponenten konfiguriert.',
+        'add_component' => 'Komponente hinzufügen',
+    ],
+    'open_incidents' => [
+        'heading' => 'Offene Vorfälle',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'occurred_at' => 'Aufgetreten',
+            'components' => 'Betroffene Komponenten',
+        ],
+        'actions' => [
+            'create' => 'Vorfall erstellen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine offenen Vorfälle',
+            'description' => 'Alles in Ordnung. Vorfälle, die noch nicht behoben wurden, werden hier angezeigt.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Wartung',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'scheduled_at' => 'Terminiert für',
+        ],
+        'actions' => [
+            'create' => 'Wartung planen',
+        ],
+        'empty_state' => [
+            'heading' => 'Keine geplante Wartung',
+            'description' => 'Anstehende und laufende Wartungsfenster werden hier angezeigt.',
+        ],
+    ],
+];

--- a/resources/lang/de_CH/incident.php
+++ b/resources/lang/de_CH/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Vorfälle insgesamt',
-        'total_incidents_description' => 'Anzahl aller Vorfälle',
+        'open_incidents_label' => 'Offene Vorfälle',
+        'open_incidents_description' => 'Vorfälle, die noch nicht behoben wurden.',
     ],
 ];

--- a/resources/lang/de_CH/subscriber.php
+++ b/resources/lang/de_CH/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Abonnenten insgesamt',
-        'total_subscribers_description' => 'Anzahl aller Abonnenten',
+        'verified_subscribers_description' => ':count verifiziert',
     ],
 ];

--- a/resources/lang/en/cachet.php
+++ b/resources/lang/en/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Support Cachet',
         'consider_supporting' => 'Please consider supporting Cachet via *GitHub Sponsors*.',
         'keep_up_to_date' => 'Keep up to date with the latest news and releases by following the *Cachet blog*.',
-        'work_in_progress_text' => 'Cachet is under active development. Things are still subject to change.',
     ],
     'feed' => [
         'section_heading' => 'Latest Blog Posts',

--- a/resources/lang/en/component.php
+++ b/resources/lang/en/component.php
@@ -39,6 +39,10 @@ return [
         'under_maintenance' => 'Under maintenance',
         'unknown' => 'Unknown',
     ],
+    'overview' => [
+        'operational_components_label' => 'Operational Components',
+        'operational_components_description' => 'Components that are fully operational.',
+    ],
     'checks' => [
         'title' => 'Recent checks',
         'empty_state' => [

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'No components have been configured yet.',
+        'add_component' => 'Add a component',
+    ],
+    'open_incidents' => [
+        'heading' => 'Open Incidents',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'occurred_at' => 'Occurred',
+            'components' => 'Affected components',
+        ],
+        'actions' => [
+            'create' => 'Create Incident',
+        ],
+        'empty_state' => [
+            'heading' => 'No open incidents',
+            'description' => 'All clear. Incidents that have not been fixed will show up here.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Maintenance',
+        'headers' => [
+            'name' => 'Name',
+            'status' => 'Status',
+            'scheduled_at' => 'Scheduled for',
+        ],
+        'actions' => [
+            'create' => 'Schedule Maintenance',
+        ],
+        'empty_state' => [
+            'heading' => 'No scheduled maintenance',
+            'description' => 'Upcoming and in-progress maintenance windows will show up here.',
+        ],
+    ],
+];

--- a/resources/lang/en/incident.php
+++ b/resources/lang/en/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Total Incidents',
-        'total_incidents_description' => 'Total number of incidents.',
+        'open_incidents_label' => 'Open Incidents',
+        'open_incidents_description' => 'Incidents that have not been fixed.',
     ],
 ];

--- a/resources/lang/en/subscriber.php
+++ b/resources/lang/en/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Total Subscribers',
-        'total_subscribers_description' => 'Total number of subscribers.',
+        'verified_subscribers_description' => ':count verified',
     ],
 ];

--- a/resources/lang/es_ES/cachet.php
+++ b/resources/lang/es_ES/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Soporte de Cachet',
         'consider_supporting' => 'Por favor, considera apoyar Cachet a través de *GitHub Sponsors*.',
         'keep_up_to_date' => 'Mantente al día con las últimas noticias y versiones siguiendo el *blog de Cachet*.',
-        'work_in_progress_text' => 'Cachet está en desarrollo activo. Las cosas aún pueden cambiar.',
     ],
     'feed' => [
         'section_heading' => 'Últimas entradas del blog',

--- a/resources/lang/es_ES/component.php
+++ b/resources/lang/es_ES/component.php
@@ -36,4 +36,8 @@ return [
         'under_maintenance' => 'En mantenimiento',
         'unknown' => 'Desconocido',
     ],
+    'overview' => [
+        'operational_components_label' => 'Componentes Operativos',
+        'operational_components_description' => 'Componentes que están totalmente operativos.',
+    ],
 ];

--- a/resources/lang/es_ES/dashboard.php
+++ b/resources/lang/es_ES/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Aún no se ha configurado ningún componente.',
+        'add_component' => 'Añadir un componente',
+    ],
+    'open_incidents' => [
+        'heading' => 'Incidentes Abiertos',
+        'headers' => [
+            'name' => 'Nombre',
+            'status' => 'Estado',
+            'occurred_at' => 'Ocurrido el',
+            'components' => 'Componentes afectados',
+        ],
+        'actions' => [
+            'create' => 'Crear Incidente',
+        ],
+        'empty_state' => [
+            'heading' => 'No hay incidentes abiertos',
+            'description' => 'Todo en orden. Los incidentes que no hayan sido solucionados aparecerán aquí.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Mantenimiento',
+        'headers' => [
+            'name' => 'Nombre',
+            'status' => 'Estado',
+            'scheduled_at' => 'Programado para',
+        ],
+        'actions' => [
+            'create' => 'Programar Mantenimiento',
+        ],
+        'empty_state' => [
+            'heading' => 'No hay mantenimientos programados',
+            'description' => 'Los mantenimientos próximos y en progreso aparecerán aquí.',
+        ],
+    ],
+];

--- a/resources/lang/es_ES/incident.php
+++ b/resources/lang/es_ES/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Total de Incidentes',
-        'total_incidents_description' => 'Número total de incidentes.',
+        'open_incidents_label' => 'Incidentes Abiertos',
+        'open_incidents_description' => 'Incidentes que no han sido solucionados.',
     ],
 ];

--- a/resources/lang/es_ES/subscriber.php
+++ b/resources/lang/es_ES/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Total de Suscriptores',
-        'total_subscribers_description' => 'Número total de suscriptores.',
+        'verified_subscribers_description' => ':count verificados',
     ],
 ];

--- a/resources/lang/fr/cachet.php
+++ b/resources/lang/fr/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Support de Cachet',
         'consider_supporting' => 'Veuillez envisager de soutenir Cachet via *GitHub Sponsors*.',
         'keep_up_to_date' => 'Restez informé des dernières nouvelles et mises à jour en suivant le *blog de Cachet*.',
-        'work_in_progress_text' => 'Cachet est en cours de développement actif. Des modifications peuvent encore survenir.',
     ],
     'feed' => [
         'section_heading' => 'Derniers articles',

--- a/resources/lang/fr/component.php
+++ b/resources/lang/fr/component.php
@@ -36,4 +36,8 @@ return [
         'under_maintenance' => 'En maintenance',
         'unknown' => 'Inconnu',
     ],
+    'overview' => [
+        'operational_components_label' => 'Composants opérationnels',
+        'operational_components_description' => 'Composants entièrement opérationnels.',
+    ],
 ];

--- a/resources/lang/fr/dashboard.php
+++ b/resources/lang/fr/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Aucun composant n’a encore été configuré.',
+        'add_component' => 'Ajouter un composant',
+    ],
+    'open_incidents' => [
+        'heading' => 'Incidents ouverts',
+        'headers' => [
+            'name' => 'Nom',
+            'status' => 'Statut',
+            'occurred_at' => 'Survenu le',
+            'components' => 'Composants affectés',
+        ],
+        'actions' => [
+            'create' => 'Créer un incident',
+        ],
+        'empty_state' => [
+            'heading' => 'Aucun incident ouvert',
+            'description' => 'Tout va bien. Les incidents qui n’ont pas été résolus s’afficheront ici.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Maintenance',
+        'headers' => [
+            'name' => 'Nom',
+            'status' => 'Statut',
+            'scheduled_at' => 'Planifié le',
+        ],
+        'actions' => [
+            'create' => 'Planifier une maintenance',
+        ],
+        'empty_state' => [
+            'heading' => 'Aucune maintenance planifiée',
+            'description' => 'Les maintenances à venir et en cours s’afficheront ici.',
+        ],
+    ],
+];

--- a/resources/lang/fr/incident.php
+++ b/resources/lang/fr/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Nombre total d’incidents',
-        'total_incidents_description' => 'Nombre total d’incidents signalés.',
+        'open_incidents_label' => 'Incidents ouverts',
+        'open_incidents_description' => 'Incidents qui n’ont pas été résolus.',
     ],
 ];

--- a/resources/lang/fr/subscriber.php
+++ b/resources/lang/fr/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Nombre total d’abonnés',
-        'total_subscribers_description' => 'Nombre total d’abonnés.',
+        'verified_subscribers_description' => ':count vérifiés',
     ],
 ];

--- a/resources/lang/ko/cachet.php
+++ b/resources/lang/ko/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Cachet 지원',
         'consider_supporting' => '*GitHub 스폰서*를 통해 Cachet를 지원해 주세요.',
         'keep_up_to_date' => '*Cachet 블로그*를 팔로우하여 최신 뉴스와 릴리스 정보를 확인하세요.',
-        'work_in_progress_text' => 'Cachet는 활발히 개발 중입니다. 아직 변경될 수 있는 부분이 있습니다.',
     ],
     'feed' => [
         'section_heading' => '최신 블로그 게시물',

--- a/resources/lang/ko/component.php
+++ b/resources/lang/ko/component.php
@@ -36,4 +36,8 @@ return [
         'under_maintenance' => '유지보수 중',
         'unknown' => '알 수 없음',
     ],
+    'overview' => [
+        'operational_components_label' => '정상 작동 중인 구성 요소',
+        'operational_components_description' => '완전히 정상 작동 중인 구성 요소입니다.',
+    ],
 ];

--- a/resources/lang/ko/dashboard.php
+++ b/resources/lang/ko/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => '아직 구성된 구성 요소가 없습니다.',
+        'add_component' => '구성 요소 추가',
+    ],
+    'open_incidents' => [
+        'heading' => '진행 중인 사고',
+        'headers' => [
+            'name' => '이름',
+            'status' => '상태',
+            'occurred_at' => '발생 시간',
+            'components' => '영향받는 구성 요소',
+        ],
+        'actions' => [
+            'create' => '사고 생성',
+        ],
+        'empty_state' => [
+            'heading' => '진행 중인 사고 없음',
+            'description' => '모두 정상입니다. 아직 해결되지 않은 사고가 여기에 표시됩니다.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => '유지보수',
+        'headers' => [
+            'name' => '이름',
+            'status' => '상태',
+            'scheduled_at' => '예정 시간',
+        ],
+        'actions' => [
+            'create' => '유지보수 일정 잡기',
+        ],
+        'empty_state' => [
+            'heading' => '예정된 유지보수 없음',
+            'description' => '예정되었거나 진행 중인 유지보수가 여기에 표시됩니다.',
+        ],
+    ],
+];

--- a/resources/lang/ko/incident.php
+++ b/resources/lang/ko/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => '총 사고 수',
-        'total_incidents_description' => '총 사고 수입니다.',
+        'open_incidents_label' => '진행 중인 사고',
+        'open_incidents_description' => '아직 해결되지 않은 사고입니다.',
     ],
 ];

--- a/resources/lang/ko/subscriber.php
+++ b/resources/lang/ko/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => '총 구독자 수',
-        'total_subscribers_description' => '총 구독자 수입니다.',
+        'verified_subscribers_description' => ':count명 인증됨',
     ],
 ];

--- a/resources/lang/nl/cachet.php
+++ b/resources/lang/nl/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Ondersteuning Cachet',
         'consider_supporting' => 'Overweeg Cachet te steunen via GitHub Sponsors.',
         'keep_up_to_date' => 'Blijf op de hoogte van het laatste nieuws en de nieuwste releases door de *Cachet-Blog* te volgen.',
-        'work_in_progress_text' => 'Cachet is in actieve ontwikkeling. Onder voorbehoud van wijzigingen.',
     ],
     'powered_by' => 'Ondersteund door',
     'open_source_status_page' => 'De open source-statuspagina.',

--- a/resources/lang/nl/component.php
+++ b/resources/lang/nl/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => 'In onderhoud',
         'unknown' => 'Onbekend',
     ],
+    'overview' => [
+        'operational_components_label' => 'Functionele componenten',
+        'operational_components_description' => 'Componenten die volledig functioneel zijn.',
+    ],
 
 ];

--- a/resources/lang/nl/dashboard.php
+++ b/resources/lang/nl/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Er zijn nog geen componenten geconfigureerd.',
+        'add_component' => 'Component toevoegen',
+    ],
+    'open_incidents' => [
+        'heading' => 'Openstaande incidenten',
+        'headers' => [
+            'name' => 'Naam',
+            'status' => 'Toestand',
+            'occurred_at' => 'Voorgekomen op',
+            'components' => 'Getroffen componenten',
+        ],
+        'actions' => [
+            'create' => 'Incident toevoegen',
+        ],
+        'empty_state' => [
+            'heading' => 'Geen openstaande incidenten',
+            'description' => 'Alles in orde. Incidenten die nog niet zijn opgelost, worden hier weergegeven.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Onderhoud',
+        'headers' => [
+            'name' => 'Naam',
+            'status' => 'Toestand',
+            'scheduled_at' => 'Gepland voor',
+        ],
+        'actions' => [
+            'create' => 'Onderhoud plannen',
+        ],
+        'empty_state' => [
+            'heading' => 'Geen gepland onderhoud',
+            'description' => 'Aankomend en actief onderhoud wordt hier weergegeven.',
+        ],
+    ],
+];

--- a/resources/lang/nl/incident.php
+++ b/resources/lang/nl/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Incidenten in totaal',
-        'total_incidents_description' => 'Aantal van alle incidenten',
+        'open_incidents_label' => 'Openstaande incidenten',
+        'open_incidents_description' => 'Incidenten die nog niet zijn opgelost.',
     ],
 ];

--- a/resources/lang/nl/subscriber.php
+++ b/resources/lang/nl/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Totaal aantal abonnees',
-        'total_subscribers_description' => 'Aantal van alle abonnees',
+        'verified_subscribers_description' => ':count geverifieerd',
     ],
 ];

--- a/resources/lang/ph/cachet.php
+++ b/resources/lang/ph/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Suporta sa Cachet',
         'consider_supporting' => 'Pakisuportahan ang Cachet sa pamamagitan ng *GitHub Sponsors*.',
         'keep_up_to_date' => 'Manatiling updated sa mga balita at release sa pamamagitan ng pagsubaybay sa *Cachet blog*.',
-        'work_in_progress_text' => 'Ang Cachet ay patuloy na ina-update. Maaaring magbago pa ang ilang bagay.',
     ],
     'powered_by' => 'Pinatatakbo ng',
     'open_source_status_page' => 'Ang open-source status page.',

--- a/resources/lang/ph/component.php
+++ b/resources/lang/ph/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => 'Nasa ilalim ng maintenance',
         'unknown' => 'Hindi Alam',
     ],
+    'overview' => [
+        'operational_components_label' => 'Mga Gumaganang Komponent',
+        'operational_components_description' => 'Mga komponent na ganap na gumagana.',
+    ],
 
 ];

--- a/resources/lang/ph/dashboard.php
+++ b/resources/lang/ph/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Wala pang naka-configure na komponent.',
+        'add_component' => 'Magdagdag ng komponent',
+    ],
+    'open_incidents' => [
+        'heading' => 'Mga Bukas na Insidente',
+        'headers' => [
+            'name' => 'Pangalan',
+            'status' => 'Kalagayan',
+            'occurred_at' => 'Nangyari noong',
+            'components' => 'Mga apektadong komponent',
+        ],
+        'actions' => [
+            'create' => 'Gumawa ng Insidente',
+        ],
+        'empty_state' => [
+            'heading' => 'Walang bukas na insidente',
+            'description' => 'Maayos ang lahat. Ang mga insidenteng hindi pa naaayos ay lalabas dito.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Maintenance',
+        'headers' => [
+            'name' => 'Pangalan',
+            'status' => 'Kalagayan',
+            'scheduled_at' => 'Naka-iskedyul sa',
+        ],
+        'actions' => [
+            'create' => 'Mag-iskedyul ng Maintenance',
+        ],
+        'empty_state' => [
+            'heading' => 'Walang naka-iskedyul na maintenance',
+            'description' => 'Ang mga darating at isinasagawang maintenance ay lalabas dito.',
+        ],
+    ],
+];

--- a/resources/lang/ph/incident.php
+++ b/resources/lang/ph/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Kabuuang Insidente',
-        'total_incidents_description' => 'Kabuuang bilang ng mga insidente.',
+        'open_incidents_label' => 'Mga Bukas na Insidente',
+        'open_incidents_description' => 'Mga insidenteng hindi pa naaayos.',
     ],
 ];

--- a/resources/lang/ph/subscriber.php
+++ b/resources/lang/ph/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Kabuuang mga Subscriber',
-        'total_subscribers_description' => 'Kabuuang bilang ng mga subscriber.',
+        'verified_subscribers_description' => ':count ang nakumpirma',
     ],
 ];

--- a/resources/lang/pt_BR/cachet.php
+++ b/resources/lang/pt_BR/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => 'Apoiar o Cachet',
         'consider_supporting' => 'Por favor, considere apoiar o Cachet via *GitHub Sponsors*.',
         'keep_up_to_date' => 'Mantenha-se atualizado com as últimas notícias e lançamentos seguindo o *blog do Cachet*.',
-        'work_in_progress_text' => 'O Cachet está em desenvolvimento ativo. As coisas ainda estão sujeitas a mudanças.',
     ],
     'powered_by' => 'Powered by',
     'open_source_status_page' => 'The open-source status page.',

--- a/resources/lang/pt_BR/component.php
+++ b/resources/lang/pt_BR/component.php
@@ -36,4 +36,8 @@ return [
         'under_maintenance' => 'Em manutenção',
         'unknown' => 'Desconhecido',
     ],
+    'overview' => [
+        'operational_components_label' => 'Componentes Operacionais',
+        'operational_components_description' => 'Componentes que estão totalmente operacionais.',
+    ],
 ];

--- a/resources/lang/pt_BR/dashboard.php
+++ b/resources/lang/pt_BR/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => 'Nenhum componente foi configurado ainda.',
+        'add_component' => 'Adicionar um componente',
+    ],
+    'open_incidents' => [
+        'heading' => 'Incidentes Abertos',
+        'headers' => [
+            'name' => 'Nome',
+            'status' => 'Status',
+            'occurred_at' => 'Ocorrido em',
+            'components' => 'Componentes afetados',
+        ],
+        'actions' => [
+            'create' => 'Criar Incidente',
+        ],
+        'empty_state' => [
+            'heading' => 'Nenhum incidente aberto',
+            'description' => 'Tudo certo. Incidentes que não foram resolvidos aparecerão aqui.',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => 'Manutenção',
+        'headers' => [
+            'name' => 'Nome',
+            'status' => 'Status',
+            'scheduled_at' => 'Agendado para',
+        ],
+        'actions' => [
+            'create' => 'Agendar Manutenção',
+        ],
+        'empty_state' => [
+            'heading' => 'Nenhuma manutenção agendada',
+            'description' => 'Manutenções futuras e em andamento aparecerão aqui.',
+        ],
+    ],
+];

--- a/resources/lang/pt_BR/incident.php
+++ b/resources/lang/pt_BR/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => 'Total de Incidentes',
-        'total_incidents_description' => 'Número total de incidentes.',
+        'open_incidents_label' => 'Incidentes Abertos',
+        'open_incidents_description' => 'Incidentes que não foram resolvidos.',
     ],
 ];

--- a/resources/lang/pt_BR/subscriber.php
+++ b/resources/lang/pt_BR/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => 'Total de Inscritos',
-        'total_subscribers_description' => 'Número total de inscritos.',
+        'verified_subscribers_description' => ':count verificados',
     ],
 ];

--- a/resources/lang/zh_CN/cachet.php
+++ b/resources/lang/zh_CN/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => '支持 Cachet',
         'consider_supporting' => '请考虑通过 *GitHub Sponsors* 支持 Cachet。',
         'keep_up_to_date' => '通过关注 *Cachet 博客* 了解最新的新闻和发布信息。',
-        'work_in_progress_text' => 'Cachet 正在积极开发中。某些内容可能会发生变化。',
     ],
     'powered_by' => '技术支持',
     'open_source_status_page' => '开源的状态页面。',

--- a/resources/lang/zh_CN/component.php
+++ b/resources/lang/zh_CN/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => '维护中',
         'unknown' => '未知',
     ],
+    'overview' => [
+        'operational_components_label' => '正常运行的组件',
+        'operational_components_description' => '完全正常运行的组件。',
+    ],
 
 ];

--- a/resources/lang/zh_CN/dashboard.php
+++ b/resources/lang/zh_CN/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => '尚未配置任何组件。',
+        'add_component' => '添加组件',
+    ],
+    'open_incidents' => [
+        'heading' => '未解决的事件',
+        'headers' => [
+            'name' => '名称',
+            'status' => '状态',
+            'occurred_at' => '发生时间',
+            'components' => '受影响的组件',
+        ],
+        'actions' => [
+            'create' => '创建事件',
+        ],
+        'empty_state' => [
+            'heading' => '没有未解决的事件',
+            'description' => '一切正常。尚未修复的事件将显示在这里。',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => '维护',
+        'headers' => [
+            'name' => '名称',
+            'status' => '状态',
+            'scheduled_at' => '预定时间',
+        ],
+        'actions' => [
+            'create' => '安排维护',
+        ],
+        'empty_state' => [
+            'heading' => '没有计划的维护',
+            'description' => '即将进行和进行中的维护将显示在这里。',
+        ],
+    ],
+];

--- a/resources/lang/zh_CN/incident.php
+++ b/resources/lang/zh_CN/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => '总事件数',
-        'total_incidents_description' => '事件的总数。',
+        'open_incidents_label' => '未解决的事件',
+        'open_incidents_description' => '尚未修复的事件。',
     ],
 ];

--- a/resources/lang/zh_CN/subscriber.php
+++ b/resources/lang/zh_CN/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => '总订阅者数',
-        'total_subscribers_description' => '订阅者的总数。',
+        'verified_subscribers_description' => ':count 位已验证',
     ],
 ];

--- a/resources/lang/zh_TW/cachet.php
+++ b/resources/lang/zh_TW/cachet.php
@@ -5,7 +5,6 @@ return [
         'section_heading' => '支援 Cachet',
         'consider_supporting' => '請考慮通過 *GitHub 贊助者* 支援 Cachet。',
         'keep_up_to_date' => '透過關注 *Cachet 部落格* 瞭解最新的新聞和發佈資訊。',
-        'work_in_progress_text' => 'Cachet 正在積極開發中。某些內容可能會發生變化。',
     ],
     'powered_by' => '技術支援',
     'open_source_status_page' => '開源的狀態頁面。',

--- a/resources/lang/zh_TW/component.php
+++ b/resources/lang/zh_TW/component.php
@@ -36,5 +36,9 @@ return [
         'under_maintenance' => '維護中',
         'unknown' => '未知',
     ],
+    'overview' => [
+        'operational_components_label' => '正常運行的組件',
+        'operational_components_description' => '完全正常運行的組件。',
+    ],
 
 ];

--- a/resources/lang/zh_TW/dashboard.php
+++ b/resources/lang/zh_TW/dashboard.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'system_health' => [
+        'empty' => '尚未配置任何組件。',
+        'add_component' => '添加組件',
+    ],
+    'open_incidents' => [
+        'heading' => '未解決的事件',
+        'headers' => [
+            'name' => '名稱',
+            'status' => '狀態',
+            'occurred_at' => '發生時間',
+            'components' => '受影響的元件',
+        ],
+        'actions' => [
+            'create' => '創建事件',
+        ],
+        'empty_state' => [
+            'heading' => '沒有未解決的事件',
+            'description' => '一切正常。尚未修復的事件將顯示在這裡。',
+        ],
+    ],
+    'upcoming_maintenance' => [
+        'heading' => '維護',
+        'headers' => [
+            'name' => '名稱',
+            'status' => '狀態',
+            'scheduled_at' => '預定時間',
+        ],
+        'actions' => [
+            'create' => '安排維護',
+        ],
+        'empty_state' => [
+            'heading' => '沒有計劃的維護',
+            'description' => '即將進行和進行中的維護將顯示在這裡。',
+        ],
+    ],
+];

--- a/resources/lang/zh_TW/incident.php
+++ b/resources/lang/zh_TW/incident.php
@@ -75,7 +75,7 @@ return [
         ],
     ],
     'overview' => [
-        'total_incidents_label' => '總事件數',
-        'total_incidents_description' => '事件的總數。',
+        'open_incidents_label' => '未解決的事件',
+        'open_incidents_description' => '尚未修復的事件。',
     ],
 ];

--- a/resources/lang/zh_TW/subscriber.php
+++ b/resources/lang/zh_TW/subscriber.php
@@ -29,6 +29,6 @@ return [
     ],
     'overview' => [
         'total_subscribers_label' => '總訂閱者數',
-        'total_subscribers_description' => '訂閱者的總數。',
+        'verified_subscribers_description' => ':count 位已驗證',
     ],
 ];

--- a/resources/views/filament/widgets/support.blade.php
+++ b/resources/views/filament/widgets/support.blade.php
@@ -6,9 +6,6 @@
         <p class="text-sm leading-6 text-gray-500 dark:text-gray-400">
             {!! $keepUpToDate !!}
         </p>
-        <p class="text-sm leading-6 text-gray-500 dark:text-gray-400 font-semibold">
-            {{ __('cachet::cachet.support.work_in_progress_text') }}
-        </p>
     </x-filament::section>
 </x-filament-widgets::widget>
 

--- a/resources/views/filament/widgets/system-health.blade.php
+++ b/resources/views/filament/widgets/system-health.blade.php
@@ -1,0 +1,39 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        <div @if ($pollingInterval) wire:poll.{{ $pollingInterval }} @endif>
+            @if ($totalComponents === 0)
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('cachet::dashboard.system_health.empty') }}
+                    </p>
+
+                    <x-filament::link :href="$createComponentUrl">
+                        {{ __('cachet::dashboard.system_health.add_component') }}
+                    </x-filament::link>
+                </div>
+            @else
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="flex items-center gap-3">
+                        <x-filament::icon
+                            :icon="$systemStatus->getIcon()"
+                            class="h-9 w-9 shrink-0"
+                            style="color: {{ $systemStatus->getColor()[500] }}"
+                        />
+
+                        <h2 class="text-lg font-semibold text-gray-950 dark:text-white">
+                            {{ $systemStatus->getLabel() }}
+                        </h2>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-2">
+                        @foreach ($statusCounts as $item)
+                            <x-filament::badge :color="$item['status']->getColor()" :icon="$item['status']->getIcon()">
+                                {{ $item['count'] }} {{ $item['status']->getLabel() }}
+                            </x-filament::badge>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/Filament/Pages/Dashboard.php
+++ b/src/Filament/Pages/Dashboard.php
@@ -2,7 +2,32 @@
 
 namespace Cachet\Filament\Pages;
 
+use Cachet\Filament\Widgets\Components;
+use Cachet\Filament\Widgets\Feed;
+use Cachet\Filament\Widgets\OpenIncidents;
+use Cachet\Filament\Widgets\Overview;
+use Cachet\Filament\Widgets\Support;
+use Cachet\Filament\Widgets\SystemHealth;
+use Cachet\Filament\Widgets\UpcomingMaintenance;
+use Filament\Widgets\Widget;
+
 class Dashboard extends \Filament\Pages\Dashboard
 {
     protected static string|\BackedEnum|null $navigationIcon = 'cachet-dashboard';
+
+    /**
+     * @return array<class-string<Widget>>
+     */
+    public function getWidgets(): array
+    {
+        return [
+            SystemHealth::class,
+            Overview::class,
+            OpenIncidents::class,
+            UpcomingMaintenance::class,
+            Components::class,
+            Feed::class,
+            Support::class,
+        ];
+    }
 }

--- a/src/Filament/Widgets/Components.php
+++ b/src/Filament/Widgets/Components.php
@@ -22,6 +22,8 @@ class Components extends Widget implements HasSchemas
 
     protected int|string|array $columnSpan = 'full';
 
+    protected static ?int $sort = 4;
+
     public Collection $formData;
 
     public Collection $components;

--- a/src/Filament/Widgets/Concerns/PollsFromAppSettings.php
+++ b/src/Filament/Widgets/Concerns/PollsFromAppSettings.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Cachet\Filament\Widgets\Concerns;
+
+use Cachet\Settings\AppSettings;
+
+trait PollsFromAppSettings
+{
+    protected function getPollingInterval(): ?string
+    {
+        $refreshRate = app(AppSettings::class)->refresh_rate;
+
+        return $refreshRate ? max(5, $refreshRate).'s' : null;
+    }
+}

--- a/src/Filament/Widgets/Feed.php
+++ b/src/Filament/Widgets/Feed.php
@@ -2,7 +2,6 @@
 
 namespace Cachet\Filament\Widgets;
 
-use Filament\Widgets\Concerns\CanPoll;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Blade;
@@ -14,8 +13,6 @@ use Throwable;
 
 class Feed extends Widget
 {
-    use CanPoll;
-
     protected int|string|array $columnSpan = 'full';
 
     protected string $view = 'cachet::filament.widgets.feed';
@@ -60,8 +57,10 @@ class Feed extends Widget
      */
     protected function fetchFeed(string $uri, int $maxPosts = 5): array
     {
+        $useInternalErrors = libxml_use_internal_errors(true);
+
         try {
-            $response = Http::get($uri);
+            $response = Http::timeout(5)->get($uri);
 
             $xml = simplexml_load_string($response->body());
 
@@ -91,7 +90,12 @@ class Feed extends Widget
 
             return $posts;
         } catch (Throwable $e) {
+            report($e);
+
             return [];
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($useInternalErrors);
         }
     }
 }

--- a/src/Filament/Widgets/OpenIncidents.php
+++ b/src/Filament/Widgets/OpenIncidents.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Cachet\Filament\Widgets;
+
+use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Filament\Widgets\Concerns\PollsFromAppSettings;
+use Cachet\Models\Incident;
+use Filament\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+
+class OpenIncidents extends TableWidget
+{
+    use PollsFromAppSettings;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?int $sort = 2;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Incident::query()
+                    ->unresolved()
+                    ->withCount('components')
+                    ->orderByDesc('occurred_at')
+            )
+            ->heading(__('cachet::dashboard.open_incidents.heading'))
+            ->poll($this->getPollingInterval())
+            ->paginated([5])
+            ->defaultPaginationPageOption(5)
+            ->columns([
+                TextColumn::make('name')
+                    ->label(__('cachet::dashboard.open_incidents.headers.name')),
+                TextColumn::make('latest_status')
+                    ->label(__('cachet::dashboard.open_incidents.headers.status'))
+                    ->badge(),
+                TextColumn::make('occurred_at')
+                    ->label(__('cachet::dashboard.open_incidents.headers.occurred_at'))
+                    ->since()
+                    ->tooltip(fn (Incident $record): string => $record->timestamp->toDayDateTimeString()),
+                TextColumn::make('components_count')
+                    ->label(__('cachet::dashboard.open_incidents.headers.components')),
+            ])
+            ->recordUrl(fn (Incident $record): string => $record->filamentDashboardEditUrl())
+            ->headerActions([
+                Action::make('create')
+                    ->label(__('cachet::dashboard.open_incidents.actions.create'))
+                    ->url(IncidentResource::getUrl('create')),
+            ])
+            ->emptyStateHeading(__('cachet::dashboard.open_incidents.empty_state.heading'))
+            ->emptyStateDescription(__('cachet::dashboard.open_incidents.empty_state.description'))
+            ->emptyStateIcon('cachet-circle-check');
+    }
+}

--- a/src/Filament/Widgets/Overview.php
+++ b/src/Filament/Widgets/Overview.php
@@ -3,14 +3,16 @@
 namespace Cachet\Filament\Widgets;
 
 use Cachet\Models\Incident;
-use Cachet\Models\MetricPoint;
 use Cachet\Models\Subscriber;
+use Cachet\Status;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\DB;
 
 class Overview extends BaseWidget
 {
+    protected static ?int $sort = 1;
+
     protected function getColumns(): int
     {
         return 3;
@@ -18,30 +20,52 @@ class Overview extends BaseWidget
 
     protected function getStats(): array
     {
-        return [
-            Stat::make('total_incidents', Incident::count())
-                ->label(__('cachet::incident.overview.total_incidents_label'))
-                ->description(__('cachet::incident.overview.total_incidents_description'))
-                ->chart(DB::table('incidents')->selectRaw('count(*) as total')->groupByRaw('date(created_at)')->pluck('total')->toArray())
-                ->icon('cachet-incident')
-                ->chartColor('info')
-                ->color('gray'),
+        $openIncidents = Incident::query()->unresolved()->count();
+        $components = app(Status::class)->components();
+        $totalComponents = (int) $components->total;
+        $operationalComponents = (int) $components->operational;
+        $allOperational = $totalComponents === $operationalComponents;
 
-            Stat::make('metric_points', MetricPoint::count())
-                ->label(__('cachet::metric.overview.metric_points_label'))
-                ->description(__('cachet::metric.overview.metric_points_description'))
-                ->chart(DB::table('metric_points')->selectRaw('count(*) as total')->groupBy('created_at')->pluck('total')->toArray())
-                ->icon('cachet-metrics')
-                ->chartColor('info')
-                ->color('gray'),
+        return [
+            Stat::make('open_incidents', $openIncidents)
+                ->label(__('cachet::incident.overview.open_incidents_label'))
+                ->description(__('cachet::incident.overview.open_incidents_description'))
+                ->chart($this->dailyCounts('incidents'))
+                ->icon('cachet-incident')
+                ->chartColor($openIncidents > 0 ? 'danger' : 'success')
+                ->color($openIncidents > 0 ? 'danger' : 'success'),
+
+            Stat::make('operational_components', "{$operationalComponents} / {$totalComponents}")
+                ->label(__('cachet::component.overview.operational_components_label'))
+                ->description(__('cachet::component.overview.operational_components_description'))
+                ->icon('cachet-components')
+                ->color($allOperational ? 'success' : 'warning'),
 
             Stat::make('total_subscribers', Subscriber::count())
                 ->label(__('cachet::subscriber.overview.total_subscribers_label'))
-                ->description(__('cachet::subscriber.overview.total_subscribers_description'))
-                ->chart(DB::table('subscribers')->selectRaw('count(*) as total')->groupByRaw('date(created_at)')->pluck('total')->toArray())
+                ->description(__('cachet::subscriber.overview.verified_subscribers_description', [
+                    'count' => Subscriber::query()->whereNotNull('verified_at')->count(),
+                ]))
+                ->chart($this->dailyCounts('subscribers'))
                 ->icon('cachet-subscribers')
                 ->chartColor('info')
                 ->color('gray'),
         ];
+    }
+
+    /**
+     * Get the number of records created per day over the last 30 days.
+     *
+     * @return array<int, int>
+     */
+    protected function dailyCounts(string $table): array
+    {
+        return DB::table($table)
+            ->selectRaw('count(*) as total')
+            ->where('created_at', '>=', now()->subDays(30))
+            ->groupByRaw('date(created_at)')
+            ->orderByRaw('date(created_at)')
+            ->pluck('total')
+            ->all();
     }
 }

--- a/src/Filament/Widgets/Support.php
+++ b/src/Filament/Widgets/Support.php
@@ -11,6 +11,8 @@ class Support extends Widget
 
     protected string $view = 'cachet::filament.widgets.support';
 
+    protected static ?int $sort = 20;
+
     public function getConsiderSupportingBlock()
     {
         return preg_replace(

--- a/src/Filament/Widgets/SystemHealth.php
+++ b/src/Filament/Widgets/SystemHealth.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Cachet\Filament\Widgets;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Resources\Components\ComponentResource;
+use Cachet\Filament\Widgets\Concerns\PollsFromAppSettings;
+use Cachet\Status;
+use Filament\Widgets\Widget;
+
+class SystemHealth extends Widget
+{
+    use PollsFromAppSettings;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected string $view = 'cachet::filament.widgets.system-health';
+
+    protected static ?int $sort = 0;
+
+    protected function getViewData(): array
+    {
+        $status = app(Status::class);
+        $components = $status->components();
+
+        return [
+            'systemStatus' => $status->current(),
+            'totalComponents' => (int) $components->total,
+            'statusCounts' => $this->statusCounts($components),
+            'createComponentUrl' => ComponentResource::getUrl('create'),
+            'pollingInterval' => $this->getPollingInterval(),
+        ];
+    }
+
+    /**
+     * Get the number of components per status, excluding statuses with no components.
+     *
+     * @return array<int, array{status: ComponentStatusEnum, count: int}>
+     */
+    protected function statusCounts(object $components): array
+    {
+        return collect([
+            ComponentStatusEnum::operational,
+            ComponentStatusEnum::performance_issues,
+            ComponentStatusEnum::partial_outage,
+            ComponentStatusEnum::major_outage,
+            ComponentStatusEnum::under_maintenance,
+        ])
+            ->map(fn (ComponentStatusEnum $status) => [
+                'status' => $status,
+                'count' => (int) $components->{$status->name},
+            ])
+            ->filter(fn (array $item) => $item['count'] > 0)
+            ->values()
+            ->all();
+    }
+}

--- a/src/Filament/Widgets/UpcomingMaintenance.php
+++ b/src/Filament/Widgets/UpcomingMaintenance.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Cachet\Filament\Widgets;
+
+use Cachet\Filament\Resources\Schedules\ScheduleResource;
+use Cachet\Models\Schedule;
+use Filament\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+
+class UpcomingMaintenance extends TableWidget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?int $sort = 3;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Schedule::query()
+                    ->incomplete()
+                    ->orderBy('scheduled_at')
+            )
+            ->heading(__('cachet::dashboard.upcoming_maintenance.heading'))
+            ->paginated([5])
+            ->defaultPaginationPageOption(5)
+            ->columns([
+                TextColumn::make('name')
+                    ->label(__('cachet::dashboard.upcoming_maintenance.headers.name')),
+                TextColumn::make('status')
+                    ->label(__('cachet::dashboard.upcoming_maintenance.headers.status'))
+                    ->badge(),
+                TextColumn::make('scheduled_at')
+                    ->label(__('cachet::dashboard.upcoming_maintenance.headers.scheduled_at'))
+                    ->since()
+                    ->tooltip(fn (Schedule $record): string => $record->scheduled_at->toDayDateTimeString()),
+            ])
+            ->recordUrl(fn (Schedule $record): string => ScheduleResource::getUrl('edit', ['record' => $record]))
+            ->headerActions([
+                Action::make('create')
+                    ->label(__('cachet::dashboard.upcoming_maintenance.actions.create'))
+                    ->url(ScheduleResource::getUrl('create')),
+            ])
+            ->emptyStateHeading(__('cachet::dashboard.upcoming_maintenance.empty_state.heading'))
+            ->emptyStateDescription(__('cachet::dashboard.upcoming_maintenance.empty_state.description'))
+            ->emptyStateIcon('cachet-clock');
+    }
+}

--- a/tests/Feature/Filament/DashboardTest.php
+++ b/tests/Feature/Filament/DashboardTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use Cachet\Filament\Pages\Dashboard;
+use Cachet\Filament\Widgets\Components;
+use Cachet\Filament\Widgets\Feed;
+use Cachet\Filament\Widgets\OpenIncidents;
+use Cachet\Filament\Widgets\Overview;
+use Cachet\Filament\Widgets\Support;
+use Cachet\Filament\Widgets\SystemHealth;
+use Cachet\Filament\Widgets\UpcomingMaintenance;
+use Illuminate\Support\Facades\Http;
+use Workbench\App\User;
+
+use function Pest\Laravel\actingAs;
+use function PHPUnit\Framework\assertSame;
+
+it('renders the dashboard', function () {
+    Http::fake();
+
+    actingAs(User::factory()->create(['is_admin' => true]))
+        ->get(Dashboard::getUrl())
+        ->assertOk();
+});
+
+it('orders the widgets by importance', function () {
+    assertSame([
+        SystemHealth::class,
+        Overview::class,
+        OpenIncidents::class,
+        UpcomingMaintenance::class,
+        Components::class,
+        Feed::class,
+        Support::class,
+    ], (new Dashboard)->getWidgets());
+});

--- a/tests/Feature/Filament/Widgets/FeedTest.php
+++ b/tests/Feature/Filament/Widgets/FeedTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Filament\Widgets\Feed;
+use Illuminate\Support\Facades\Http;
+
+use function Pest\Livewire\livewire;
+
+it('feed smoke test', function () {
+    Http::fake();
+
+    $component = livewire(Feed::class);
+
+    $component->assertSuccessful();
+});
+
+it('renders posts from the feed', function () {
+    Http::fake([
+        '*' => Http::response(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+                <channel>
+                    <title>Cachet Blog</title>
+                    <item>
+                        <title>Cachet 3.x released</title>
+                        <link>https://blog.cachethq.io/cachet-3-x-released</link>
+                        <description>The next major version of Cachet.</description>
+                        <pubDate>Mon, 01 Jun 2026 09:00:00 +0000</pubDate>
+                    </item>
+                </channel>
+            </rss>
+            XML),
+    ]);
+
+    $component = livewire(Feed::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee('Cachet 3.x released');
+});
+
+it('renders the empty state when the feed cannot be fetched', function () {
+    Http::fake([
+        '*' => Http::response('not xml', 500),
+    ]);
+
+    $component = livewire(Feed::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee('No blog posts were found.');
+});

--- a/tests/Feature/Filament/Widgets/OpenIncidentsTest.php
+++ b/tests/Feature/Filament/Widgets/OpenIncidentsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Filament\Widgets\OpenIncidents;
+use Cachet\Models\Incident;
+
+use function Pest\Livewire\livewire;
+
+it('open incidents smoke test', function () {
+    $component = livewire(OpenIncidents::class);
+
+    $component->assertSuccessful();
+});
+
+it('lists unresolved incidents', function () {
+    Incident::factory()->create([
+        'name' => 'API is unreachable',
+        'status' => IncidentStatusEnum::investigating,
+    ]);
+
+    $component = livewire(OpenIncidents::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee('API is unreachable');
+    $component->assertSee(__('cachet::incident.status.investigating'));
+});
+
+it('does not list fixed incidents', function () {
+    Incident::factory()->create([
+        'name' => 'Resolved incident',
+        'status' => IncidentStatusEnum::fixed,
+    ]);
+
+    $component = livewire(OpenIncidents::class);
+
+    $component->assertSuccessful();
+
+    $component->assertDontSee('Resolved incident');
+});
+
+it('shows the empty state when there are no open incidents', function () {
+    $component = livewire(OpenIncidents::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::dashboard.open_incidents.empty_state.heading'));
+});

--- a/tests/Feature/Filament/Widgets/OverviewTest.php
+++ b/tests/Feature/Filament/Widgets/OverviewTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Filament\Widgets\Overview;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\Models\Subscriber;
+
+use function Pest\Livewire\livewire;
+
+it('overview smoke test', function () {
+    $component = livewire(Overview::class);
+
+    $component->assertSuccessful();
+});
+
+it('counts only unresolved incidents', function () {
+    Incident::factory()->count(2)->create([
+        'status' => IncidentStatusEnum::investigating,
+    ]);
+
+    Incident::factory()->create([
+        'status' => IncidentStatusEnum::fixed,
+    ]);
+
+    $component = livewire(Overview::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::incident.overview.open_incidents_label'));
+    $component->assertSee('2');
+});
+
+it('shows operational components out of the enabled total', function () {
+    Component::factory()->count(3)->create([
+        'status' => ComponentStatusEnum::operational,
+        'enabled' => true,
+    ]);
+
+    Component::factory()->create([
+        'status' => ComponentStatusEnum::major_outage,
+        'enabled' => true,
+    ]);
+
+    Component::factory()->create([
+        'status' => ComponentStatusEnum::operational,
+        'enabled' => false,
+    ]);
+
+    $component = livewire(Overview::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee('3 / 4');
+});
+
+it('shows the total and verified subscriber counts', function () {
+    Subscriber::factory()->count(2)->verified()->create();
+    Subscriber::factory()->create();
+
+    $component = livewire(Overview::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::subscriber.overview.total_subscribers_label'));
+    $component->assertSee('3');
+    $component->assertSee(__('cachet::subscriber.overview.verified_subscribers_description', ['count' => 2]));
+});

--- a/tests/Feature/Filament/Widgets/SupportTest.php
+++ b/tests/Feature/Filament/Widgets/SupportTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Filament\Widgets\Support;
+
+use function Pest\Livewire\livewire;
+
+it('support smoke test', function () {
+    $component = livewire(Support::class);
+
+    $component->assertSuccessful();
+});
+
+it('renders the support section', function () {
+    $component = livewire(Support::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::cachet.support.section_heading'));
+    $component->assertSee('GitHub Sponsors');
+    $component->assertSee('Cachet blog');
+});
+
+it('links to the sponsorship page and the blog', function () {
+    $component = livewire(Support::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSeeHtml('href="https://github.com/cachethq/cachet/?sponsor=1"');
+    $component->assertSeeHtml('href="https://blog.cachethq.io"');
+});

--- a/tests/Feature/Filament/Widgets/SystemHealthTest.php
+++ b/tests/Feature/Filament/Widgets/SystemHealthTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Widgets\SystemHealth;
+use Cachet\Models\Component;
+
+use function Pest\Livewire\livewire;
+
+it('system health smoke test', function () {
+    $component = livewire(SystemHealth::class);
+
+    $component->assertSuccessful();
+});
+
+it('shows the empty state when no components are configured', function () {
+    $component = livewire(SystemHealth::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::dashboard.system_health.empty'));
+    $component->assertSee(__('cachet::dashboard.system_health.add_component'));
+});
+
+it('shows an operational status when all components are operational', function () {
+    Component::factory()->count(2)->create([
+        'status' => ComponentStatusEnum::operational,
+        'enabled' => true,
+    ]);
+
+    $component = livewire(SystemHealth::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::system_status.operational'));
+    $component->assertSee(__('cachet::component.status.operational'));
+});
+
+it('shows a major outage when enough components are down', function () {
+    Component::factory()->count(3)->create([
+        'status' => ComponentStatusEnum::major_outage,
+        'enabled' => true,
+    ]);
+
+    Component::factory()->create([
+        'status' => ComponentStatusEnum::operational,
+        'enabled' => true,
+    ]);
+
+    $component = livewire(SystemHealth::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::system_status.major_outage'));
+});
+
+it('ignores disabled components', function () {
+    Component::factory()->create([
+        'status' => ComponentStatusEnum::major_outage,
+        'enabled' => false,
+    ]);
+
+    $component = livewire(SystemHealth::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::dashboard.system_health.empty'));
+});

--- a/tests/Feature/Filament/Widgets/UpcomingMaintenanceTest.php
+++ b/tests/Feature/Filament/Widgets/UpcomingMaintenanceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Filament\Widgets;
+
+use Cachet\Filament\Widgets\UpcomingMaintenance;
+use Cachet\Models\Schedule;
+
+use function Pest\Livewire\livewire;
+
+it('upcoming maintenance smoke test', function () {
+    $component = livewire(UpcomingMaintenance::class);
+
+    $component->assertSuccessful();
+});
+
+it('lists upcoming and in-progress maintenance', function () {
+    Schedule::factory()->create([
+        'name' => 'Database upgrade',
+        'scheduled_at' => now()->addDays(2),
+        'completed_at' => null,
+    ]);
+
+    Schedule::factory()->inProgress()->create([
+        'name' => 'Network maintenance',
+    ]);
+
+    $component = livewire(UpcomingMaintenance::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee('Database upgrade');
+    $component->assertSee('Network maintenance');
+});
+
+it('does not list completed maintenance', function () {
+    Schedule::factory()->completed()->create([
+        'name' => 'Finished maintenance',
+    ]);
+
+    $component = livewire(UpcomingMaintenance::class);
+
+    $component->assertSuccessful();
+
+    $component->assertDontSee('Finished maintenance');
+});
+
+it('shows the empty state when there is no maintenance', function () {
+    $component = livewire(UpcomingMaintenance::class);
+
+    $component->assertSuccessful();
+
+    $component->assertSee(__('cachet::dashboard.upcoming_maintenance.empty_state.heading'));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,14 @@ namespace Cachet\Tests;
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
 use Dedoc\Scramble\ScrambleServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
 use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
+use Filament\Infolists\InfolistsServiceProvider;
+use Filament\Notifications\NotificationsServiceProvider;
 use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
+use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Application;
@@ -35,10 +39,14 @@ abstract class TestCase extends Orchestra
     {
         $providers = array_merge(parent::getPackageProviders($app), [
             LivewireServiceProvider::class,
+            ActionsServiceProvider::class,
             FilamentServiceProvider::class,
             FormsServiceProvider::class,
+            InfolistsServiceProvider::class,
+            NotificationsServiceProvider::class,
             SchemasServiceProvider::class,
             SupportServiceProvider::class,
+            TablesServiceProvider::class,
             BladeIconsServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             WidgetsServiceProvider::class,


### PR DESCRIPTION
## Summary

Replaces the placeholder dashboard with purpose-built widgets, ordered by importance:

- **System Health** — banner showing the overall system status with per-status component counts, and an empty state prompting to add a first component.
- **Overview** — refreshed stats: open (unresolved) incidents with a 30-day trend, operational components out of the enabled total, and total subscribers with a verified count. Stats colour themselves based on state.
- **Open Incidents** — table of unresolved incidents (status, occurrence time, affected components) linking through to the incident, with a create action.
- **Upcoming Maintenance** — table of incomplete maintenance windows with a schedule action.

Supporting changes:

- New `PollsFromAppSettings` concern so widgets poll using the configured refresh rate (minimum 5s).
- The blog feed widget now uses a 5 second request timeout, reports fetch failures, and restores libxml error handling state after parsing.
- Removed the "work in progress" notice from the support widget.
- All new strings translated for every supported locale (de, de_AT, de_CH, es_ES, fr, ko, nl, ph, pt_BR, zh_CN, zh_TW).

## Test plan

- 34 new Feature tests covering the dashboard page, widget order, and every widget (system health states, incident/maintenance listing and empty states, overview counts, feed parsing and failure handling, support links).
- Full suite (477 tests), PHPStan, and Pint all pass.