### PR TITLE
Add API endpoints to manage subscribers

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use Cachet\Http\Controllers\Api\MetricPointController;
 use Cachet\Http\Controllers\Api\ScheduleController;
 use Cachet\Http\Controllers\Api\ScheduleUpdateController;
 use Cachet\Http\Controllers\Api\StatusController;
+use Cachet\Http\Controllers\Api\SubscriberController;
 use Illuminate\Support\Facades\Route;
 
 Route::apiResources([
@@ -63,6 +64,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
     ])
         ->parameter('points', 'metricPoint')
         ->scoped();
+
+    Route::apiResource('subscribers', SubscriberController::class);
 });
 
 Route::get('/ping', [GeneralController::class, 'ping'])->name('ping');

--- a/src/Actions/Subscriber/UpdateSubscriber.php
+++ b/src/Actions/Subscriber/UpdateSubscriber.php
@@ -9,7 +9,7 @@ class UpdateSubscriber
     /**
      * Handle the action.
      */
-    public function handle(Subscriber $subscriber, ?string $email = null, ?bool $global = null, array $components = []): Subscriber
+    public function handle(Subscriber $subscriber, ?string $email = null, ?bool $global = null, ?array $components = null): Subscriber
     {
         $subscriber->update(array_filter([
             'email' => $email,
@@ -20,7 +20,9 @@ class UpdateSubscriber
             $subscriber->resetVerification();
         }
 
-        $subscriber->components()->sync($components);
+        if ($components !== null) {
+            $subscriber->components()->sync($components);
+        }
 
         return $subscriber;
     }

--- a/src/Cachet.php
+++ b/src/Cachet.php
@@ -99,6 +99,7 @@ class Cachet
             'metric-points' => ['manage', 'delete'],
             'schedules' => ['manage', 'delete'],
             'schedule-updates' => ['manage', 'delete'],
+            'subscribers' => ['manage', 'delete'],
         ];
     }
 

--- a/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cachet\Data\Requests\Subscriber;
+
+use Cachet\Data\BaseData;
+use Illuminate\Validation\Rule;
+use Spatie\LaravelData\Support\Validation\ValidationContext;
+
+final class CreateSubscriberRequestData extends BaseData
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly ?bool $global = null,
+        public readonly ?array $components = null,
+        public readonly ?bool $verified = null,
+    ) {}
+
+    public static function rules(ValidationContext $context): array
+    {
+        return [
+            'email' => ['required', 'email', 'max:255'],
+            'global' => ['bool'],
+            'components' => ['array'],
+            'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            'verified' => ['bool'],
+        ];
+    }
+}

--- a/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cachet\Data\Requests\Subscriber;
+
+use Cachet\Data\BaseData;
+use Illuminate\Validation\Rule;
+use Spatie\LaravelData\Support\Validation\ValidationContext;
+
+final class UpdateSubscriberRequestData extends BaseData
+{
+    public function __construct(
+        public readonly ?string $email = null,
+        public readonly ?bool $global = null,
+        public readonly ?array $components = null,
+    ) {}
+
+    public static function rules(ValidationContext $context): array
+    {
+        return [
+            'email' => ['email', 'max:255'],
+            'global' => ['bool'],
+            'components' => ['array'],
+            'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+        ];
+    }
+}

--- a/src/Http/Controllers/Api/SubscriberController.php
+++ b/src/Http/Controllers/Api/SubscriberController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Cachet\Http\Controllers\Api;
+
+use Cachet\Actions\Subscriber\CreateSubscriber;
+use Cachet\Actions\Subscriber\UnsubscribeSubscriber;
+use Cachet\Actions\Subscriber\UpdateSubscriber;
+use Cachet\Concerns\GuardsApiAbilities;
+use Cachet\Data\Requests\Subscriber\CreateSubscriberRequestData;
+use Cachet\Data\Requests\Subscriber\UpdateSubscriberRequestData;
+use Cachet\Http\Resources\Subscriber as SubscriberResource;
+use Cachet\Models\Subscriber;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
+
+#[Group('Subscribers', weight: 10)]
+class SubscriberController extends Controller
+{
+    use GuardsApiAbilities;
+
+    /**
+     * List Subscribers
+     */
+    #[QueryParameter('filter[email]', 'Filter by email address.', example: 'john@example.com')]
+    #[QueryParameter('filter[global]', 'Filter by global subscription status.', type: 'bool', example: '1')]
+    #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
+    #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
+    public function index(Request $request)
+    {
+        $subscribers = QueryBuilder::for(Subscriber::class)
+            ->allowedIncludes(['components'])
+            ->allowedFilters([
+                'email',
+                AllowedFilter::exact('global'),
+            ])
+            ->allowedSorts(['email', 'id'])
+            ->simplePaginate($request->input('per_page', 15));
+
+        return SubscriberResource::collection($subscribers);
+    }
+
+    /**
+     * Create Subscriber
+     */
+    public function store(CreateSubscriberRequestData $data, CreateSubscriber $createSubscriberAction)
+    {
+        $this->guard('subscribers.manage');
+
+        $subscriber = $createSubscriberAction->handle(
+            $data->email,
+            $data->global ?? true,
+            $data->components ?? [],
+            $data->verified ?? false,
+        );
+
+        if (! $subscriber->hasVerifiedEmail()) {
+            $subscriber->sendEmailVerificationNotification();
+        }
+
+        return SubscriberResource::make($subscriber);
+    }
+
+    /**
+     * Get Subscriber
+     */
+    public function show(Subscriber $subscriber)
+    {
+        $subscriberQuery = QueryBuilder::for(Subscriber::class)
+            ->allowedIncludes(['components'])
+            ->find($subscriber->id);
+
+        return SubscriberResource::make($subscriberQuery)
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Update Subscriber
+     */
+    public function update(UpdateSubscriberRequestData $data, Subscriber $subscriber, UpdateSubscriber $updateSubscriberAction)
+    {
+        $this->guard('subscribers.manage');
+
+        $updateSubscriberAction->handle(
+            $subscriber,
+            email: $data->email,
+            global: $data->global,
+            components: $data->components,
+        );
+
+        return SubscriberResource::make($subscriber->fresh());
+    }
+
+    /**
+     * Delete Subscriber
+     */
+    public function destroy(Subscriber $subscriber, UnsubscribeSubscriber $unsubscribeSubscriberAction)
+    {
+        $this->guard('subscribers.delete');
+
+        $unsubscribeSubscriberAction->handle($subscriber);
+
+        return response()->noContent();
+    }
+}

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Cachet\Http\Resources;
+
+use Illuminate\Http\Request;
+use TiMacDonald\JsonApi\JsonApiResource;
+
+/** @mixin \Cachet\Models\Subscriber */
+class Subscriber extends JsonApiResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'email' => $this->email,
+            'global' => (bool) $this->global,
+            'verified' => $this->hasVerifiedEmail(),
+            'verified_at' => [
+                'human' => $this->email_verified_at?->diffForHumans(),
+                'string' => $this->email_verified_at?->toDateTimeString(),
+            ],
+            'created' => [
+                'human' => $this->created_at?->diffForHumans(),
+                'string' => $this->created_at?->toDateTimeString(),
+            ],
+            'updated' => [
+                'human' => $this->updated_at?->diffForHumans(),
+                'string' => $this->updated_at?->toDateTimeString(),
+            ],
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'components' => fn () => Component::collection($this->components),
+        ];
+    }
+}

--- a/tests/Feature/Api/SubscriberTest.php
+++ b/tests/Feature/Api/SubscriberTest.php
@@ -1,0 +1,312 @@
+<?php
+
+use Cachet\Models\Component;
+use Cachet\Models\Subscriber;
+use Cachet\Notifications\VerifySubscriberEmail;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+it('cannot list subscribers when not authenticated', function () {
+    Subscriber::factory(2)->create();
+
+    $response = getJson('/status/api/subscribers');
+
+    $response->assertUnauthorized();
+});
+
+it('can list subscribers', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Subscriber::factory(2)->create();
+
+    $response = getJson('/status/api/subscribers');
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('does not list more than 15 subscribers by default', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Subscriber::factory(20)->create();
+
+    $response = getJson('/status/api/subscribers');
+
+    $response->assertOk();
+    $response->assertJsonCount(15, 'data');
+});
+
+it('can list more than 15 subscribers', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Subscriber::factory(20)->create();
+
+    $response = getJson('/status/api/subscribers?per_page=18');
+
+    $response->assertOk();
+    $response->assertJsonCount(18, 'data');
+});
+
+it('can filter subscribers by email', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Subscriber::factory(5)->create();
+    Subscriber::factory()->create(['email' => 'james@alt-three.com']);
+
+    $response = getJson('/status/api/subscribers?filter[email]=james@alt-three.com');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonFragment(['email' => 'james@alt-three.com']);
+});
+
+it('cannot get a subscriber when not authenticated', function () {
+    $subscriber = Subscriber::factory()->create();
+
+    $response = getJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertUnauthorized();
+});
+
+it('can get a subscriber', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    Subscriber::factory(5)->create();
+    $subscriber = Subscriber::factory()->create();
+
+    $response = getJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertOk();
+    $response->assertJsonFragment([
+        'id' => $subscriber->id,
+    ]);
+});
+
+it('can get a subscriber with components', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $subscriber = Subscriber::factory()->hasComponents(2)->create();
+
+    $response = getJson('/status/api/subscribers/'.$subscriber->id.'?include=components');
+
+    $response->assertOk();
+    $response->assertJsonFragment(['id' => $subscriber->id]);
+});
+
+it('cannot create a subscriber when not authenticated', function () {
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot create a subscriber without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertForbidden();
+});
+
+it('can create a subscriber', function () {
+    Notification::fake();
+
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonFragment([
+        'email' => 'james@alt-three.com',
+    ]);
+    $this->assertDatabaseHas('subscribers', [
+        'email' => 'james@alt-three.com',
+        'email_verified_at' => null,
+    ]);
+
+    Notification::assertSentTo(
+        Subscriber::query()->firstWhere('email', 'james@alt-three.com'),
+        VerifySubscriberEmail::class,
+    );
+});
+
+it('can create a verified subscriber without sending a verification email', function () {
+    Notification::fake();
+
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+        'verified' => true,
+    ]);
+
+    $response->assertCreated();
+
+    expect(Subscriber::query()->firstWhere('email', 'james@alt-three.com'))
+        ->hasVerifiedEmail()->toBeTrue();
+
+    Notification::assertNothingSent();
+});
+
+it('can create a subscriber with component subscriptions', function () {
+    Notification::fake();
+
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $components = Component::factory(2)->create();
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+        'global' => false,
+        'components' => $components->pluck('id')->values()->all(),
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('subscribers', [
+        'email' => 'james@alt-three.com',
+        'global' => false,
+    ]);
+    $this->assertDatabaseHas('subscriptions', [
+        'subscriber_id' => $response->json('data.id'),
+        'component_id' => $components->first()->id,
+    ]);
+});
+
+it('cannot create a subscriber with an invalid email address', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'not-an-email',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors('email');
+});
+
+it('cannot create a subscriber with components that do not exist', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+        'components' => [999],
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors('components.0');
+});
+
+it('cannot update a subscriber when not authenticated', function () {
+    $subscriber = Subscriber::factory()->create();
+
+    $response = putJson('/status/api/subscribers/'.$subscriber->id, [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot update a subscriber without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $subscriber = Subscriber::factory()->create();
+
+    $response = putJson('/status/api/subscribers/'.$subscriber->id, [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertForbidden();
+});
+
+it('can update a subscriber', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->verified()->create();
+
+    $response = putJson('/status/api/subscribers/'.$subscriber->id, [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonFragment([
+        'email' => 'james@alt-three.com',
+    ]);
+    $this->assertDatabaseHas('subscribers', [
+        'id' => $subscriber->id,
+        'email' => 'james@alt-three.com',
+        'email_verified_at' => null,
+    ]);
+});
+
+it('can update a subscriber component subscriptions', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->hasComponents(1)->create();
+    $components = Component::factory(2)->create();
+
+    $response = putJson('/status/api/subscribers/'.$subscriber->id, [
+        'components' => $components->pluck('id')->values()->all(),
+    ]);
+
+    $response->assertOk();
+
+    expect($subscriber->fresh()->components)->toHaveCount(2);
+});
+
+it('does not detach component subscriptions when components are omitted from an update', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->hasComponents(2)->create();
+
+    $response = putJson('/status/api/subscribers/'.$subscriber->id, [
+        'email' => 'james@alt-three.com',
+    ]);
+
+    $response->assertOk();
+
+    expect($subscriber->fresh()->components)->toHaveCount(2);
+});
+
+it('cannot delete a subscriber when not authenticated', function () {
+    $subscriber = Subscriber::factory()->create();
+
+    $response = deleteJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertUnauthorized();
+});
+
+it('cannot delete a subscriber without the token ability', function () {
+    Sanctum::actingAs(User::factory()->create());
+
+    $subscriber = Subscriber::factory()->create();
+
+    $response = deleteJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertForbidden();
+});
+
+it('can delete a subscriber', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.delete']);
+
+    $subscriber = Subscriber::factory()->hasComponents(2)->create();
+
+    $response = deleteJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertNoContent();
+    $this->assertDatabaseMissing('subscribers', [
+        'id' => $subscriber->id,
+    ]);
+    $this->assertDatabaseMissing('subscriptions', [
+        'subscriber_id' => $subscriber->id,
+    ]);
+});


### PR DESCRIPTION
## Summary

Adds a fully-protected API for managing status page subscribers. Unlike other resources, **every endpoint — including `GET`s — requires authentication**, since subscriber emails are PII.

| Method | URI | Ability |
|---|---|---|
| GET | `/api/subscribers` | any valid token |
| GET | `/api/subscribers/{subscriber}` | any valid token |
| POST | `/api/subscribers` | `subscribers.manage` |
| PUT/PATCH | `/api/subscribers/{subscriber}` | `subscribers.manage` |
| DELETE | `/api/subscribers/{subscriber}` | `subscribers.delete` |

The index supports `filter[email]`, `filter[global]`, `include=components`, sorting by `email`/`id`, and the standard pagination parameters.

## Implementation notes

- Follows the existing API conventions: Scramble doc attributes, spatie/laravel-data request objects, JSON:API resource, and the existing `CreateSubscriber` / `UpdateSubscriber` / `UnsubscribeSubscriber` actions.
- The new `subscribers.manage` / `subscribers.delete` abilities are registered in `Cachet::getResourceApiAbilities()`, so they automatically appear in the dashboard's API key form.
- Creating a subscriber sends a verification email unless `verified: true` is passed, mirroring the public subscribe flow. Creation is idempotent by email (`firstOrCreate`).
- `UpdateSubscriber`'s `$components` parameter is now nullable so partial updates that omit `components` no longer detach all component subscriptions; passing an array still syncs exactly as before.
- The API is intentionally not gated by the `allow_subscribers` mail setting — that setting controls the public subscribe form, whereas this is an admin surface (same as the dashboard's subscriber management).

## Tests

- 23 new feature tests covering auth (401 on unauthenticated `GET`s included), ability checks, validation, verification email behaviour, component subscriptions, and deletion.
- Full suite passes locally; Pint and Psalm are clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)