### PR TITLE
Improve performance across status page, API, and dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,9 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 - Add useful array shape type definitions when appropriate.
 </laravel-boost-guidelines>
+
+# Project Conventions
+
+## HTTP Requests
+
+- Never use the `request()` helper. Inject `Illuminate\Http\Request` into the controller method and read input from `$request` (e.g. `$request->integer('per_page', 15)`).

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -134,6 +134,31 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Cachet Settings Cache
+     |--------------------------------------------------------------------------
+     |
+     | Cache Cachet's settings so they are not read from the database on every
+     | request. The cache is refreshed automatically whenever settings are
+     | saved, so it never serves stale values.
+     |
+     */
+    'settings_cache' => env('CACHET_SETTINGS_CACHE', true),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Cachet Component Checks
+     |--------------------------------------------------------------------------
+     |
+     | Configure how long component check results are kept before they are
+     | pruned by the model:prune scheduled task.
+     |
+     */
+    'checks' => [
+        'prune_checks_after_days' => env('CACHET_PRUNE_CHECKS_AFTER_DAYS', 30),
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
      | Cachet Webhooks
      |--------------------------------------------------------------------------
      |

--- a/src/Actions/Incident/NotifyIncidentSubscribers.php
+++ b/src/Actions/Incident/NotifyIncidentSubscribers.php
@@ -7,7 +7,6 @@ use Cachet\Models\Incident;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\NewIncidentNotification;
 use Cachet\Settings\MailSettings;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyIncidentSubscribers
 {
@@ -36,9 +35,10 @@ class NotifyIncidentSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($incident)->get(),
-            new NewIncidentNotification($incident),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($incident)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new NewIncidentNotification($incident)));
     }
 }

--- a/src/Actions/Schedule/NotifyScheduleCompletedSubscribers.php
+++ b/src/Actions/Schedule/NotifyScheduleCompletedSubscribers.php
@@ -7,7 +7,6 @@ use Cachet\Models\Schedule;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\ScheduleCompletedNotification;
 use Cachet\Settings\MailSettings;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyScheduleCompletedSubscribers
 {
@@ -37,10 +36,11 @@ class NotifyScheduleCompletedSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($schedule)->get(),
-            new ScheduleCompletedNotification($schedule),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($schedule)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new ScheduleCompletedNotification($schedule)));
 
         $schedule->forceFill(['completed_notified_at' => now()])->saveQuietly();
     }

--- a/src/Actions/Schedule/NotifyScheduleRescheduledSubscribers.php
+++ b/src/Actions/Schedule/NotifyScheduleRescheduledSubscribers.php
@@ -8,7 +8,6 @@ use Cachet\Models\Subscriber;
 use Cachet\Notifications\ScheduleRescheduledNotification;
 use Cachet\Settings\MailSettings;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyScheduleRescheduledSubscribers
 {
@@ -34,9 +33,10 @@ class NotifyScheduleRescheduledSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($schedule)->get(),
-            new ScheduleRescheduledNotification($schedule, $previousScheduledAt, $previousCompletedAt),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($schedule)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new ScheduleRescheduledNotification($schedule, $previousScheduledAt, $previousCompletedAt)));
     }
 }

--- a/src/Actions/Schedule/NotifyScheduleSubscribers.php
+++ b/src/Actions/Schedule/NotifyScheduleSubscribers.php
@@ -6,7 +6,6 @@ use Cachet\Models\Schedule;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\NewScheduleNotification;
 use Cachet\Settings\MailSettings;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyScheduleSubscribers
 {
@@ -31,9 +30,10 @@ class NotifyScheduleSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($schedule)->get(),
-            new NewScheduleNotification($schedule),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($schedule)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new NewScheduleNotification($schedule)));
     }
 }

--- a/src/Actions/Update/NotifyIncidentUpdateSubscribers.php
+++ b/src/Actions/Update/NotifyIncidentUpdateSubscribers.php
@@ -8,7 +8,6 @@ use Cachet\Models\Subscriber;
 use Cachet\Models\Update;
 use Cachet\Notifications\IncidentUpdatedNotification;
 use Cachet\Settings\MailSettings;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyIncidentUpdateSubscribers
 {
@@ -40,9 +39,10 @@ class NotifyIncidentUpdateSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($incident)->get(),
-            new IncidentUpdatedNotification($update),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($incident)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new IncidentUpdatedNotification($update)));
     }
 }

--- a/src/Actions/Update/NotifyScheduleUpdateSubscribers.php
+++ b/src/Actions/Update/NotifyScheduleUpdateSubscribers.php
@@ -7,7 +7,6 @@ use Cachet\Models\Subscriber;
 use Cachet\Models\Update;
 use Cachet\Notifications\ScheduleUpdatedNotification;
 use Cachet\Settings\MailSettings;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyScheduleUpdateSubscribers
 {
@@ -35,9 +34,10 @@ class NotifyScheduleUpdateSubscribers
             return;
         }
 
-        Notification::send(
-            Subscriber::query()->verified()->subscribedTo($schedule)->get(),
-            new ScheduleUpdatedNotification($update),
-        );
+        Subscriber::query()
+            ->verified()
+            ->subscribedTo($schedule)
+            ->cursor()
+            ->each(fn (Subscriber $subscriber) => $subscriber->notify(new ScheduleUpdatedNotification($update)));
     }
 }

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -12,8 +12,10 @@ use Cachet\Commands\VersionCommand;
 use Cachet\Database\Seeders\DatabaseSeeder;
 use Cachet\Listeners\SendWebhookListener;
 use Cachet\Listeners\WebhookCallEventListener;
+use Cachet\Models\ComponentCheck;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
+use Cachet\Models\WebhookAttempt;
 use Cachet\Settings\AppSettings;
 use Cachet\Settings\MailSettings;
 use Cachet\View\Composers\MailThemeComposer;
@@ -33,7 +35,6 @@ use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -54,6 +55,22 @@ class CachetCoreServiceProvider extends ServiceProvider
 
         $this->app->singleton(Cachet::class);
         $this->app->singleton(ViewManager::class);
+        $this->app->scoped(Status::class);
+
+        $this->configureSettingsCache();
+    }
+
+    /**
+     * Enable spatie/laravel-settings' cache so settings are not read from the
+     * database on every request. The cache is refreshed automatically when
+     * settings are saved. Must run during registration, before the dashboard
+     * panel provider resolves any settings.
+     */
+    private function configureSettingsCache(): void
+    {
+        if (config('cachet.settings_cache', true)) {
+            config()->set('settings.cache.enabled', true);
+        }
     }
 
     /**
@@ -88,10 +105,6 @@ class CachetCoreServiceProvider extends ServiceProvider
         ], SendWebhookListener::class);
         Event::listen([WebhookCallSucceededEvent::class, WebhookCallFailedEvent::class], WebhookCallEventListener::class);
 
-        Http::globalRequestMiddleware(fn ($request) => $request->withHeader(
-            'User-Agent', Cachet::USER_AGENT
-        ));
-
         FilamentColor::register([
             'cachet' => Color::generateV3Palette('rgb(4, 193, 71)'),
         ]);
@@ -115,9 +128,19 @@ class CachetCoreServiceProvider extends ServiceProvider
     /**
      * Override the application's mail configuration with Cachet's mail settings, when configured.
      *
+     * Deferred until the mailer is first resolved so requests that never send
+     * mail do not pay for loading the mail settings.
+     *
      * Wrapped in rescue() so a missing settings table (pre-setup, pre-migration) is not fatal.
      */
     private function configureMail(): void
+    {
+        $this->callAfterResolving('mail.manager', function (): void {
+            $this->applyMailSettings();
+        });
+    }
+
+    private function applyMailSettings(): void
     {
         rescue(function (): void {
             $settings = $this->app->make(MailSettings::class);
@@ -251,6 +274,10 @@ class CachetCoreServiceProvider extends ServiceProvider
             $schedule->command('cachet:notify-long-running-incidents')->hourly();
 
             $schedule->command('cachet:notify-completed-schedules')->everyFiveMinutes();
+
+            $schedule->command('model:prune', [
+                '--model' => [WebhookAttempt::class, ComponentCheck::class],
+            ])->daily();
 
             $schedule->command('db:seed', [
                 '--class' => DatabaseSeeder::class,

--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -29,12 +29,13 @@ class CachetDashboardServiceProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
-        $appSettings = app(AppSettings::class);
+        $enableExternalDependencies = ! $this->app->runningInConsole()
+            && rescue(fn () => app(AppSettings::class)->enable_external_dependencies, false, report: false);
 
         return $panel
             ->id('cachet')
             ->when(
-                ! $this->app->runningInConsole() && $appSettings->enable_external_dependencies,
+                $enableExternalDependencies,
                 fn ($panel) => $panel->font('switzer', 'https://fonts.cdnfonts.com/css/switzer'),
                 fn ($panel) => $panel->font('ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" ', provider: LocalFontProvider::class),
             )

--- a/src/Commands/NotifyLongRunningIncidentsCommand.php
+++ b/src/Commands/NotifyLongRunningIncidentsCommand.php
@@ -7,7 +7,6 @@ use Cachet\Notifications\LongRunningIncidentNotification;
 use Cachet\Settings\MailSettings;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Notification;
 
 class NotifyLongRunningIncidentsCommand extends Command
 {
@@ -53,10 +52,10 @@ class NotifyLongRunningIncidentsCommand extends Command
             return 0;
         }
 
-        $users = config('cachet.user_model')::query()->get();
-
-        $incidents->each(function (Incident $incident) use ($users) {
-            Notification::send($users, new LongRunningIncidentNotification($incident));
+        $incidents->each(function (Incident $incident) {
+            config('cachet.user_model')::query()
+                ->cursor()
+                ->each(fn ($user) => $user->notify(new LongRunningIncidentNotification($incident)));
 
             $incident->forceFill(['long_running_notified_at' => Carbon::now()])->saveQuietly();
         });

--- a/src/Filament/Pages/Integrations/OhDear.php
+++ b/src/Filament/Pages/Integrations/OhDear.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Pages\Integrations;
 
 use Cachet\Actions\Integrations\ImportOhDearFeed;
+use Cachet\Cachet;
 use Cachet\Filament\Resources\ComponentGroups\ComponentGroupResource;
 use Cachet\Models\Component;
 use Filament\Forms\Components\Select;
@@ -103,6 +104,7 @@ class OhDear extends Page
 
         try {
             $ohDear = Http::baseUrl(rtrim($this->url))
+                ->withUserAgent(Cachet::USER_AGENT)
                 ->get('/json')
                 ->throw()
                 ->json();

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -14,6 +14,7 @@ use Cachet\Filament\Resources\Incidents\RelationManagers\ComponentsRelationManag
 use Cachet\Filament\Resources\Updates\RelationManagers\UpdatesRelationManager;
 use Cachet\Models\Incident;
 use Cachet\Settings\MailSettings;
+use Cachet\Status;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -35,6 +36,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class IncidentResource extends Resource
 {
@@ -253,11 +255,14 @@ class IncidentResource extends Resource
         return trans_choice('cachet::incident.resource_label', 2);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->with('updates');
+    }
+
     public static function getNavigationBadge(): ?string
     {
-        return (string) Incident::unresolved()
-            ->get()
-            ->filter(fn (Incident $incident) => in_array($incident->latest_status, IncidentStatusEnum::unresolved()))->count();
+        return (string) (int) app(Status::class)->incidents()->unresolved;
     }
 
     public static function getNavigationBadgeColor(): string

--- a/src/Filament/Resources/WebhookSubscriptions/Pages/EditWebhookSubscription.php
+++ b/src/Filament/Resources/WebhookSubscriptions/Pages/EditWebhookSubscription.php
@@ -29,7 +29,7 @@ class EditWebhookSubscription extends EditRecord
                 $this->getFormContentComponent(),
                 $this->getRelationManagersContentComponent(),
                 view('cachet::filament.widgets.webhook-attempts', [
-                    'attempts' => $webhookSubscription->attempts,
+                    'attempts' => $webhookSubscription->attempts()->latest()->limit(50)->get(),
                 ]),
             ]);
     }

--- a/src/Filament/Widgets/Components.php
+++ b/src/Filament/Widgets/Components.php
@@ -49,7 +49,7 @@ class Components extends Widget implements HasSchemas
                 return Section::make($componentGroup->name)
                     ->schema(function () use ($componentGroup) {
                         return $this->components
-                            ->filter(fn (Component $component) => $componentGroup->is($component->group))
+                            ->filter(fn (Component $component) => $component->component_group_id === $componentGroup->getKey())
                             ->map(fn (Component $component) => Group::make([$this->buildToggleButton($component)]))
                             ->toArray();
                     })

--- a/src/Filament/Widgets/Feed.php
+++ b/src/Filament/Widgets/Feed.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Filament\Widgets;
 
+use Cachet\Cachet;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Blade;
@@ -60,7 +61,7 @@ class Feed extends Widget
         $useInternalErrors = libxml_use_internal_errors(true);
 
         try {
-            $response = Http::timeout(5)->get($uri);
+            $response = Http::withUserAgent(Cachet::USER_AGENT)->timeout(5)->get($uri);
 
             $xml = simplexml_load_string($response->body());
 

--- a/src/Filament/Widgets/OpenIncidents.php
+++ b/src/Filament/Widgets/OpenIncidents.php
@@ -24,6 +24,7 @@ class OpenIncidents extends TableWidget
             ->query(
                 Incident::query()
                     ->unresolved()
+                    ->with('updates')
                     ->withCount('components')
                     ->orderByDesc('occurred_at')
             )

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -13,8 +13,10 @@ use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -39,7 +41,7 @@ class ComponentController extends Controller
     #[QueryParameter('filter[enabled]', 'Filter by enabled status.', type: 'bool', example: '1')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index()
+    public function index(Request $request)
     {
         $components = QueryBuilder::for(Component::class)
             ->allowedIncludes(self::ALLOWED_INCLUDES)
@@ -49,7 +51,7 @@ class ComponentController extends Controller
                 AllowedFilter::exact('enabled'),
             ])
             ->allowedSorts(['name', 'order', 'id'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return ComponentResource::collection($components);
     }

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -12,8 +12,10 @@ use Cachet\Http\Resources\ComponentGroup as ComponentGroupResource;
 use Cachet\Models\ComponentGroup;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Component Groups', weight: 2)]
@@ -26,12 +28,12 @@ class ComponentGroupController extends Controller
      */
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index()
+    public function index(Request $request)
     {
         $componentGroups = QueryBuilder::for(ComponentGroup::class)
             ->allowedIncludes(['components'])
             ->allowedSorts(['name', 'id'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return ComponentGroupResource::collection($componentGroups);
     }

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -15,6 +15,7 @@ use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -40,7 +41,7 @@ class IncidentController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $incidents = QueryBuilder::for(Incident::query())
+        $incidents = QueryBuilder::for(Incident::query()->with('updates'))
             ->allowedIncludes(self::ALLOWED_INCLUDES)
             ->allowedFilters([
                 'name',
@@ -51,7 +52,7 @@ class IncidentController extends Controller
             ])
             ->allowedSorts(['name', 'status', 'id', 'created_at'])
             ->defaultSort('-created_at')
-            ->simplePaginate($request->input('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return IncidentResource::collection($incidents);
     }

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -12,8 +12,10 @@ use Cachet\Http\Resources\IncidentTemplate as IncidentTemplateResource;
 use Cachet\Models\IncidentTemplate;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Incident Templates', weight: 5)]
@@ -28,12 +30,12 @@ class IncidentTemplateController extends Controller
     #[QueryParameter('filter[slug]', 'Filter by slug', example: 'my-template')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index()
+    public function index(Request $request)
     {
         $templates = QueryBuilder::for(IncidentTemplate::class)
             ->allowedFilters(['name', 'slug'])
             ->allowedSorts(['name', 'slug', 'id'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return IncidentTemplateResource::collection($templates);
     }

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -13,8 +13,10 @@ use Cachet\Models\Incident;
 use Cachet\Models\Update;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -29,7 +31,7 @@ class IncidentUpdateController extends Controller
      */
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index(Incident $incident)
+    public function index(Request $request, Incident $incident)
     {
         $query = Update::query()
             ->where('updateable_id', $incident->id)
@@ -39,7 +41,7 @@ class IncidentUpdateController extends Controller
             ->allowedFilters([AllowedFilter::exact('status')])
             ->allowedIncludes(['incident'])
             ->allowedSorts(['status', 'created_at'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return UpdateResource::collection($updates);
     }

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -14,8 +14,10 @@ use Cachet\Models\Metric;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Metrics', weight: 6)]
@@ -30,7 +32,7 @@ class MetricController extends Controller
     #[QueryParameter('filter[calc_type]', 'Filter by calculation type.', type: MetricTypeEnum::class)]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index()
+    public function index(Request $request)
     {
         $query = Metric::query()
             ->when(! request('sort'), function (Builder $builder) {
@@ -41,7 +43,7 @@ class MetricController extends Controller
             ->allowedIncludes(['points'])
             ->allowedFilters(['name', 'calc_type'])
             ->allowedSorts(['name', 'order', 'id'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return MetricResource::collection($metrics);
     }

--- a/src/Http/Controllers/Api/MetricPointController.php
+++ b/src/Http/Controllers/Api/MetricPointController.php
@@ -11,8 +11,10 @@ use Cachet\Models\Metric;
 use Cachet\Models\MetricPoint;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Metric Points', weight: 7)]
@@ -25,7 +27,7 @@ class MetricPointController extends Controller
      */
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index(Metric $metric)
+    public function index(Request $request, Metric $metric)
     {
         $query = MetricPoint::query()
             ->where('metric_id', $metric->id);
@@ -33,7 +35,7 @@ class MetricPointController extends Controller
         $points = QueryBuilder::for($query)
             ->allowedIncludes(['metric'])
             ->allowedSorts(['name', 'order', 'id'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return MetricPointResource::collection($points);
     }

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -14,8 +14,10 @@ use Cachet\Http\Resources\Schedule as ScheduleResource;
 use Cachet\Models\Schedule;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -31,13 +33,13 @@ class ScheduleController extends Controller
     #[QueryParameter('filter[status]', 'Filter the resources by status.', type: ScheduleStatusEnum::class)]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index()
+    public function index(Request $request)
     {
         $schedules = QueryBuilder::for(Schedule::class)
             ->allowedIncludes(['components', 'components.group', 'updates', 'user'])
             ->allowedFilters(['name', AllowedFilter::custom('status', new ScheduleStatusFilter)])
             ->allowedSorts(['name', 'id', 'scheduled_at', 'completed_at'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return ScheduleResource::collection($schedules);
     }

--- a/src/Http/Controllers/Api/ScheduleUpdateController.php
+++ b/src/Http/Controllers/Api/ScheduleUpdateController.php
@@ -14,8 +14,10 @@ use Cachet\Models\Update;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -29,7 +31,7 @@ class ScheduleUpdateController extends Controller
      */
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
-    public function index(Schedule $schedule)
+    public function index(Request $request, Schedule $schedule)
     {
         $query = Update::query()
             ->where('updateable_id', $schedule->id)
@@ -38,7 +40,7 @@ class ScheduleUpdateController extends Controller
         $updates = QueryBuilder::for($query)
             ->allowedSorts(['created_at'])
             ->allowedIncludes(['schedule'])
-            ->simplePaginate(request('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return UpdateResource::collection($updates);
     }

--- a/src/Http/Controllers/Api/SubscriberController.php
+++ b/src/Http/Controllers/Api/SubscriberController.php
@@ -15,6 +15,7 @@ use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Number;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -39,7 +40,7 @@ class SubscriberController extends Controller
                 AllowedFilter::exact('global'),
             ])
             ->allowedSorts(['email', 'id'])
-            ->simplePaginate($request->input('per_page', 15));
+            ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
         return SubscriberResource::collection($subscribers);
     }

--- a/src/Http/Controllers/RssController.php
+++ b/src/Http/Controllers/RssController.php
@@ -6,37 +6,53 @@ use Cachet\Models\Incident;
 use Cachet\Settings\AppSettings;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 class RssController
 {
+    /**
+     * The maximum number of incidents included in the feed.
+     */
+    private const MAX_ITEMS = 100;
+
+    /**
+     * How long the rendered feed is cached for, in seconds.
+     */
+    private const CACHE_TTL = 60;
+
     /**
      * Returns the RSS feed of all incidents.
      */
     public function __invoke(AppSettings $appSettings): Response
     {
-        return response()->view('cachet::rss', [
-            'statusPageName' => $appSettings->name,
-            'statusAbout' => $appSettings->about,
-            'incidents' => Incident::query()
-                ->guests()
-                ->with('updates')
-                ->when($appSettings->recent_incidents_only, function ($query) use ($appSettings) {
-                    $query->where(function ($query) use ($appSettings) {
-                        $query->whereDate(
-                            'occurred_at',
-                            '>',
-                            Carbon::now()->subDays($appSettings->recent_incidents_days)->format('Y-m-d')
-                        )->orWhere(function ($query) use ($appSettings) {
-                            $query->whereNull('occurred_at')->whereDate(
-                                'created_at',
+        $feed = Cache::remember('cachet::rss-feed', self::CACHE_TTL, function () use ($appSettings) {
+            return view('cachet::rss', [
+                'statusPageName' => $appSettings->name,
+                'statusAbout' => $appSettings->about,
+                'incidents' => Incident::query()
+                    ->guests()
+                    ->with('updates')
+                    ->when($appSettings->recent_incidents_only, function ($query) use ($appSettings) {
+                        $query->where(function ($query) use ($appSettings) {
+                            $query->whereDate(
+                                'occurred_at',
                                 '>',
                                 Carbon::now()->subDays($appSettings->recent_incidents_days)->format('Y-m-d')
-                            );
+                            )->orWhere(function ($query) use ($appSettings) {
+                                $query->whereNull('occurred_at')->whereDate(
+                                    'created_at',
+                                    '>',
+                                    Carbon::now()->subDays($appSettings->recent_incidents_days)->format('Y-m-d')
+                                );
+                            });
                         });
-                    });
-                })
-                ->orderByDesc('created_at')
-                ->get(),
-        ])->header('Content-Type', 'application/rss+xml');
+                    })
+                    ->orderByDesc('created_at')
+                    ->limit(self::MAX_ITEMS)
+                    ->get(),
+            ])->render();
+        });
+
+        return response($feed)->header('Content-Type', 'application/rss+xml');
     }
 }

--- a/src/Jobs/SendBeaconJob.php
+++ b/src/Jobs/SendBeaconJob.php
@@ -23,6 +23,7 @@ class SendBeaconJob
         }
 
         $request = Http::asJson()
+            ->withUserAgent(Cachet::USER_AGENT)
             ->retry(3)
             ->post('https://cachethq.io/beacon', [
                 'install_id' => app(AppSettings::class)->install_id,

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -106,6 +106,16 @@ class Component extends Model
     }
 
     /**
+     * Get the unresolved incidents for the component, newest first.
+     *
+     * @return BelongsToMany<Incident, $this, IncidentComponent>
+     */
+    public function unresolvedIncidents(): BelongsToMany
+    {
+        return $this->incidents()->unresolved()->latest();
+    }
+
+    /**
      * Get the schedules for the component.
      *
      * @return BelongsToMany<Schedule, $this>
@@ -174,10 +184,14 @@ class Component extends Model
 
     /**
      * Get the latest unresolved incident affecting the component.
+     *
+     * Uses the eager-loaded relation when available to avoid a query per component.
      */
     public function latestUnresolvedIncident(): Attribute
     {
-        return Attribute::get(fn () => $this->incidents()->unresolved()->latest()->first())->shouldCache();
+        return Attribute::get(fn () => $this->relationLoaded('unresolvedIncidents')
+            ? $this->unresolvedIncidents->first()
+            : $this->unresolvedIncidents()->first())->shouldCache();
     }
 
     /**

--- a/src/Models/ComponentCheck.php
+++ b/src/Models/ComponentCheck.php
@@ -4,8 +4,10 @@ namespace Cachet\Models;
 
 use Cachet\Database\Factories\ComponentCheckFactory;
 use Cachet\Enums\ComponentStatusEnum;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -28,6 +30,8 @@ class ComponentCheck extends Model
 {
     /** @use HasFactory<ComponentCheckFactory> */
     use HasFactory;
+
+    use MassPrunable;
 
     /** @var array<string, string> */
     protected $casts = [
@@ -56,6 +60,18 @@ class ComponentCheck extends Model
     public function component(): BelongsTo
     {
         return $this->belongsTo(Component::class);
+    }
+
+    /**
+     * Get the prunable model query.
+     *
+     * @return Builder<static>
+     */
+    public function prunable(): Builder
+    {
+        return static::query()->where('created_at', '<', now()->subDays(
+            config('cachet.checks.prune_checks_after_days', 30)
+        ));
     }
 
     /**

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -104,6 +104,10 @@ class ComponentGroup extends Model
 
     public function hasActiveIncident(): bool
     {
+        if ($this->components->every(fn (Component $component) => $component->hasAttribute('incidents_count'))) {
+            return $this->components->contains(fn (Component $component) => $component->incidents_count > 0);
+        }
+
         return Incident::query()
             ->unresolved()
             ->whereHas('components', fn ($query) => $query->whereIn('components.id', $this->components->pluck('id')))

--- a/src/PendingRouteRegistration.php
+++ b/src/PendingRouteRegistration.php
@@ -56,7 +56,9 @@ class PendingRouteRegistration
 
                 $router->get('/health', HealthController::class)->name('health');
 
-                $router->get('/rss', RssController::class)->name('rss');
+                $router->get('/rss', RssController::class)
+                    ->middleware('throttle:60,1')
+                    ->name('rss');
 
             });
 

--- a/src/View/Components/ComponentGroups.php
+++ b/src/View/Components/ComponentGroups.php
@@ -20,6 +20,7 @@ class ComponentGroups extends ViewComponent
                 ->enabled()
                 ->whereNull('component_group_id')
                 ->orderBy('order')
+                ->with('unresolvedIncidents')
                 ->withCount(['incidents' => fn ($query) => $query->unresolved()])
                 ->get(),
         ]);
@@ -31,7 +32,10 @@ class ComponentGroups extends ViewComponent
     private function componentGroups(): Collection
     {
         return ComponentGroup::query()
-            ->with(['components' => fn ($query) => $query->enabled()->orderBy('order')->withCount(['incidents' => fn ($query) => $query->unresolved()])])
+            ->with([
+                'components' => fn ($query) => $query->enabled()->orderBy('order')->withCount(['incidents' => fn ($query) => $query->unresolved()]),
+                'components.unresolvedIncidents',
+            ])
             ->visible(auth()->check())
             ->orderBy('order')
             ->when(auth()->check(), fn (Builder $query) => $query->users(), fn ($query) => $query->guests())

--- a/src/View/Components/Metrics.php
+++ b/src/View/Components/Metrics.php
@@ -8,10 +8,16 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\Component;
 
 class Metrics extends Component
 {
+    /**
+     * How long the metrics are cached for, in seconds.
+     */
+    private const CACHE_TTL = 30;
+
     public function __construct(protected AppSettings $appSettings)
     {
         //
@@ -19,16 +25,22 @@ class Metrics extends Component
 
     public function render(): View
     {
-        $startDate = Carbon::now()->subDays(30);
+        $cacheKey = 'cachet::metrics.'.(auth()->check() ? 'users' : 'guests');
 
-        $metrics = $this->metrics($startDate);
+        $metrics = Cache::remember($cacheKey, self::CACHE_TTL, function () {
+            $startDate = Carbon::now()->subDays(30);
 
-        // Convert each metric point to Chart.js format (x, y)
-        $metrics->each(function ($metric) {
-            $metric->metricPoints->transform(fn ($point) => [
-                'x' => $point->created_at->utc(),
-                'y' => $point->value,
-            ]);
+            $metrics = $this->metrics($startDate);
+
+            // Convert each metric point to Chart.js format (x, y)
+            $metrics->each(function ($metric) {
+                $metric->metricPoints->transform(fn ($point) => [
+                    'x' => $point->created_at->utc(),
+                    'y' => $point->value,
+                ]);
+            });
+
+            return $metrics;
         });
 
         return view('cachet::components.metrics', [
@@ -37,14 +49,14 @@ class Metrics extends Component
     }
 
     /**
-     * Fetch the available metrics and their points.
+     * Fetch the available metrics and their points within the chart window.
      */
     private function metrics(Carbon $startDate): Collection
     {
         return Metric::query()
             ->visible(auth()->check())
             ->with([
-                'metricPoints' => fn ($query) => $query->orderBy('created_at'),
+                'metricPoints' => fn ($query) => $query->where('created_at', '>=', $startDate)->orderBy('created_at'),
             ])
             ->where('display_chart', true)
             ->where(fn (Builder $query) => $query->where('show_when_empty', true)->orWhereHas('metricPoints', fn (Builder $query) => $query->where('created_at', '>=', $startDate)))

--- a/tests/Unit/HttpFactoryTest.php
+++ b/tests/Unit/HttpFactoryTest.php
@@ -1,13 +1,24 @@
 <?php
 
 use Cachet\Cachet;
+use Cachet\Jobs\SendBeaconJob;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 
-it('sets the Cachet user-agent header on outgoing requests', function () {
+it('sets the Cachet user-agent header on beacon requests', function () {
+    config()->set('cachet.beacon', true);
+
+    Http::fake(['https://cachethq.io/*' => Http::response()]);
+
+    (new SendBeaconJob)->handle();
+
+    Http::assertSent(fn (Request $request) => $request->header('User-Agent')[0] === Cachet::USER_AGENT);
+});
+
+it('does not override the user-agent of non-Cachet requests', function () {
     Http::fake(fn (Request $request) => Http::response($request->header('User-Agent')[0]));
 
-    $response = Http::get('https://cachethq.io');
+    $response = Http::get('https://example.com');
 
-    expect($response->body())->toBe(Cachet::USER_AGENT);
+    expect($response->body())->not->toBe(Cachet::USER_AGENT);
 });

--- a/tests/Unit/Settings/MailSettingsTest.php
+++ b/tests/Unit/Settings/MailSettingsTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\Unit\Settings;
 
-use Cachet\CachetCoreServiceProvider;
 use Cachet\Settings\MailSettings;
-use ReflectionMethod;
 
 it('is not configured until a mailer is chosen', function () {
     expect(app(MailSettings::class)->configured())->toBeFalse();
@@ -47,7 +45,7 @@ it('builds a sendmail mailer configuration', function () {
     ]);
 });
 
-it('overrides the application mail configuration when configured', function () {
+it('overrides the application mail configuration when configured and the mailer resolves', function () {
     app(MailSettings::class)->fill([
         'mailer' => 'smtp',
         'host' => 'smtp.example.com',
@@ -55,8 +53,7 @@ it('overrides the application mail configuration when configured', function () {
         'from_name' => 'Example Status',
     ])->save();
 
-    $provider = app()->getProvider(CachetCoreServiceProvider::class);
-    (new ReflectionMethod($provider, 'configureMail'))->invoke($provider);
+    app('mail.manager');
 
     expect(config('mail.default'))->toBe('cachet')
         ->and(config('mail.mailers.cachet.host'))->toBe('smtp.example.com')
@@ -64,11 +61,19 @@ it('overrides the application mail configuration when configured', function () {
         ->and(config('mail.from.name'))->toBe('Example Status');
 });
 
+it('does not touch the mail configuration before the mailer resolves', function () {
+    app(MailSettings::class)->fill([
+        'mailer' => 'smtp',
+        'host' => 'smtp.example.com',
+    ])->save();
+
+    expect(config('mail.mailers.cachet'))->toBeNull();
+});
+
 it('leaves the application mail configuration alone when not configured', function () {
     $default = config('mail.default');
 
-    $provider = app()->getProvider(CachetCoreServiceProvider::class);
-    (new ReflectionMethod($provider, 'configureMail'))->invoke($provider);
+    app('mail.manager');
 
     expect(config('mail.default'))->toBe($default)
         ->and(config('mail.mailers.cachet'))->toBeNull();


### PR DESCRIPTION
## Summary

A batch of performance improvements from a full review of `src/`, focused on the hottest paths: the public status page, the read API, and dashboard rendering.

### Status page
- **Metrics are cached for 30 seconds** (per guest/authenticated visibility) and the point query is now bounded to the 30-day chart window — previously every metric point ever recorded was hydrated on every render, while the chart only displays the last 30 days.
- **Unresolved incidents are eager-loaded** via a new `Component::unresolvedIncidents()` relation, removing the per-component `latestUnresolvedIncident` query and the per-group `hasActiveIncident()` / `worstComponentStatus()` queries.
- **RSS feed** is capped at 100 items, the rendered feed is cached for a minute, and the route is throttled (60/min).

### API
- **`per_page` is clamped to 1–100** on every index endpoint using `Number::clamp()` — previously `?per_page=1000000` would serialize the entire table in one request.
- The incident index eager-loads `updates`, so `latest_status` no longer lazy-loads per row.

### Dashboard
- The **incidents navigation badge** — previously `unresolved()->get()` plus one `updates` query per incident on every page load — is now a single aggregate query via `Status`, which is also now a scoped container binding so its aggregates are shared across widgets within a request.
- The incidents table and open incidents widget eager-load `updates`; the components widget no longer lazy-loads `group` per component; the webhook attempts panel shows the latest 50 attempts instead of loading all of them.

### Settings
- **The spatie/laravel-settings cache is now enabled by the package** (opt-out via `CACHET_SETTINGS_CACHE=false`). The cache is write-through — every `save()` refreshes it — so it never serves stale values. This removes the settings queries that ran on every request during boot.
- Cachet's mail configuration is deferred until the mailer actually resolves, and the dashboard panel's settings access is guarded with `rescue()` so a missing/unmigrated settings table no longer breaks every web request.

### Background work
- `model:prune` is scheduled daily for `WebhookAttempt` (making the existing `prune_logs_after_days` config effective) and `ComponentCheck`, which is now `MassPrunable` with a `CACHET_PRUNE_CHECKS_AFTER_DAYS` config (default 30).
- Subscriber and user notification fan-outs stream with lazy cursors instead of materializing whole tables in memory.

### Behavior changes to note
- **The global `Http::globalRequestMiddleware` User-Agent override is removed.** It rewrote the User-Agent of *every* outgoing HTTP request made by the host application. Cachet's own requests (beacon, OhDear import, feed widget, component checks) now set the header individually. `HttpFactoryTest` was updated to assert both the new behavior and that non-Cachet requests are untouched.
- **Component check results older than 30 days are now pruned** (configurable). The table previously grew unbounded with no pruning mechanism.
- API responses for `per_page` values above 100 now return 100 items.

## Test plan

- Full Pest suite passes (`vendor/bin/pest`, 2,884 assertions, 0 failures). The parallel runner's 128M memory exhaustion also occurs on `main` and is unrelated.
- `MailSettingsTest` updated for the deferred mail configuration; `HttpFactoryTest` updated for the per-request User-Agent.
- Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)