### PR TITLE
Add settings to disable the API or require authentication for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Cachet 3.x is currently in development and is not yet completely ready for produ
 
 Cachet is built on:
 
-- [Laravel 11.x](https://laravel.com)
-- [Filament 3.x](https://filamentphp.com)
+- [Laravel](https://laravel.com)
+- [Filament](https://filamentphp.com)
 - [Tailwind CSS](https://tailwindcss.com)
 - [Alpine.js](https://alpinejs.dev)
 

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\User;
+use Cachet\Http\Middleware\AuthenticateApiIfProtected;
+use Cachet\Http\Middleware\EnsureApiIsEnabled;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
 return [
@@ -89,6 +91,8 @@ return [
      |
      */
     'api_middleware' => [
+        EnsureApiIsEnabled::class,
+        AuthenticateApiIfProtected::class,
         SubstituteBindings::class,
     ],
 

--- a/database/migrations/2026_07_08_000001_add_api_settings.php
+++ b/database/migrations/2026_07_08_000001_add_api_settings.php
@@ -1,0 +1,15 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        rescue(fn () => $this->migrator->add('app.api_enabled', true));
+        rescue(fn () => $this->migrator->add('app.api_protected', false));
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -248,6 +248,8 @@ ABOUT;
         $appSettings->major_outage_threshold = 25;
         $appSettings->recent_incidents_only = false;
         $appSettings->recent_incidents_days = 7;
+        $appSettings->api_enabled = true;
+        $appSettings->api_protected = false;
         $appSettings->save();
 
         $customizationSettings = app(CustomizationSettings::class);

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -32,8 +32,13 @@ return [
             'recent_incidents_only_helper' => 'Beschränke die Vorfallliste auf einen aktuellen Zeitraum, anstatt alle anzuzeigen.',
             'recent_incidents_days' => 'Anzahl der Tage, an denen aktuelle Vorfälle angezeigt werden sollen',
             'recent_incidents_days_helper' => 'Wie weit zurück bei der Anzeige aktueller Vorfälle gesucht werden soll.',
+            'api_enabled' => 'API aktivieren',
+            'api_enabled_helper' => 'Zugriff auf die Cachet-API erlauben. Wenn deaktiviert, geben alle API-Anfragen 404 zurück.',
+            'api_protected' => 'Authentifizierung erforderlich',
+            'api_protected_helper' => 'Für alle API-Anfragen einen API-Token verlangen, auch für rein lesende Endpunkte.',
         ],
         'display_settings_title' => 'Anzeigeeinstellungen',
+        'api_settings_title' => 'API-Einstellungen',
     ],
     'manage_customization' => [
         'header_label' => 'Benutzerdefinierter HTML-Header',

--- a/resources/lang/de_AT/settings.php
+++ b/resources/lang/de_AT/settings.php
@@ -32,8 +32,13 @@ return [
             'recent_incidents_only_helper' => 'Beschränke die Vorfallliste auf einen aktuellen Zeitraum, anstatt alle anzuzeigen.',
             'recent_incidents_days' => 'Anzahl der Tage, an denen aktuelle Vorfälle angezeigt werden sollen',
             'recent_incidents_days_helper' => 'Wie weit zurück bei der Anzeige aktueller Vorfälle gesucht werden soll.',
+            'api_enabled' => 'API aktivieren',
+            'api_enabled_helper' => 'Zugriff auf die Cachet-API erlauben. Wenn deaktiviert, geben alle API-Anfragen 404 zurück.',
+            'api_protected' => 'Authentifizierung erforderlich',
+            'api_protected_helper' => 'Für alle API-Anfragen einen API-Token verlangen, auch für rein lesende Endpunkte.',
         ],
         'display_settings_title' => 'Anzeigeeinstellungen',
+        'api_settings_title' => 'API-Einstellungen',
     ],
     'manage_customization' => [
         'header_label' => 'Benutzerdefinierter HTML-Header',

--- a/resources/lang/de_CH/settings.php
+++ b/resources/lang/de_CH/settings.php
@@ -32,8 +32,13 @@ return [
             'recent_incidents_only_helper' => 'Beschränke die Vorfallliste auf einen aktuellen Zeitraum, anstatt alle anzuzeigen.',
             'recent_incidents_days' => 'Anzahl der Tage, an denen aktuelle Vorfälle angezeigt werden sollen',
             'recent_incidents_days_helper' => 'Wie weit zurück bei der Anzeige aktueller Vorfälle gesucht werden soll.',
+            'api_enabled' => 'API aktivieren',
+            'api_enabled_helper' => 'Zugriff auf die Cachet-API erlauben. Wenn deaktiviert, geben alle API-Anfragen 404 zurück.',
+            'api_protected' => 'Authentifizierung erforderlich',
+            'api_protected_helper' => 'Für alle API-Anfragen einen API-Token verlangen, auch für rein lesende Endpunkte.',
         ],
         'display_settings_title' => 'Anzeigeeinstellungen',
+        'api_settings_title' => 'API-Einstellungen',
     ],
     'manage_customization' => [
         'header_label' => 'Benutzerdefinierter HTML-Header',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -32,8 +32,13 @@ return [
             'recent_incidents_only_helper' => 'Limit the incidents list to a recent window instead of showing all.',
             'recent_incidents_days' => 'Number of Days to Show Recent Incidents',
             'recent_incidents_days_helper' => 'How far back to look when listing recent incidents.',
+            'api_enabled' => 'Enable API',
+            'api_enabled_helper' => 'Allow access to the Cachet API. When disabled, all API requests return a 404.',
+            'api_protected' => 'Require Authentication',
+            'api_protected_helper' => 'Require an API token for all API requests, including read-only endpoints.',
         ],
         'display_settings_title' => 'Display Settings',
+        'api_settings_title' => 'API Settings',
     ],
     'manage_customization' => [
         'header_label' => 'Custom Header HTML',

--- a/resources/lang/es_ES/settings.php
+++ b/resources/lang/es_ES/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => 'Permite a Cachet cargar recursos como fuentes desde servicios externos.',
             'recent_incidents_days' => 'Número de Días para Mostrar Incidentes Recientes',
             'recent_incidents_days_helper' => 'Cuánto tiempo atrás buscar al listar incidentes recientes.',
+            'api_enabled' => 'Activar API',
+            'api_enabled_helper' => 'Permitir el acceso a la API de Cachet. Si se desactiva, todas las peticiones a la API devolverán 404.',
+            'api_protected' => 'Requerir autenticación',
+            'api_protected_helper' => 'Exigir un token de API para todas las peticiones, incluidos los endpoints de solo lectura.',
         ],
         'display_settings_title' => 'Configuración de visualización',
+        'api_settings_title' => 'Configuración de la API',
     ],
     'manage_customization' => [
         'header_label' => 'Encabezado Personalizado HTML',

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -33,8 +33,13 @@ return [
             'recent_incidents_only_helper' => "Limite la liste des incidents \u{00E0} une fen\u{00EA}tre r\u{00E9}cente plut\u{00F4}t que de tous les afficher.",
             'recent_incidents_days' => "Nombre de jours \u{00E0} afficher pour les incidents r\u{00E9}cents",
             'recent_incidents_days_helper' => "Jusqu\u{2019}\u{00E0} quand remonter pour lister les incidents r\u{00E9}cents.",
+            'api_enabled' => "Activer l\u{2019}API",
+            'api_enabled_helper' => "Autoriser l\u{2019}acc\u{00E8}s \u{00E0} l\u{2019}API de Cachet. Si d\u{00E9}sactiv\u{00E9}, toutes les requ\u{00EA}tes API renvoient une erreur 404.",
+            'api_protected' => "Exiger une authentification",
+            'api_protected_helper' => "Exiger un jeton d\u{2019}API pour toutes les requ\u{00EA}tes, y compris les points de terminaison en lecture seule.",
         ],
         'display_settings_title' => "Param\u{00E8}tres d\u{2019}affichage",
+        'api_settings_title' => "Param\u{00E8}tres de l\u{2019}API",
     ],
     'manage_customization' => [
         'header_label' => "HTML personnalis\u{00E9} pour l\u{2019}en-t\u{00EA}te",

--- a/resources/lang/ko/settings.php
+++ b/resources/lang/ko/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => 'Cachet가 외부 서비스에서 글꼴 등의 자산을 로드할 수 있도록 허용합니다.',
             'recent_incidents_days' => '최근 사고를 표시할 일수',
             'recent_incidents_days_helper' => '최근 사고를 나열할 때 얼마나 거슬러 올라갈지 결정합니다.',
+            'api_enabled' => 'API 활성화',
+            'api_enabled_helper' => 'Cachet API에 대한 접근을 허용합니다. 비활성화하면 모든 API 요청이 404를 반환합니다.',
+            'api_protected' => '인증 필요',
+            'api_protected_helper' => '읽기 전용 엔드포인트를 포함한 모든 API 요청에 API 토큰을 요구합니다.',
         ],
         'display_settings_title' => '표시 설정',
+        'api_settings_title' => 'API 설정',
     ],
     'manage_customization' => [
         'header_label' => '사용자 정의 헤더 HTML',

--- a/resources/lang/nl/settings.php
+++ b/resources/lang/nl/settings.php
@@ -33,8 +33,13 @@ return [
             'recent_incidents_only_helper' => 'Beperk de incidentenlijst tot een recent venster in plaats van alle te tonen.',
             'recent_incidents_days' => 'Aantal dagen waarop actuele incidenten moeten worden weergegeven',
             'recent_incidents_days_helper' => 'Hoe ver terug gekeken moet worden bij het tonen van recente incidenten.',
+            'api_enabled' => 'API inschakelen',
+            'api_enabled_helper' => 'Sta toegang tot de Cachet API toe. Indien uitgeschakeld, geven alle API-verzoeken een 404 terug.',
+            'api_protected' => 'Authenticatie vereist',
+            'api_protected_helper' => 'Vereis een API-token voor alle API-verzoeken, inclusief alleen-lezen endpoints.',
         ],
         'display_settings_title' => 'Weergave-instellingen',
+        'api_settings_title' => 'API-instellingen',
     ],
     'manage_customization' => [
         'header_label' => 'Aangepaste HTML-Header',

--- a/resources/lang/ph/settings.php
+++ b/resources/lang/ph/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => 'Payagan ang Cachet na mag-load ng mga asset tulad ng mga font mula sa mga panlabas na serbisyo.',
             'recent_incidents_days' => 'Bilang ng Araw para Ipakita ang Mga Kamakailang Insidente',
             'recent_incidents_days_helper' => 'Gaano kalayo bumalik kapag naglilista ng mga kamakailang insidente.',
+            'api_enabled' => 'Paganahin ang API',
+            'api_enabled_helper' => 'Payagan ang pag-access sa Cachet API. Kapag naka-disable, lahat ng API request ay magbabalik ng 404.',
+            'api_protected' => 'Kailangan ng Authentication',
+            'api_protected_helper' => 'Mangailangan ng API token para sa lahat ng API request, kabilang ang mga read-only na endpoint.',
         ],
         'display_settings_title' => 'Mga Setting ng Display',
+        'api_settings_title' => 'Mga Setting ng API',
     ],
     'manage_customization' => [
         'header_label' => 'Custom na HTML para sa Header',

--- a/resources/lang/pt_BR/settings.php
+++ b/resources/lang/pt_BR/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => 'Permite que o Cachet carregue recursos como fontes de serviços externos.',
             'recent_incidents_days' => 'Número de Dias para Exibir Incidentes Recentes',
             'recent_incidents_days_helper' => 'Até quanto tempo atrás procurar ao listar incidentes recentes.',
+            'api_enabled' => 'Ativar API',
+            'api_enabled_helper' => 'Permitir o acesso à API do Cachet. Quando desativada, todas as requisições à API retornam 404.',
+            'api_protected' => 'Exigir Autenticação',
+            'api_protected_helper' => 'Exigir um token de API para todas as requisições, incluindo endpoints somente leitura.',
         ],
         'display_settings_title' => 'Configurações de Exibição',
+        'api_settings_title' => 'Configurações da API',
     ],
     'manage_customization' => [
         'header_label' => 'HTML Personalizado do Cabeçalho',

--- a/resources/lang/zh_CN/settings.php
+++ b/resources/lang/zh_CN/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => '允许 Cachet 从外部服务加载字体等资源。',
             'recent_incidents_days' => '显示最近事件的天数',
             'recent_incidents_days_helper' => '列出最近事件时回溯多远。',
+            'api_enabled' => '启用 API',
+            'api_enabled_helper' => '允许访问 Cachet API。禁用后,所有 API 请求将返回 404。',
+            'api_protected' => '需要身份验证',
+            'api_protected_helper' => '所有 API 请求(包括只读接口)都需要 API 令牌。',
         ],
         'display_settings_title' => '显示设置',
+        'api_settings_title' => 'API 设置',
     ],
     'manage_customization' => [
         'header_label' => '自定义 Header HTML',

--- a/resources/lang/zh_TW/settings.php
+++ b/resources/lang/zh_TW/settings.php
@@ -33,8 +33,13 @@ return [
             'enable_external_dependencies_helper' => '允許 Cachet 從外部服務載入字型等資源。',
             'recent_incidents_days' => '顯示最近事件的天數',
             'recent_incidents_days_helper' => '列出最近事件時回溯多遠。',
+            'api_enabled' => '啟用 API',
+            'api_enabled_helper' => '允許存取 Cachet API。停用後,所有 API 請求將返回 404。',
+            'api_protected' => '需要身份驗證',
+            'api_protected_helper' => '所有 API 請求(包括唯讀端點)都需要 API 權杖。',
         ],
         'display_settings_title' => '顯示設定',
+        'api_settings_title' => 'API 設定',
     ],
     'manage_customization' => [
         'header_label' => '自定義 Header HTML',

--- a/src/Filament/Pages/Settings/ManageCachet.php
+++ b/src/Filament/Pages/Settings/ManageCachet.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 
 use function __;
@@ -105,6 +106,20 @@ class ManageCachet extends SettingsPage
                         Toggle::make('only_disrupted_days')
                             ->label(__('cachet::settings.manage_cachet.toggles.only_show_disrupted_days'))
                             ->helperText(__('cachet::settings.manage_cachet.toggles.only_show_disrupted_days_helper')),
+                    ]),
+
+                Section::make(__('cachet::settings.manage_cachet.api_settings_title'))
+                    ->columns(2)
+                    ->schema([
+                        Toggle::make('api_enabled')
+                            ->label(__('cachet::settings.manage_cachet.toggles.api_enabled'))
+                            ->helperText(__('cachet::settings.manage_cachet.toggles.api_enabled_helper'))
+                            ->afterStateUpdated(fn (Set $set) => $set('api_protected', false))
+                            ->reactive(),
+                        Toggle::make('api_protected')
+                            ->label(__('cachet::settings.manage_cachet.toggles.api_protected'))
+                            ->helperText(__('cachet::settings.manage_cachet.toggles.api_protected_helper'))
+                            ->visible(fn (Get $get) => $get('api_enabled') === true),
                     ]),
             ]);
     }

--- a/src/Http/Middleware/AuthenticateApiIfProtected.php
+++ b/src/Http/Middleware/AuthenticateApiIfProtected.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Cachet\Settings\AppSettings;
+use Closure;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Http\Request;
+
+class AuthenticateApiIfProtected
+{
+    public function __construct(
+        private AppSettings $settings,
+        private AuthFactory $auth,
+    ) {}
+
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->settings->api_protected && ! $this->auth->guard('sanctum')->check()) {
+            abort(401, 'Unauthenticated.');
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/EnsureApiIsEnabled.php
+++ b/src/Http/Middleware/EnsureApiIsEnabled.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Cachet\Settings\AppSettings;
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureApiIsEnabled
+{
+    public function __construct(private AppSettings $settings) {}
+
+    public function handle(Request $request, Closure $next)
+    {
+        abort_unless($this->settings->api_enabled, 404);
+
+        return $next($request);
+    }
+}

--- a/src/Settings/AppSettings.php
+++ b/src/Settings/AppSettings.php
@@ -38,6 +38,10 @@ class AppSettings extends Settings
 
     public bool $enable_external_dependencies = true;
 
+    public bool $api_enabled = true;
+
+    public bool $api_protected = false;
+
     public static function group(): string
     {
         return 'app';

--- a/tests/Feature/Api/ApiSettingsTest.php
+++ b/tests/Feature/Api/ApiSettingsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Cachet\Settings\AppSettings;
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+it('allows guests to read the api by default', function () {
+    getJson('/status/api/ping')
+        ->assertOk();
+});
+
+it('responds not found when the api is disabled', function () {
+    $settings = app(AppSettings::class);
+    $settings->api_enabled = false;
+    $settings->save();
+
+    getJson('/status/api/ping')
+        ->assertNotFound();
+});
+
+it('responds not found when the api is disabled, even for authenticated users', function () {
+    $settings = app(AppSettings::class);
+    $settings->api_enabled = false;
+    $settings->api_protected = true;
+    $settings->save();
+
+    Sanctum::actingAs(User::factory()->create(), ['*']);
+
+    getJson('/status/api/ping')
+        ->assertNotFound();
+});
+
+it('requires authentication for read endpoints when the api is protected', function () {
+    $settings = app(AppSettings::class);
+    $settings->api_protected = true;
+    $settings->save();
+
+    getJson('/status/api/ping')
+        ->assertUnauthorized();
+});
+
+it('allows authenticated users to read the api when the api is protected', function () {
+    $settings = app(AppSettings::class);
+    $settings->api_protected = true;
+    $settings->save();
+
+    Sanctum::actingAs(User::factory()->create(), ['*']);
+
+    getJson('/status/api/ping')
+        ->assertOk();
+});
+
+it('still guards write endpoints by token abilities when the api is protected', function () {
+    $settings = app(AppSettings::class);
+    $settings->api_protected = true;
+    $settings->save();
+
+    Sanctum::actingAs(User::factory()->create(), ['components.view']);
+
+    postJson('/status/api/components', [
+        'name' => 'New Component',
+    ])->assertForbidden();
+});


### PR DESCRIPTION
Reimplements #236 on current `main` (Filament v4), following the repo guidelines. Closes #235.

## What this adds

Two new app settings, manageable from **Settings → Manage Cachet** in the dashboard:

- **Enable API** (`api_enabled`, default `true`) — when disabled, every API request responds with a 404.
- **Require Authentication** (`api_protected`, default `false`) — when enabled, read-only endpoints (`index`/`show`, ping, status, etc.) also require a Sanctum token. Write endpoints keep their existing `auth:sanctum` + ability guards.

## How it works

- Two single-purpose middleware are added to the `cachet.api_middleware` config group, so they apply to every API route:
  - `EnsureApiIsEnabled` aborts with 404 when the API is disabled.
  - `AuthenticateApiIfProtected` aborts with 401 when the API is protected and the sanctum guard has no authenticated user. It deliberately does not extend the framework `Authenticate` middleware, so there is no redirect to a non-existent `login` route (addresses review feedback on #236).
- Settings migration follows the `add_external_dependencies_setting` pattern (`rescue()` + `migrator->add()`), so no `getOrDefault()` helper is needed on `AppSettings`.
- In the dashboard, **Require Authentication** is only visible while the API is enabled, and flipping **Enable API** resets it to `false` (per review feedback on #236).
- Labels and helper text added for all locales that carry the `manage_cachet` section (en_GB falls back to en).

## Tests

`tests/Feature/Api/ApiSettingsTest.php` covers: default public access, disabled → 404 (including for authenticated users), protected → 401 for guests / 200 with a token, and that write endpoints still enforce token abilities when protected.

Full suite, Pint, and Psalm pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)