### PR TITLE
Add spacing around collapse chevron in component groups on mobile

### DIFF
--- a/resources/views/components/component-group.blade.php
+++ b/resources/views/components/component-group.blade.php
@@ -3,8 +3,8 @@
 {{ \Cachet\Facades\CachetView::renderHook(\Cachet\View\RenderHook::STATUS_PAGE_COMPONENT_GROUPS_BEFORE) }}
 @php($groupStatus = $componentGroup->worstComponentStatus())
 <li x-data x-disclosure @if ($componentGroup->isExpanded()) default-open @endif>
-    <button x-disclosure:button class="relative flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition hover:bg-zinc-50/60 dark:hover:bg-white/[0.02] sm:px-6 sm:py-4">
-        <span class="absolute left-1 top-1/2 -translate-y-1/2 text-zinc-400 dark:text-zinc-500 sm:left-2">
+    <button x-disclosure:button class="relative flex w-full items-center justify-between gap-3 py-3 pl-8 pr-4 text-left transition hover:bg-zinc-50/60 dark:hover:bg-white/[0.02] sm:py-4 sm:pl-9 sm:pr-6">
+        <span class="absolute left-2 top-1/2 -translate-y-1/2 text-zinc-400 dark:text-zinc-500 sm:left-3">
             <x-heroicon-m-chevron-right ::class="$disclosure.isOpen && 'rotate-90'" class="size-3.5 transition" />
         </span>
 


### PR DESCRIPTION
The chevron sat at left-1 (4px) with only px-4 (16px) left padding, so
the disclosure indicator overlapped the group title on mobile. Shift the
chevron to left-2/sm:left-3 and add pl-8/sm:pl-9 to the button so the
title clears the chevron with balanced spacing on both sides.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018GX3FhjFCLKEkcGtksLLw4