### PR TITLE
Add app-based two-factor authentication for dashboard users

### DIFF
--- a/database/migrations/2026_07_08_000003_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2026_07_08_000003_add_two_factor_columns_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('app_authentication_secret')->nullable();
+            $table->text('app_authentication_recovery_codes')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['app_authentication_secret', 'app_authentication_recovery_codes']);
+        });
+    }
+};

--- a/resources/css/dashboard/theme.css
+++ b/resources/css/dashboard/theme.css
@@ -5,3 +5,38 @@
 .theme-swatch {
     @apply inline-flex w-4 h-4 rounded-full mr-2 bg-[var(--swatch)];
 }
+
+/*
+ * Stretch the one-time code input (2FA set up and login challenge) to the full
+ * width of the form, spreading the six digit boxes evenly. The characters are
+ * typed into a hidden overlaid input, so its letter spacing and padding are
+ * recalculated with container query units to keep each digit centred in its box.
+ * The pitch math assumes Filament's default code length of six digits.
+ */
+.fi-one-time-code-input-ctn {
+    --otp-gap: 0.5rem;
+    --otp-pitch: calc((100cqw + var(--otp-gap)) / 6);
+
+    container-type: inline-size;
+    display: flex;
+    gap: var(--otp-gap);
+
+    & > .fi-one-time-code-input-digit-field {
+        flex: 1 1 0%;
+
+        /* Filament thickens the active digit's border from 1px to 2px, which
+         * makes the boxes shift as focus moves. Keep the border at 1px and
+         * draw the second pixel with an inset ring instead. */
+        &.fi-active {
+            @apply border shadow-[inset_0_0_0_1px_var(--color-primary-600)] dark:shadow-[inset_0_0_0_1px_var(--color-primary-500)];
+        }
+    }
+}
+
+input[type='text'].fi-one-time-code-input {
+    font-size: 1.25rem;
+    letter-spacing: calc(var(--otp-pitch) - 1ch);
+    padding-inline: 0;
+    padding-left: calc((var(--otp-pitch) - var(--otp-gap) - 1ch) / 2);
+    right: calc(1ch - var(--otp-pitch));
+}

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -15,6 +15,9 @@ return [
         ],
         'actions' => [
             'verify_email' => 'Verify Email',
+            'reset_two_factor' => 'Reset Two-Factor Authentication',
+            'reset_two_factor_confirmation' => 'This will remove the user\'s two-factor authentication setup and recovery codes. They will be able to sign in with only their password until they set it up again.',
+            'reset_two_factor_success' => 'Two-factor authentication has been reset.',
         ],
     ],
     'form' => [

--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Cachet;
 
+use Cachet\Filament\MultiFactor\AppAuthentication;
 use Cachet\Filament\Pages\EditProfile;
 use Cachet\Http\Middleware\AuthenticateSession;
 use Cachet\Http\Middleware\SetAppLocale;
@@ -40,6 +41,9 @@ class CachetDashboardServiceProvider extends PanelProvider
             ->default()
             ->login()
             ->passwordReset()
+            ->multiFactorAuthentication([
+                AppAuthentication::make()->recoverable(),
+            ])
             ->profile(EditProfile::class)
             ->brandLogo(fn () => view('cachet::filament.brand-logo'))
             ->brandLogoHeight('2rem')

--- a/src/Filament/MultiFactor/AppAuthentication.php
+++ b/src/Filament/MultiFactor/AppAuthentication.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Cachet\Filament\MultiFactor;
+
+use Cachet\Settings\AppSettings;
+use Filament\Actions\Action;
+use Filament\Auth\MultiFactor\App\AppAuthentication as BaseAppAuthentication;
+use Filament\Forms\Components\OneTimeCodeInput;
+use Filament\Schemas\Components\Flex;
+use Filament\Schemas\Components\Group;
+use Filament\Schemas\Components\Image;
+use Filament\Schemas\Components\Text;
+use Filament\Schemas\Components\Wizard;
+use Filament\Schemas\Components\Wizard\Step;
+use Filament\Support\Enums\FontFamily;
+
+class AppAuthentication extends BaseAppAuthentication
+{
+    /**
+     * The status page name identifies the account in authenticator apps, rather
+     * than the host application's name. Resolved lazily to avoid querying the
+     * settings table while the panel is being configured.
+     */
+    public function getBrandName(): string
+    {
+        return $this->brandName ?? app(AppSettings::class)->name ?? parent::getBrandName();
+    }
+
+    /**
+     * @return array<Action>
+     */
+    public function getActions(): array
+    {
+        return array_map(
+            fn (Action $action): Action => $action->getName() === 'setUpAppAuthentication'
+                ? $this->configureSetUpAction($action)
+                : $action,
+            parent::getActions(),
+        );
+    }
+
+    /**
+     * Restyles Filament's set-up wizard while reusing its verification and persistence logic.
+     * Only the visual QR code group is rebuilt; the one-time code input, with its validation
+     * and rate limiting, is kept as-is. If Filament's internal structure changes, the stock
+     * wizard is rendered unchanged.
+     */
+    protected function configureSetUpAction(Action $action): Action
+    {
+        return $action
+            ->button()
+            ->modifyWizardUsing(function (Wizard $wizard) use ($action): Wizard {
+                $wizard->hiddenHeader();
+
+                $steps = $wizard->getDefaultChildComponents();
+                $appStep = is_array($steps) ? ($steps[0] ?? null) : null;
+
+                if (! $appStep instanceof Step) {
+                    return $wizard;
+                }
+
+                $stepComponents = $appStep->getDefaultChildComponents();
+
+                $codeInput = is_array($stepComponents)
+                    ? collect($stepComponents)->first(fn (mixed $component): bool => $component instanceof OneTimeCodeInput)
+                    : null;
+
+                if (! $codeInput instanceof OneTimeCodeInput) {
+                    return $wizard;
+                }
+
+                $secret = fn (): string => decrypt($action->getArguments()['encrypted'])['secret'];
+
+                $appStep->schema([
+                    Group::make([
+                        Text::make(__('filament-panels::auth/multi-factor/app/actions/set-up.modal.content.qr_code.instruction'))
+                            ->color('neutral'),
+                        Image::make(
+                            url: fn (): string => $this->generateQrCodeDataUri($secret()),
+                            alt: __('filament-panels::auth/multi-factor/app/actions/set-up.modal.content.qr_code.alt'),
+                        )
+                            ->imageHeight('10rem')
+                            ->alignCenter(),
+                        Flex::make([
+                            Text::make(__('filament-panels::auth/multi-factor/app/actions/set-up.modal.content.text_code.instruction'))
+                                ->color('neutral')
+                                ->grow(false),
+                            Text::make($secret)
+                                ->fontFamily(FontFamily::Mono)
+                                ->badge()
+                                ->copyable()
+                                ->copyMessage(__('filament-panels::auth/multi-factor/app/actions/set-up.modal.content.text_code.messages.copied'))
+                                ->grow(false),
+                        ])->from('sm'),
+                    ])
+                        ->dense(),
+                    $codeInput,
+                ]);
+
+                return $wizard;
+            });
+    }
+}

--- a/src/Filament/Resources/Users/UserResource.php
+++ b/src/Filament/Resources/Users/UserResource.php
@@ -131,6 +131,19 @@ class UserResource extends Resource
                     ->icon('heroicon-o-check-badge')
                     ->disabled(fn (User $record): bool => $record->hasVerifiedEmail())
                     ->action(fn (Builder $query, User $record) => $record->sendEmailVerificationNotification()),
+                Action::make('reset-two-factor')
+                    ->label(__('cachet::user.list.actions.reset_two_factor'))
+                    ->icon('heroicon-o-shield-exclamation')
+                    ->requiresConfirmation()
+                    ->modalDescription(__('cachet::user.list.actions.reset_two_factor_confirmation'))
+                    ->visible(fn (User $record): bool => filled($record->getAppAuthenticationSecret()))
+                    ->action(function (Action $action, User $record): void {
+                        $record->saveAppAuthenticationSecret(null);
+                        $record->saveAppAuthenticationRecoveryCodes(null);
+
+                        $action->success();
+                    })
+                    ->successNotificationTitle(__('cachet::user.list.actions.reset_two_factor_success')),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -4,6 +4,10 @@ namespace Cachet\Models;
 
 use Cachet\Concerns\CachetUser;
 use Cachet\Database\Factories\UserFactory;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -20,11 +24,13 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $password
  * @property bool $is_admin
  * @property string $preferred_locale
+ * @property ?string $app_authentication_secret
+ * @property ?array $app_authentication_recovery_codes
  */
-class User extends Authenticatable implements CachetUser, HasLocalePreference, MustVerifyEmail
+class User extends Authenticatable implements CachetUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasLocalePreference, MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
-    use HasApiTokens, HasFactory, MustVerifyEmailTrait, Notifiable;
+    use HasApiTokens, HasFactory, InteractsWithAppAuthentication, InteractsWithAppAuthenticationRecovery, MustVerifyEmailTrait, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/Feature/Filament/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Filament/TwoFactorAuthenticationTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use Cachet\Filament\MultiFactor\AppAuthentication;
+use Cachet\Filament\Pages\EditProfile;
+use Cachet\Filament\Resources\Users\Pages\ListUsers;
+use Cachet\Settings\AppSettings;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\OneTimeCodeInput;
+use Filament\Schemas\Components\Image;
+use Filament\Schemas\Components\Wizard;
+use Illuminate\Support\Facades\DB;
+use Workbench\App\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('cachet'));
+
+    actingAs(User::factory()->create(['is_admin' => true]));
+});
+
+it('registers app authentication on the panel', function () {
+    $providers = Filament::getCurrentPanel()->getMultiFactorAuthenticationProviders();
+
+    expect($providers)->toHaveCount(1)
+        ->and($providers['app'])->toBeInstanceOf(AppAuthentication::class)
+        ->and($providers['app']->isRecoverable())->toBeTrue();
+});
+
+it('renders the set up action as a button', function () {
+    $provider = Filament::getCurrentPanel()->getMultiFactorAuthenticationProviders()['app'];
+
+    $setUpAction = collect($provider->getActions())
+        ->first(fn ($action) => $action->getName() === 'setUpAppAuthentication');
+
+    expect($setUpAction->isButton())->toBeTrue();
+});
+
+it('mounts the set up wizard with the restyled first step', function () {
+    $page = livewire(EditProfile::class)
+        ->mountAction(TestAction::make('setUpAppAuthentication')->schemaComponent(schema: 'content'))
+        ->instance();
+
+    $wizard = $page->getSchema($page->getMountedActionSchemaName())->getComponents()[0];
+
+    expect($wizard)->toBeInstanceOf(Wizard::class);
+
+    $appStepComponents = $wizard->getChildComponents()[0]->getChildComponents();
+
+    expect($appStepComponents[1])->toBeInstanceOf(OneTimeCodeInput::class);
+
+    $image = collect($appStepComponents[0]->getChildComponents())
+        ->first(fn (mixed $component): bool => $component instanceof Image);
+
+    expect($image->getImageHeight())->toBe('10rem');
+});
+
+it('labels authenticator app entries with the status page name', function () {
+    $provider = Filament::getCurrentPanel()->getMultiFactorAuthenticationProviders()['app'];
+
+    $settings = app(AppSettings::class);
+    $settings->name = 'Acme Status';
+    $settings->save();
+
+    expect($provider->getBrandName())->toBe('Acme Status');
+});
+
+it('shows the two factor authentication section on the profile page', function () {
+    $this->get(EditProfile::getUrl())
+        ->assertOk()
+        ->assertSee(__('filament-panels::auth/pages/edit-profile.multi_factor_authentication.label'));
+});
+
+it('encrypts the app authentication secret and recovery codes', function () {
+    $user = User::factory()->create();
+
+    $user->saveAppAuthenticationSecret('super-secret');
+    $user->saveAppAuthenticationRecoveryCodes(['code-one', 'code-two']);
+
+    $rawUser = DB::table('users')->find($user->id);
+
+    expect($rawUser->app_authentication_secret)->not->toContain('super-secret')
+        ->and($rawUser->app_authentication_recovery_codes)->not->toContain('code-one')
+        ->and($user->fresh()->getAppAuthenticationSecret())->toBe('super-secret')
+        ->and($user->fresh()->getAppAuthenticationRecoveryCodes())->toBe(['code-one', 'code-two']);
+});
+
+it('hides the app authentication secret and recovery codes from serialization', function () {
+    $user = User::factory()->create();
+
+    $user->saveAppAuthenticationSecret('super-secret');
+    $user->saveAppAuthenticationRecoveryCodes(['code-one']);
+
+    expect($user->fresh()->toArray())
+        ->not->toHaveKeys(['app_authentication_secret', 'app_authentication_recovery_codes']);
+});
+
+it('resets a user\'s two factor authentication through the table action', function () {
+    $user = User::factory()->create();
+    $user->saveAppAuthenticationSecret('super-secret');
+    $user->saveAppAuthenticationRecoveryCodes(['code-one', 'code-two']);
+
+    livewire(ListUsers::class)
+        ->callAction(TestAction::make('reset-two-factor')->table($user))
+        ->assertHasNoActionErrors();
+
+    $user = $user->fresh();
+
+    expect($user->getAppAuthenticationSecret())->toBeNull()
+        ->and($user->getAppAuthenticationRecoveryCodes())->toBeNull();
+});
+
+it('hides the reset two factor action for users without two factor authentication', function () {
+    $user = User::factory()->create();
+
+    livewire(ListUsers::class)
+        ->assertActionHidden(TestAction::make('reset-two-factor')->table($user));
+});


### PR DESCRIPTION
Adds app-based two-factor authentication to the dashboard, built on Filament's multi-factor authentication.

## What's included

- **Set up from the profile page.** Users enable two-factor authentication from their profile by scanning a QR code (or entering the setup key manually) with any TOTP authenticator app, then confirming with a 6-digit code. The setup wizard is restyled to match the Cachet dashboard, and authenticator app entries are labelled with the status page name rather than the host application's name.
- **Sign-in challenge.** Once enabled, users must enter a code from their authenticator app when signing in or performing sensitive actions.
- **Recovery codes.** Generated at set up so users can regain access if they lose their device.
- **Admin reset.** Admins can reset a user's two-factor authentication from the users table (with confirmation), covering the lost-device case.
- **Encrypted at rest.** The secret and recovery codes are stored encrypted and hidden from serialization.

Addressing each consideration from the original issue:

> How to generate the code

Standard TOTP via Filament's app authentication, compatible with Google Authenticator, 1Password, Authy, and similar apps.

> How to verify via 2FA when this is enabled on a user's account

Filament challenges the user at sign-in and re-verifies before sensitive actions.

> Can admins reset 2FA for a user if they've lost their 2FA device?

Yes, via a new action on the users table, only visible for users who have two-factor authentication enabled.

> How should backup codes work?

Recovery codes are generated during set up, stored encrypted, and can be used in place of a code. Resetting clears them alongside the secret.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)