### PR TITLE
Fix Component status pill to link to ongoing incident instead of resolved one

### DIFF
--- a/resources/views/components/component.blade.php
+++ b/resources/views/components/component.blade.php
@@ -32,7 +32,7 @@
                  class="relative shrink-0">
                 <div x-ref="badgeAnchor">
                     @if ($component->incidents_count > 0)
-                        <a href="{{ route('cachet.status-page.incident', [$component->incidents->first()]) }}" class="inline-flex">
+                        <a href="{{ route('cachet.status-page.incident', [$component->latest_unresolved_incident]) }}" class="inline-flex">
                             <x-cachet::badge :status="$component->latest_status" />
                         </a>
                     @else

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property ?string $link
  * @property ?ComponentStatusEnum $status
  * @property ComponentStatusEnum $latest_status
+ * @property-read Incident|null $latest_unresolved_incident
  * @property ?int $order
  * @property ?int $component_group_id
  * @property ?bool $checked
@@ -172,11 +173,19 @@ class Component extends Model
     }
 
     /**
+     * Get the latest unresolved incident for the component.
+     */
+    public function latestUnresolvedIncident(): Attribute
+    {
+        return Attribute::get(fn () => $this->incidents()->unresolved()->latest()->first());
+    }
+
+    /**
      * Get the latest status for the component.
      */
     public function latestStatus(): Attribute
     {
-        return Attribute::get(fn () => $this->incidents()->unresolved()->latest()->first()?->pivot->component_status ?? $this->status);
+        return Attribute::get(fn () => $this->latest_unresolved_incident?->pivot->component_status ?? $this->status);
     }
 
     /**

--- a/tests/Unit/Views/ComponentTest.php
+++ b/tests/Unit/Views/ComponentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
@@ -39,6 +40,42 @@ it('shows the latest status for a component one linked incident', function () {
     $view
         ->assertSee(ComponentStatusEnum::performance_issues->getLabel())
         ->assertDontSee(ComponentStatusEnum::operational->getLabel());
+});
+
+it('links the status pill to the latest unresolved incident, not an older resolved one', function () {
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational->value,
+    ]);
+
+    $resolvedIncident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::fixed->value,
+    ]);
+    $ongoingIncident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::investigating->value,
+    ]);
+
+    $this->travelTo(now()->subSeconds(2), function () use ($component, $resolvedIncident) {
+        $component->incidents()->attach($resolvedIncident, [
+            'component_status' => ComponentStatusEnum::performance_issues->value,
+        ]);
+    });
+
+    $component->incidents()->attach($ongoingIncident, [
+        'component_status' => ComponentStatusEnum::partial_outage->value,
+    ]);
+
+    $component = Component::query()
+        ->withCount(['incidents' => fn ($query) => $query->unresolved()])
+        ->first();
+
+    $view = $this->view('cachet::components.component', [
+        'component' => $component,
+        'status' => $component->status,
+    ]);
+
+    $view
+        ->assertSee($ongoingIncident->guid)
+        ->assertDontSee($resolvedIncident->guid);
 });
 
 it('shows the latest status for a component multiple linked incidents', function () {


### PR DESCRIPTION
Added an accessor that returns the same incident driving the status, and refactored `latestStatus` and pill link in template to reuse it.

Closes https://github.com/cachethq/core/issues/371