### PR TITLE
Add metadata support for incidents, schedules and components

### DIFF
--- a/database/factories/ComponentFactory.php
+++ b/database/factories/ComponentFactory.php
@@ -66,10 +66,8 @@ class ComponentFactory extends Factory
      */
     public function withMeta(): self
     {
-        return $this->state([
-            'meta' => [
-                'foo' => 'bar',
-            ],
-        ]);
+        return $this->afterCreating(function (Component $component) {
+            $component->meta()->create(['key' => 'foo', 'value' => 'bar']);
+        });
     }
 }

--- a/database/factories/ComponentGroupFactory.php
+++ b/database/factories/ComponentGroupFactory.php
@@ -41,4 +41,14 @@ class ComponentGroupFactory extends Factory
             'order_direction' => $column === ResourceOrderColumnEnum::Manual ? null : $direction,
         ]);
     }
+
+    /**
+     * Provide the component group with additional meta.
+     */
+    public function withMeta(): self
+    {
+        return $this->afterCreating(function (ComponentGroup $componentGroup) {
+            $componentGroup->meta()->create(['key' => 'foo', 'value' => 'bar']);
+        });
+    }
 }

--- a/database/factories/IncidentFactory.php
+++ b/database/factories/IncidentFactory.php
@@ -27,4 +27,14 @@ class IncidentFactory extends Factory
             'message' => fake()->paragraph,
         ];
     }
+
+    /**
+     * Provide the incident with additional meta.
+     */
+    public function withMeta(): self
+    {
+        return $this->afterCreating(function (Incident $incident) {
+            $incident->meta()->create(['key' => 'foo', 'value' => 'bar']);
+        });
+    }
 }

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -57,4 +57,14 @@ class ScheduleFactory extends Factory
             'completed_at' => now()->subDays(30),
         ]);
     }
+
+    /**
+     * Provide the schedule with additional meta.
+     */
+    public function withMeta(): self
+    {
+        return $this->afterCreating(function (Schedule $schedule) {
+            $schedule->meta()->create(['key' => 'foo', 'value' => 'bar']);
+        });
+    }
 }

--- a/database/factories/SubscriberFactory.php
+++ b/database/factories/SubscriberFactory.php
@@ -25,4 +25,14 @@ class SubscriberFactory extends Factory
             'email_verified_at' => now(),
         ]);
     }
+
+    /**
+     * Provide the subscriber with additional meta.
+     */
+    public function withMeta(): self
+    {
+        return $this->afterCreating(function (Subscriber $subscriber) {
+            $subscriber->meta()->create(['key' => 'foo', 'value' => 'bar']);
+        });
+    }
 }

--- a/database/migrations/2026_07_11_000001_migrate_component_meta_to_meta_table.php
+++ b/database/migrations/2026_07_11_000001_migrate_component_meta_to_meta_table.php
@@ -1,14 +1,29 @@
 <?php
 
-use Cachet\Models\Component;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * The morph aliases written by the metadata feature this migration enables.
+     *
+     * Hardcoded rather than read from the runtime morph map so this migration
+     * stays stable as application code evolves.
+     *
+     * @var list<string>
+     */
+    private array $morphAliases = [
+        'component',
+        'component_group',
+        'incident',
+        'schedule',
+        'subscriber',
+    ];
+
     /**
      * Run the migrations.
      */
@@ -18,28 +33,31 @@ return new class extends Migration
             $table->text('value')->nullable()->change();
         });
 
-        $type = Relation::getMorphAlias(Component::class);
-
         DB::table('components')
             ->whereNotNull('meta')
             ->orderBy('id')
-            ->each(function (object $component) use ($type) {
+            ->each(function (object $component) {
                 $meta = json_decode($component->meta, true);
 
                 if (! is_array($meta)) {
+                    Log::warning('Skipping component meta that is not a key/value object during migration.', [
+                        'component_id' => $component->id,
+                        'meta' => $component->meta,
+                    ]);
+
                     return;
                 }
 
-                foreach ($meta as $key => $value) {
-                    DB::table('meta')->insert([
-                        'key' => (string) $key,
-                        'value' => json_encode($value),
-                        'meta_id' => $component->id,
-                        'meta_type' => $type,
-                        'created_at' => now(),
-                        'updated_at' => now(),
-                    ]);
-                }
+                $rows = collect($meta)->map(fn (mixed $value, int|string $key) => [
+                    'key' => (string) $key,
+                    'value' => json_encode($value),
+                    'meta_id' => $component->id,
+                    'meta_type' => 'component',
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ])->values()->all();
+
+                DB::table('meta')->insert($rows);
             });
 
         Schema::table('components', function (Blueprint $table) {
@@ -56,10 +74,8 @@ return new class extends Migration
             $table->longText('meta')->nullable()->default(null)->after('enabled');
         });
 
-        $type = Relation::getMorphAlias(Component::class);
-
         DB::table('meta')
-            ->where('meta_type', $type)
+            ->where('meta_type', 'component')
             ->orderBy('meta_id')
             ->get()
             ->groupBy('meta_id')
@@ -73,10 +89,10 @@ return new class extends Migration
                     ->update(['meta' => json_encode($meta)]);
             });
 
-        DB::table('meta')->where('meta_type', $type)->delete();
+        DB::table('meta')->whereIn('meta_type', $this->morphAliases)->delete();
 
         Schema::table('meta', function (Blueprint $table) {
-            $table->text('value')->nullable()->change();
+            $table->string('value')->nullable(false)->change();
         });
     }
 };

--- a/database/migrations/2026_07_11_000001_migrate_component_meta_to_meta_table.php
+++ b/database/migrations/2026_07_11_000001_migrate_component_meta_to_meta_table.php
@@ -1,0 +1,82 @@
+<?php
+
+use Cachet\Models\Component;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('meta', function (Blueprint $table) {
+            $table->text('value')->nullable()->change();
+        });
+
+        $type = Relation::getMorphAlias(Component::class);
+
+        DB::table('components')
+            ->whereNotNull('meta')
+            ->orderBy('id')
+            ->each(function (object $component) use ($type) {
+                $meta = json_decode($component->meta, true);
+
+                if (! is_array($meta)) {
+                    return;
+                }
+
+                foreach ($meta as $key => $value) {
+                    DB::table('meta')->insert([
+                        'key' => (string) $key,
+                        'value' => json_encode($value),
+                        'meta_id' => $component->id,
+                        'meta_type' => $type,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                }
+            });
+
+        Schema::table('components', function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('components', function (Blueprint $table) {
+            $table->longText('meta')->nullable()->default(null)->after('enabled');
+        });
+
+        $type = Relation::getMorphAlias(Component::class);
+
+        DB::table('meta')
+            ->where('meta_type', $type)
+            ->orderBy('meta_id')
+            ->get()
+            ->groupBy('meta_id')
+            ->each(function ($rows, $componentId) {
+                $meta = $rows->mapWithKeys(fn (object $row) => [
+                    $row->key => json_decode($row->value, true),
+                ])->all();
+
+                DB::table('components')
+                    ->where('id', $componentId)
+                    ->update(['meta' => json_encode($meta)]);
+            });
+
+        DB::table('meta')->where('meta_type', $type)->delete();
+
+        Schema::table('meta', function (Blueprint $table) {
+            $table->text('value')->nullable()->change();
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -40,6 +40,7 @@ class DatabaseSeeder extends Seeder
         DB::table('component_checks')->truncate();
         DB::table('component_groups')->truncate();
         DB::table('schedules')->truncate();
+        DB::table('meta')->truncate();
         DB::table('metrics')->truncate();
         DB::table('metric_points')->truncate();
         DB::table('updates')->truncate();

--- a/resources/lang/en/component_group.php
+++ b/resources/lang/en/component_group.php
@@ -28,5 +28,6 @@ return [
         'collapsed_label' => 'Collapsed',
         'order_column_label' => 'Component group order',
         'order_direction' => 'Order direction',
+        'meta_label' => 'Meta',
     ],
 ];

--- a/resources/lang/en/incident.php
+++ b/resources/lang/en/incident.php
@@ -57,6 +57,7 @@ return [
         'notify_subscribers_label' => 'Notify subscribers of this incident.',
         'pin_incident_label' => 'Pin the incident to the top of the status page.',
         'guid_label' => 'Incident UUID',
+        'meta_label' => 'Meta',
         'add_component' => [
             'action_label' => 'Add component',
             'header' => 'Components',

--- a/resources/lang/en/schedule.php
+++ b/resources/lang/en/schedule.php
@@ -30,6 +30,7 @@ return [
         'completed_at_helper' => 'When the maintenance window is expected to end.',
         'notify_subscribers_label' => 'Notify subscribers of this maintenance.',
         'notifications_helper' => 'Email subscribers about this scheduled maintenance and its updates.',
+        'meta_label' => 'Meta',
         'add_component' => [
             'action_label' => 'Add component',
             'header' => 'Affected components',

--- a/resources/lang/en/subscriber.php
+++ b/resources/lang/en/subscriber.php
@@ -27,6 +27,7 @@ return [
     'form' => [
         'email_label' => 'Email',
         'verified_at_label' => 'Verified at',
+        'meta_label' => 'Meta',
     ],
     'overview' => [
         'total_subscribers_label' => 'Total subscribers',

--- a/src/Actions/Component/CreateComponent.php
+++ b/src/Actions/Component/CreateComponent.php
@@ -12,6 +12,8 @@ class CreateComponent
      */
     public function handle(CreateComponentRequestData $component): Component
     {
-        return Component::create($component->toArray());
+        return tap(Component::create($component->except('meta')->toArray()), function (Component $model) use ($component) {
+            $model->syncMeta($component->meta ?? []);
+        });
     }
 }

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -15,7 +15,11 @@ class UpdateComponent
     {
         $oldStatus = $component->status;
 
-        $component->update($data->toArray());
+        $component->update($data->except('meta')->toArray());
+
+        if ($data->meta !== null) {
+            $component->syncMeta($data->meta);
+        }
 
         if ($component->wasChanged('status')) {
             ComponentStatusWasChanged::dispatch(

--- a/src/Actions/ComponentGroup/CreateComponentGroup.php
+++ b/src/Actions/ComponentGroup/CreateComponentGroup.php
@@ -17,8 +17,10 @@ class CreateComponentGroup
     public function handle(CreateComponentGroupRequestData $data): ComponentGroup
     {
         return tap(ComponentGroup::create(
-            $data->except('components')->toArray(),
+            $data->except('components', 'meta')->toArray(),
         ), function (ComponentGroup $componentGroup) use ($data) {
+            $componentGroup->syncMeta($data->meta ?? []);
+
             if (! $data->components) {
                 return;
             }

--- a/src/Actions/ComponentGroup/UpdateComponentGroup.php
+++ b/src/Actions/ComponentGroup/UpdateComponentGroup.php
@@ -13,7 +13,11 @@ class UpdateComponentGroup
      */
     public function handle(ComponentGroup $componentGroup, UpdateComponentGroupRequestData $data): ComponentGroup
     {
-        $componentGroup->update($data->except('components')->toArray());
+        $componentGroup->update($data->except('components', 'meta')->toArray());
+
+        if ($data->meta !== null) {
+            $componentGroup->syncMeta($data->meta);
+        }
 
         if ($data->components) {
             Component::query()->whereIn('id', $data->components)->update([

--- a/src/Actions/Incident/CreateIncident.php
+++ b/src/Actions/Incident/CreateIncident.php
@@ -32,7 +32,7 @@ class CreateIncident
 
         return tap(Incident::create(array_merge(
             ['guid' => Str::uuid()],
-            $data->except('components')->toArray()
+            $data->except('components', 'meta')->toArray()
         )), function (Incident $incident) use ($data) {
             if ($data->components) {
                 $components = collect($data->components)->map(fn (IncidentComponentRequestData $component) => [
@@ -42,6 +42,8 @@ class CreateIncident
 
                 $incident->components()->sync($components);
             }
+
+            $incident->syncMeta($data->meta ?? []);
 
             $this->notifyIncidentSubscribers->handle($incident);
         });

--- a/src/Actions/Incident/UpdateIncident.php
+++ b/src/Actions/Incident/UpdateIncident.php
@@ -12,7 +12,11 @@ class UpdateIncident
      */
     public function handle(Incident $incident, UpdateIncidentRequestData $data): Incident
     {
-        $incident->update($data->toArray());
+        $incident->update($data->except('meta')->toArray());
+
+        if ($data->meta !== null) {
+            $incident->syncMeta($data->meta);
+        }
 
         return $incident->fresh();
     }

--- a/src/Actions/Schedule/CreateSchedule.php
+++ b/src/Actions/Schedule/CreateSchedule.php
@@ -19,7 +19,7 @@ class CreateSchedule
     public function handle(CreateScheduleRequestData $data): Schedule
     {
         /** @phpstan-ignore-next-line argument.type */
-        return tap(Schedule::create($data->except('components')->toArray()), function (Schedule $schedule) use ($data) {
+        return tap(Schedule::create($data->except('components', 'meta')->toArray()), function (Schedule $schedule) use ($data) {
             if ($data->components) {
                 $components = collect($data->components)->map(fn (ScheduleComponentRequestData $component) => [
                     'component_id' => $component->id,
@@ -28,6 +28,8 @@ class CreateSchedule
 
                 $schedule->components()->sync($components);
             }
+
+            $schedule->syncMeta($data->meta ?? []);
 
             $this->notifyScheduleSubscribers->handle($schedule);
         });

--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -13,7 +13,11 @@ class UpdateSchedule
      */
     public function handle(Schedule $schedule, UpdateScheduleRequestData $data): Schedule
     {
-        $schedule->update($data->except('components')->toArray());
+        $schedule->update($data->except('components', 'meta')->toArray());
+
+        if ($data->meta !== null) {
+            $schedule->syncMeta($data->meta);
+        }
 
         if ($data->components) {
             $components = collect($data->components)->map(fn (ScheduleComponentRequestData $component) => [

--- a/src/Actions/Subscriber/CreateSubscriber.php
+++ b/src/Actions/Subscriber/CreateSubscriber.php
@@ -9,7 +9,7 @@ class CreateSubscriber
     /**
      * Handle the action.
      */
-    public function handle(string $email, bool $global = true, array $components = [], bool $verified = false): Subscriber
+    public function handle(string $email, bool $global = true, array $components = [], bool $verified = false, ?array $meta = null): Subscriber
     {
         $subscriber = Subscriber::firstOrCreate([
             'email' => $email,
@@ -19,6 +19,10 @@ class CreateSubscriber
         ]);
 
         $subscriber->components()->attach($components);
+
+        if ($meta !== null) {
+            $subscriber->syncMeta($meta);
+        }
 
         return $subscriber;
     }

--- a/src/Actions/Subscriber/UpdateSubscriber.php
+++ b/src/Actions/Subscriber/UpdateSubscriber.php
@@ -9,7 +9,7 @@ class UpdateSubscriber
     /**
      * Handle the action.
      */
-    public function handle(Subscriber $subscriber, ?string $email = null, ?bool $global = null, ?array $components = null): Subscriber
+    public function handle(Subscriber $subscriber, ?string $email = null, ?bool $global = null, ?array $components = null, ?array $meta = null): Subscriber
     {
         $subscriber->update(array_filter([
             'email' => $email,
@@ -22,6 +22,10 @@ class UpdateSubscriber
 
         if ($components !== null) {
             $subscriber->components()->sync($components);
+        }
+
+        if ($meta !== null) {
+            $subscriber->syncMeta($meta);
         }
 
         return $subscriber;

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -12,9 +12,12 @@ use Cachet\Commands\VersionCommand;
 use Cachet\Database\Seeders\DatabaseSeeder;
 use Cachet\Listeners\SendWebhookListener;
 use Cachet\Listeners\WebhookCallEventListener;
+use Cachet\Models\Component;
 use Cachet\Models\ComponentCheck;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
+use Cachet\Models\Subscriber;
 use Cachet\Models\WebhookAttempt;
 use Cachet\Settings\AppSettings;
 use Cachet\Settings\MailSettings;
@@ -86,8 +89,11 @@ class CachetCoreServiceProvider extends ServiceProvider
         Route::middlewareGroup('cachet:api', config('cachet.api_middleware', []));
 
         Relation::morphMap([
+            'component' => Component::class,
+            'component_group' => ComponentGroup::class,
             'incident' => Incident::class,
             'schedule' => Schedule::class,
+            'subscriber' => Subscriber::class,
         ]);
 
         $this->registerCommands();

--- a/src/Concerns/HasMeta.php
+++ b/src/Concerns/HasMeta.php
@@ -14,13 +14,14 @@ trait HasMeta
     /**
      * Delete the metadata when the owning model is removed.
      *
-     * Soft-deleted models keep their metadata so it survives a restore; the
-     * rows are only purged once the model is hard or force deleted.
+     * Soft-deleted models still exist, so they keep their metadata for a
+     * restore; the rows are only purged once the model is hard or force
+     * deleted and gone from the database.
      */
     protected static function bootHasMeta(): void
     {
         static::deleted(function (self $model): void {
-            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+            if ($model->exists) {
                 return;
             }
 

--- a/src/Concerns/HasMeta.php
+++ b/src/Concerns/HasMeta.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Cachet\Concerns;
+
+use Cachet\Models\Meta;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+/**
+ * @phpstan-require-extends Model
+ */
+trait HasMeta
+{
+    /**
+     * Get the metadata assigned to the model.
+     *
+     * @return MorphMany<Meta, $this>
+     */
+    public function meta(): MorphMany
+    {
+        return $this->morphMany(Meta::class, 'meta');
+    }
+
+    /**
+     * Get the metadata as a key/value array.
+     *
+     * @return array<string, mixed>
+     */
+    public function metaValues(): array
+    {
+        return $this->meta->pluck('value', 'key')->all();
+    }
+
+    /**
+     * Sync the given key/value pairs into the model's metadata.
+     *
+     * Keys not present in the given array are removed, keeping the metadata
+     * table in step with the provided values. Values are stored as JSON so
+     * they retain their original type when read back.
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    public function syncMeta(array $meta): void
+    {
+        $this->meta()->whereNotIn('key', array_keys($meta))->delete();
+
+        foreach ($meta as $key => $value) {
+            $this->meta()->updateOrCreate(
+                ['key' => (string) $key],
+                ['value' => $value],
+            );
+        }
+
+        $this->unsetRelation('meta');
+    }
+}

--- a/src/Concerns/HasMeta.php
+++ b/src/Concerns/HasMeta.php
@@ -12,6 +12,23 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 trait HasMeta
 {
     /**
+     * Delete the metadata when the owning model is removed.
+     *
+     * Soft-deleted models keep their metadata so it survives a restore; the
+     * rows are only purged once the model is hard or force deleted.
+     */
+    protected static function bootHasMeta(): void
+    {
+        static::deleted(function (self $model): void {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+                return;
+            }
+
+            $model->meta()->delete();
+        });
+    }
+
+    /**
      * Get the metadata assigned to the model.
      *
      * @return MorphMany<Meta, $this>
@@ -42,7 +59,9 @@ trait HasMeta
      */
     public function syncMeta(array $meta): void
     {
-        $this->meta()->whereNotIn('key', array_keys($meta))->delete();
+        $keys = array_map(strval(...), array_keys($meta));
+
+        $this->meta()->whereNotIn('key', $keys)->delete();
 
         foreach ($meta as $key => $value) {
             $this->meta()->updateOrCreate(

--- a/src/Concerns/Metable.php
+++ b/src/Concerns/Metable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cachet\Concerns;
+
+interface Metable
+{
+    /**
+     * Get the metadata as a key/value array.
+     *
+     * @return array<string, mixed>
+     */
+    public function metaValues(): array;
+
+    /**
+     * Sync the given key/value pairs into the model's metadata.
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    public function syncMeta(array $meta): void;
+}

--- a/src/Data/Requests/Component/CreateComponentRequestData.php
+++ b/src/Data/Requests/Component/CreateComponentRequestData.php
@@ -17,6 +17,8 @@ final class CreateComponentRequestData extends BaseData
         public readonly ?int $order = null,
         public readonly bool $enabled = true,
         public readonly ?int $componentGroupId = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -29,6 +31,7 @@ final class CreateComponentRequestData extends BaseData
             'order' => ['int', 'min:0'],
             'enabled' => ['boolean'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],
+            'meta' => ['nullable', 'array'],
         ];
     }
 

--- a/src/Data/Requests/Component/UpdateComponentRequestData.php
+++ b/src/Data/Requests/Component/UpdateComponentRequestData.php
@@ -17,6 +17,8 @@ final class UpdateComponentRequestData extends BaseData
         public readonly ?int $order = null,
         public readonly ?bool $enabled = null,
         public readonly ?int $componentGroupId = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -29,6 +31,7 @@ final class UpdateComponentRequestData extends BaseData
             'order' => ['int', 'min:0'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],
             'enabled' => ['boolean'],
+            'meta' => ['nullable', 'array'],
         ];
     }
 }

--- a/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
@@ -20,6 +20,8 @@ final class CreateComponentGroupRequestData extends BaseData
         public readonly ?ResourceOrderColumnEnum $orderColumn = null,
         public readonly ?ResourceOrderDirectionEnum $orderDirection = null,
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -41,6 +43,7 @@ final class CreateComponentGroupRequestData extends BaseData
             ],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            'meta' => ['nullable', 'array'],
         ];
     }
 

--- a/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
@@ -19,6 +19,8 @@ final class UpdateComponentGroupRequestData extends BaseData
         public readonly ?ResourceOrderColumnEnum $orderColumn = null,
         public readonly ?ResourceOrderDirectionEnum $orderDirection = null,
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -40,6 +42,7 @@ final class UpdateComponentGroupRequestData extends BaseData
             ],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            'meta' => ['nullable', 'array'],
         ];
     }
 

--- a/src/Data/Requests/Incident/CreateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/CreateIncidentRequestData.php
@@ -36,6 +36,8 @@ final class CreateIncidentRequestData extends BaseData
         public readonly ?ComponentStatusEnum $componentStatus = null,
         #[DataCollectionOf(IncidentComponentRequestData::class)]
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -55,6 +57,7 @@ final class CreateIncidentRequestData extends BaseData
             'components' => ['array'],
             'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
             'components.*.status' => ['required_with:components', 'int', Rule::enum(ComponentStatusEnum::class)],
+            'meta' => ['nullable', 'array'],
         ];
     }
 
@@ -73,6 +76,7 @@ final class CreateIncidentRequestData extends BaseData
             componentId: $this->componentId,
             componentStatus: $this->componentStatus,
             components: $this->components,
+            meta: $this->meta,
         );
     }
 }

--- a/src/Data/Requests/Incident/UpdateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/UpdateIncidentRequestData.php
@@ -18,6 +18,8 @@ final class UpdateIncidentRequestData extends BaseData
         public readonly ?bool $stickied = null,
         public readonly ?bool $notifications = null,
         public readonly ?string $occurredAt = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -30,6 +32,7 @@ final class UpdateIncidentRequestData extends BaseData
             'stickied' => ['boolean'],
             'notifications' => ['boolean'],
             'occurred_at' => ['nullable', 'date'],
+            'meta' => ['nullable', 'array'],
         ];
     }
 

--- a/src/Data/Requests/Schedule/CreateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/CreateScheduleRequestData.php
@@ -25,6 +25,8 @@ final class CreateScheduleRequestData extends BaseData
         public readonly bool $notifications = false,
         #[DataCollectionOf(ScheduleComponentRequestData::class)]
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -38,6 +40,7 @@ final class CreateScheduleRequestData extends BaseData
             'components' => ['array'],
             'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
             'components.*.status' => ['required_with:components', 'int', Rule::enum(ComponentStatusEnum::class)],
+            'meta' => ['nullable', 'array'],
         ];
     }
 }

--- a/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
@@ -24,6 +24,8 @@ final class UpdateScheduleRequestData extends BaseData
         public readonly ?Carbon $completedAt = null,
         #[DataCollectionOf(ScheduleComponentRequestData::class)]
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -36,6 +38,7 @@ final class UpdateScheduleRequestData extends BaseData
             'components' => ['array'],
             'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
             'components.*.status' => ['required_with:components', Rule::enum(ComponentStatusEnum::class)],
+            'meta' => ['nullable', 'array'],
         ];
     }
 }

--- a/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
@@ -13,6 +13,8 @@ final class CreateSubscriberRequestData extends BaseData
         public readonly ?bool $global = null,
         public readonly ?array $components = null,
         public readonly ?bool $verified = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -23,6 +25,7 @@ final class CreateSubscriberRequestData extends BaseData
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
             'verified' => ['bool'],
+            'meta' => ['nullable', 'array'],
         ];
     }
 }

--- a/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
@@ -12,6 +12,8 @@ final class UpdateSubscriberRequestData extends BaseData
         public readonly ?string $email = null,
         public readonly ?bool $global = null,
         public readonly ?array $components = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $meta = null,
     ) {}
 
     public static function rules(ValidationContext $context): array
@@ -21,6 +23,7 @@ final class UpdateSubscriberRequestData extends BaseData
             'global' => ['bool'],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            'meta' => ['nullable', 'array'],
         ];
     }
 }

--- a/src/Filament/Concerns/InteractsWithMeta.php
+++ b/src/Filament/Concerns/InteractsWithMeta.php
@@ -8,12 +8,20 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Persists a `meta` KeyValue form field into the model's polymorphic metadata.
  *
- * @property array<string, mixed> $data
+ * Pages using this concern must pass the validated form state through
+ * extractMetaFormData() (from mutateFormDataBeforeCreate or
+ * mutateFormDataBeforeSave) and call persistMeta() after the record is
+ * created or saved. The metadata must be read from the validated form state
+ * rather than the page's raw Livewire data, as the KeyValue field only
+ * casts its state to a key/value map during form dehydration.
  *
  * @method Model|null getRecord()
  */
 trait InteractsWithMeta
 {
+    /** @var array<string, mixed> */
+    protected array $metaFormState = [];
+
     /**
      * Hydrate the metadata form field from the record's stored metadata.
      *
@@ -28,11 +36,27 @@ trait InteractsWithMeta
     }
 
     /**
-     * Sync the metadata form field back into the record.
+     * Pull the metadata out of the validated form state, keeping it for
+     * persistMeta() and preventing it from reaching mass assignment.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function extractMetaFormData(array $data): array
+    {
+        $this->metaFormState = $data['meta'] ?? [];
+
+        unset($data['meta']);
+
+        return $data;
+    }
+
+    /**
+     * Sync the extracted metadata form state back into the record.
      */
     protected function persistMeta(): void
     {
-        $this->getMetaRecord()->syncMeta($this->data['meta'] ?? []);
+        $this->getMetaRecord()->syncMeta($this->metaFormState);
     }
 
     /**

--- a/src/Filament/Concerns/InteractsWithMeta.php
+++ b/src/Filament/Concerns/InteractsWithMeta.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Cachet\Filament\Concerns;
+
+use Cachet\Concerns\Metable;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Persists a `meta` KeyValue form field into the model's polymorphic metadata.
+ *
+ * @property array<string, mixed> $data
+ *
+ * @method Model|null getRecord()
+ */
+trait InteractsWithMeta
+{
+    /**
+     * Hydrate the metadata form field from the record's stored metadata.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function fillMetaFormData(array $data): array
+    {
+        $data['meta'] = $this->getMetaRecord()->metaValues();
+
+        return $data;
+    }
+
+    /**
+     * Sync the metadata form field back into the record.
+     */
+    protected function persistMeta(): void
+    {
+        $this->getMetaRecord()->syncMeta($this->data['meta'] ?? []);
+    }
+
+    /**
+     * Get the record being managed as a metadata-aware model.
+     *
+     * @return Model&Metable
+     */
+    private function getMetaRecord(): Metable
+    {
+        /** @var Model&Metable $record */
+        $record = $this->getRecord();
+
+        return $record;
+    }
+}

--- a/src/Filament/Resources/ComponentGroups/ComponentGroupResource.php
+++ b/src/Filament/Resources/ComponentGroups/ComponentGroupResource.php
@@ -14,6 +14,7 @@ use Cachet\Models\ComponentGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
@@ -68,6 +69,11 @@ class ComponentGroupResource extends Resource
                         ->options(ResourceOrderDirectionEnum::class)
                         ->required(fn (Get $get) => $get('order_column') !== ResourceOrderColumnEnum::Manual->value)
                         ->visible(fn (Get $get) => $get('order_column') !== ResourceOrderColumnEnum::Manual->value),
+                ]),
+                Section::make()->schema([
+                    KeyValue::make('meta')
+                        ->label(__('cachet::component_group.form.meta_label'))
+                        ->columnSpanFull(),
                 ]),
             ]);
     }

--- a/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
@@ -2,10 +2,18 @@
 
 namespace Cachet\Filament\Resources\ComponentGroups\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\ComponentGroups\ComponentGroupResource;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateComponentGroup extends CreateRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ComponentGroupResource::class;
+
+    protected function afterCreate(): void
+    {
+        $this->persistMeta();
+    }
 }

--- a/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/CreateComponentGroup.php
@@ -12,6 +12,11 @@ class CreateComponentGroup extends CreateRecord
 
     protected static string $resource = ComponentGroupResource::class;
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterCreate(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
@@ -25,6 +25,11 @@ class EditComponentGroup extends EditRecord
         return $this->fillMetaFormData($data);
     }
 
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterSave(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
+++ b/src/Filament/Resources/ComponentGroups/Pages/EditComponentGroup.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Filament\Resources\ComponentGroups\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\ComponentGroups\ComponentGroupResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditComponentGroup extends EditRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ComponentGroupResource::class;
 
     protected function getHeaderActions(): array
@@ -15,5 +18,15 @@ class EditComponentGroup extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->fillMetaFormData($data);
+    }
+
+    protected function afterSave(): void
+    {
+        $this->persistMeta();
     }
 }

--- a/src/Filament/Resources/Components/Pages/CreateComponent.php
+++ b/src/Filament/Resources/Components/Pages/CreateComponent.php
@@ -2,10 +2,18 @@
 
 namespace Cachet\Filament\Resources\Components\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Components\ComponentResource;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateComponent extends CreateRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ComponentResource::class;
+
+    protected function afterCreate(): void
+    {
+        $this->persistMeta();
+    }
 }

--- a/src/Filament/Resources/Components/Pages/CreateComponent.php
+++ b/src/Filament/Resources/Components/Pages/CreateComponent.php
@@ -12,6 +12,11 @@ class CreateComponent extends CreateRecord
 
     protected static string $resource = ComponentResource::class;
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterCreate(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/Components/Pages/EditComponent.php
+++ b/src/Filament/Resources/Components/Pages/EditComponent.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Filament\Resources\Components\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Components\ComponentResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditComponent extends EditRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ComponentResource::class;
 
     protected function getHeaderActions(): array
@@ -15,5 +18,15 @@ class EditComponent extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->fillMetaFormData($data);
+    }
+
+    protected function afterSave(): void
+    {
+        $this->persistMeta();
     }
 }

--- a/src/Filament/Resources/Components/Pages/EditComponent.php
+++ b/src/Filament/Resources/Components/Pages/EditComponent.php
@@ -25,6 +25,11 @@ class EditComponent extends EditRecord
         return $this->fillMetaFormData($data);
     }
 
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterSave(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -21,6 +21,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
@@ -92,6 +93,9 @@ class IncidentResource extends Resource
                                 ->required(),
                         ])
                         ->label(__('cachet::incident.form.add_component.header')),
+                    KeyValue::make('meta')
+                        ->label(__('cachet::incident.form.meta_label'))
+                        ->columnSpanFull(),
                 ])
                     ->columnSpan(3),
                 Section::make()->schema([

--- a/src/Filament/Resources/Incidents/Pages/CreateIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/CreateIncident.php
@@ -3,18 +3,23 @@
 namespace Cachet\Filament\Resources\Incidents\Pages;
 
 use Cachet\Actions\Incident\NotifyIncidentSubscribers;
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
 use Cachet\Models\Incident;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateIncident extends CreateRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = IncidentResource::class;
 
     protected function afterCreate(): void
     {
         /** @var Incident $incident */
         $incident = $this->record;
+
+        $this->persistMeta();
 
         app(NotifyIncidentSubscribers::class)->handle($incident);
     }

--- a/src/Filament/Resources/Incidents/Pages/CreateIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/CreateIncident.php
@@ -14,6 +14,11 @@ class CreateIncident extends CreateRecord
 
     protected static string $resource = IncidentResource::class;
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterCreate(): void
     {
         /** @var Incident $incident */

--- a/src/Filament/Resources/Incidents/Pages/EditIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/EditIncident.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Filament\Resources\Incidents\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditIncident extends EditRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = IncidentResource::class;
 
     protected function getHeaderActions(): array
@@ -18,5 +21,15 @@ class EditIncident extends EditRecord
                 ->icon('heroicon-o-plus'),
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->fillMetaFormData($data);
+    }
+
+    protected function afterSave(): void
+    {
+        $this->persistMeta();
     }
 }

--- a/src/Filament/Resources/Incidents/Pages/EditIncident.php
+++ b/src/Filament/Resources/Incidents/Pages/EditIncident.php
@@ -28,6 +28,11 @@ class EditIncident extends EditRecord
         return $this->fillMetaFormData($data);
     }
 
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterSave(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
@@ -14,6 +14,11 @@ class CreateSchedule extends CreateRecord
 
     protected static string $resource = ScheduleResource::class;
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterCreate(): void
     {
         /** @var Schedule $schedule */

--- a/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/CreateSchedule.php
@@ -3,18 +3,23 @@
 namespace Cachet\Filament\Resources\Schedules\Pages;
 
 use Cachet\Actions\Schedule\NotifyScheduleSubscribers;
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Schedules\ScheduleResource;
 use Cachet\Models\Schedule;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateSchedule extends CreateRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ScheduleResource::class;
 
     protected function afterCreate(): void
     {
         /** @var Schedule $schedule */
         $schedule = $this->record;
+
+        $this->persistMeta();
 
         app(NotifyScheduleSubscribers::class)->handle($schedule);
     }

--- a/src/Filament/Resources/Schedules/Pages/EditSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/EditSchedule.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Filament\Resources\Schedules\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Schedules\ScheduleResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditSchedule extends EditRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = ScheduleResource::class;
 
     protected function getHeaderActions(): array
@@ -20,10 +23,20 @@ class EditSchedule extends EditRecord
         ];
     }
 
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->fillMetaFormData($data);
+    }
+
     protected function mutateFormDataBeforeSave(array $data): array
     {
         $data['completed_at'] = $data['completed_at'] ?? null;
 
         return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        $this->persistMeta();
     }
 }

--- a/src/Filament/Resources/Schedules/Pages/EditSchedule.php
+++ b/src/Filament/Resources/Schedules/Pages/EditSchedule.php
@@ -32,7 +32,7 @@ class EditSchedule extends EditRecord
     {
         $data['completed_at'] = $data['completed_at'] ?? null;
 
-        return $data;
+        return $this->extractMetaFormData($data);
     }
 
     protected function afterSave(): void

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -19,6 +19,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
@@ -81,6 +82,9 @@ class ScheduleResource extends Resource
                                 ->default(ComponentStatusEnum::operational->value),
                         ])
                         ->label(__('cachet::schedule.form.add_component.header'))
+                        ->columnSpanFull(),
+                    KeyValue::make('meta')
+                        ->label(__('cachet::schedule.form.meta_label'))
                         ->columnSpanFull(),
                 ]),
             ]);

--- a/src/Filament/Resources/Subscribers/Pages/CreateSubscriber.php
+++ b/src/Filament/Resources/Subscribers/Pages/CreateSubscriber.php
@@ -13,6 +13,11 @@ class CreateSubscriber extends CreateRecord
 
     protected static string $resource = SubscriberResource::class;
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterCreate(): void
     {
         /** @var Subscriber $subscriber */

--- a/src/Filament/Resources/Subscribers/Pages/CreateSubscriber.php
+++ b/src/Filament/Resources/Subscribers/Pages/CreateSubscriber.php
@@ -2,18 +2,23 @@
 
 namespace Cachet\Filament\Resources\Subscribers\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Subscribers\SubscriberResource;
 use Cachet\Models\Subscriber;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateSubscriber extends CreateRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = SubscriberResource::class;
 
     protected function afterCreate(): void
     {
         /** @var Subscriber $subscriber */
         $subscriber = $this->record;
+
+        $this->persistMeta();
 
         if (! $subscriber->hasVerifiedEmail()) {
             $subscriber->sendEmailVerificationNotification();

--- a/src/Filament/Resources/Subscribers/Pages/EditSubscriber.php
+++ b/src/Filament/Resources/Subscribers/Pages/EditSubscriber.php
@@ -2,12 +2,15 @@
 
 namespace Cachet\Filament\Resources\Subscribers\Pages;
 
+use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Subscribers\SubscriberResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditSubscriber extends EditRecord
 {
+    use InteractsWithMeta;
+
     protected static string $resource = SubscriberResource::class;
 
     protected function getHeaderActions(): array
@@ -15,5 +18,15 @@ class EditSubscriber extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->fillMetaFormData($data);
+    }
+
+    protected function afterSave(): void
+    {
+        $this->persistMeta();
     }
 }

--- a/src/Filament/Resources/Subscribers/Pages/EditSubscriber.php
+++ b/src/Filament/Resources/Subscribers/Pages/EditSubscriber.php
@@ -25,6 +25,11 @@ class EditSubscriber extends EditRecord
         return $this->fillMetaFormData($data);
     }
 
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        return $this->extractMetaFormData($data);
+    }
+
     protected function afterSave(): void
     {
         $this->persistMeta();

--- a/src/Filament/Resources/Subscribers/SubscriberResource.php
+++ b/src/Filament/Resources/Subscribers/SubscriberResource.php
@@ -13,6 +13,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -48,6 +49,9 @@ class SubscriberResource extends Resource
                     //                Forms\Components\TextInput::make('phone_number')
                     //                    ->tel(),
                     //                Forms\Components\TextInput::make('slack_webhook_url'),
+                    KeyValue::make('meta')
+                        ->label(__('cachet::subscriber.form.meta_label'))
+                        ->columnSpanFull(),
                 ]),
             ]);
     }

--- a/src/Filters/MetaFilter.php
+++ b/src/Filters/MetaFilter.php
@@ -20,7 +20,7 @@ class MetaFilter implements Filter
     {
         foreach ($this->pairs($value) as $key => $expected) {
             $query->whereHas('meta', function (Builder $query) use ($key, $expected) {
-                $query->where('key', $key)->where('value', json_encode($expected));
+                $query->where('key', $key)->whereIn('value', $this->encodings($expected));
             });
         }
     }
@@ -28,7 +28,7 @@ class MetaFilter implements Filter
     /**
      * Normalise the incoming filter value into a list of key/value pairs.
      *
-     * @return array<string, string>
+     * @return array<string, bool|string>
      */
     protected function pairs(mixed $value): array
     {
@@ -43,9 +43,41 @@ class MetaFilter implements Filter
                 continue;
             }
 
-            $pairs[(string) $key] = (string) $expected;
+            $pairs[(string) $key] = is_bool($expected) ? $expected : (string) $expected;
         }
 
         return $pairs;
+    }
+
+    /**
+     * Get the stored JSON encodings a filter value should match.
+     *
+     * Metadata values keep their JSON types in storage, while filter input
+     * arrives as a string (or a boolean, once the query builder converts
+     * `true`/`false`), so `?filter[meta][priority]=3` must match both the
+     * integer 3 and the string "3".
+     *
+     * @return list<string>
+     */
+    protected function encodings(bool|string $value): array
+    {
+        if (is_bool($value)) {
+            $candidates = [$value, $value ? 'true' : 'false'];
+        } else {
+            $candidates = [$value];
+
+            if (is_numeric($value)) {
+                $candidates[] = str_contains($value, '.') ? (float) $value : (int) $value;
+            }
+
+            if ($value === 'true' || $value === 'false') {
+                $candidates[] = $value === 'true';
+            }
+        }
+
+        return array_values(array_unique(array_map(
+            fn (mixed $candidate): string => (string) json_encode($candidate),
+            $candidates,
+        )));
     }
 }

--- a/src/Filters/MetaFilter.php
+++ b/src/Filters/MetaFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Cachet\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class MetaFilter implements Filter
+{
+    /**
+     * Filter a resource by one or more metadata key/value pairs.
+     *
+     * Expects the filter value to be an associative array, e.g.
+     * `?filter[meta][region]=eu-west` becomes `['region' => 'eu-west']`. Every
+     * provided pair must match for a record to be included.
+     *
+     * @param  Builder<covariant \Illuminate\Database\Eloquent\Model>  $query
+     */
+    public function __invoke(Builder $query, $value, string $property): void
+    {
+        foreach ($this->pairs($value) as $key => $expected) {
+            $query->whereHas('meta', function (Builder $query) use ($key, $expected) {
+                $query->where('key', $key)->where('value', json_encode($expected));
+            });
+        }
+    }
+
+    /**
+     * Normalise the incoming filter value into a list of key/value pairs.
+     *
+     * @return array<string, string>
+     */
+    protected function pairs(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach ($value as $key => $expected) {
+            if ($key === '' || is_array($expected)) {
+                continue;
+            }
+
+            $pairs[(string) $key] = (string) $expected;
+        }
+
+        return $pairs;
+    }
+}

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -9,6 +9,7 @@ use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Component\CreateComponentRequestData;
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
 use Dedoc\Scramble\Attributes\Group;
@@ -31,6 +32,7 @@ class ComponentController extends Controller
     public const ALLOWED_INCLUDES = [
         'group',
         'incidents',
+        'meta',
     ];
 
     /**
@@ -39,6 +41,8 @@ class ComponentController extends Controller
     #[QueryParameter('filter[status]', 'Filter by status', type: ComponentStatusEnum::class, example: 1)]
     #[QueryParameter('filter[name]', 'Filter by name.', example: 'My Component')]
     #[QueryParameter('filter[enabled]', 'Filter by enabled status.', type: 'bool', example: '1')]
+    #[QueryParameter('filter[meta][key]', 'Filter by a metadata key/value pair.', example: 'eu-west')]
+    #[QueryParameter('include', 'Include related data (group, incidents, meta).', example: 'meta')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
@@ -49,6 +53,7 @@ class ComponentController extends Controller
                 'name',
                 AllowedFilter::exact('status'),
                 AllowedFilter::exact('enabled'),
+                AllowedFilter::custom('meta', new MetaFilter),
             ])
             ->allowedSorts(['name', 'order', 'id'])
             ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
@@ -73,6 +78,7 @@ class ComponentController extends Controller
     /**
      * Get Component
      */
+    #[QueryParameter('include', 'Include related data (group, incidents, meta).', example: 'meta')]
     public function show(Component $component)
     {
 

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -8,6 +8,7 @@ use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\ComponentGroup\CreateComponentGroupRequestData;
 use Cachet\Data\Requests\ComponentGroup\UpdateComponentGroupRequestData;
+use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\ComponentGroup as ComponentGroupResource;
 use Cachet\Models\ComponentGroup;
 use Dedoc\Scramble\Attributes\Group;
@@ -16,6 +17,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Number;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
 #[Group('Component Groups', weight: 2)]
@@ -26,12 +28,17 @@ class ComponentGroupController extends Controller
     /**
      * List Component Groups
      */
+    #[QueryParameter('filter[meta][key]', 'Filter by a metadata key/value pair.', example: 'eu-west')]
+    #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
         $componentGroups = QueryBuilder::for(ComponentGroup::class)
-            ->allowedIncludes(['components'])
+            ->allowedIncludes(['components', 'meta'])
+            ->allowedFilters([
+                AllowedFilter::custom('meta', new MetaFilter),
+            ])
             ->allowedSorts(['name', 'id'])
             ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
@@ -53,11 +60,12 @@ class ComponentGroupController extends Controller
     /**
      * Get Component Group
      */
+    #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     public function show(ComponentGroup $componentGroup)
     {
 
         $componentQuery = QueryBuilder::for(ComponentGroup::class)
-            ->allowedIncludes(['components'])
+            ->allowedIncludes(['components', 'meta'])
             ->find($componentGroup->id);
 
         return ComponentGroupResource::make($componentQuery)

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -8,6 +8,7 @@ use Cachet\Actions\Incident\UpdateIncident;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Incident\CreateIncidentRequestData;
 use Cachet\Data\Requests\Incident\UpdateIncidentRequestData;
+use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Incident as IncidentResource;
 use Cachet\Models\Incident;
 use Dedoc\Scramble\Attributes\Group;
@@ -32,11 +33,14 @@ class IncidentController extends Controller
         'components.group',
         'updates',
         'user',
+        'meta',
     ];
 
     /**
      * List Incidents
      */
+    #[QueryParameter('filter[meta][key]', 'Filter by a metadata key/value pair.', example: 'eu-west')]
+    #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
@@ -49,6 +53,7 @@ class IncidentController extends Controller
                 AllowedFilter::scope('occurs_after'),
                 AllowedFilter::scope('occurs_before'),
                 AllowedFilter::scope('occurs_on'),
+                AllowedFilter::custom('meta', new MetaFilter),
             ])
             ->allowedSorts(['name', 'status', 'id', 'created_at'])
             ->defaultSort('-created_at')
@@ -72,6 +77,7 @@ class IncidentController extends Controller
     /**
      * Get Incident
      */
+    #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     public function show(Incident $incident)
     {
 

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -9,6 +9,7 @@ use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Schedule\CreateScheduleRequestData;
 use Cachet\Data\Requests\Schedule\UpdateScheduleRequestData;
 use Cachet\Enums\ScheduleStatusEnum;
+use Cachet\Filters\MetaFilter;
 use Cachet\Filters\ScheduleStatusFilter;
 use Cachet\Http\Resources\Schedule as ScheduleResource;
 use Cachet\Models\Schedule;
@@ -31,13 +32,19 @@ class ScheduleController extends Controller
      */
     #[QueryParameter('filter[name]', 'Filter the resources by name.', example: 'api')]
     #[QueryParameter('filter[status]', 'Filter the resources by status.', type: ScheduleStatusEnum::class)]
+    #[QueryParameter('filter[meta][key]', 'Filter by a metadata key/value pair.', example: 'eu-west')]
+    #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
         $schedules = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'components.group', 'updates', 'user'])
-            ->allowedFilters(['name', AllowedFilter::custom('status', new ScheduleStatusFilter)])
+            ->allowedIncludes(['components', 'components.group', 'updates', 'user', 'meta'])
+            ->allowedFilters([
+                'name',
+                AllowedFilter::custom('status', new ScheduleStatusFilter),
+                AllowedFilter::custom('meta', new MetaFilter),
+            ])
             ->allowedSorts(['name', 'id', 'scheduled_at', 'completed_at'])
             ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
 
@@ -59,10 +66,11 @@ class ScheduleController extends Controller
     /**
      * Get Schedule
      */
+    #[QueryParameter('include', 'Include related data (components, components.group, updates, user, meta).', example: 'meta')]
     public function show(Schedule $schedule)
     {
         $scheduleQuery = QueryBuilder::for(Schedule::class)
-            ->allowedIncludes(['components', 'components.group', 'updates', 'user'])
+            ->allowedIncludes(['components', 'components.group', 'updates', 'user', 'meta'])
             ->find($schedule->id);
 
         return ScheduleResource::make($scheduleQuery)

--- a/src/Http/Controllers/Api/SubscriberController.php
+++ b/src/Http/Controllers/Api/SubscriberController.php
@@ -8,6 +8,7 @@ use Cachet\Actions\Subscriber\UpdateSubscriber;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Subscriber\CreateSubscriberRequestData;
 use Cachet\Data\Requests\Subscriber\UpdateSubscriberRequestData;
+use Cachet\Filters\MetaFilter;
 use Cachet\Http\Resources\Subscriber as SubscriberResource;
 use Cachet\Models\Subscriber;
 use Dedoc\Scramble\Attributes\Group;
@@ -29,6 +30,8 @@ class SubscriberController extends Controller
      */
     #[QueryParameter('filter[email]', 'Filter by email address.', example: 'john@example.com')]
     #[QueryParameter('filter[global]', 'Filter by global subscription status.', type: 'bool', example: '1')]
+    #[QueryParameter('filter[meta][key]', 'Filter by a metadata key/value pair.', example: 'eu-west')]
+    #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     #[QueryParameter('per_page', 'How many items to show per page.', type: 'int', default: 15, example: 20)]
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
@@ -36,10 +39,11 @@ class SubscriberController extends Controller
         $this->guard('subscribers.manage');
 
         $subscribers = QueryBuilder::for(Subscriber::class)
-            ->allowedIncludes(['components'])
+            ->allowedIncludes(['components', 'meta'])
             ->allowedFilters([
                 'email',
                 AllowedFilter::exact('global'),
+                AllowedFilter::custom('meta', new MetaFilter),
             ])
             ->allowedSorts(['email', 'id'])
             ->simplePaginate(Number::clamp($request->integer('per_page', 15), min: 1, max: 100));
@@ -59,6 +63,7 @@ class SubscriberController extends Controller
             $data->global ?? true,
             $data->components ?? [],
             $data->verified ?? false,
+            $data->meta,
         );
 
         if (! $subscriber->hasVerifiedEmail()) {
@@ -71,12 +76,13 @@ class SubscriberController extends Controller
     /**
      * Get Subscriber
      */
+    #[QueryParameter('include', 'Include related data (components, meta).', example: 'meta')]
     public function show(Subscriber $subscriber)
     {
         $this->guard('subscribers.manage');
 
         $subscriberQuery = QueryBuilder::for(Subscriber::class)
-            ->allowedIncludes(['components'])
+            ->allowedIncludes(['components', 'meta'])
             ->find($subscriber->id);
 
         return SubscriberResource::make($subscriberQuery)
@@ -96,6 +102,7 @@ class SubscriberController extends Controller
             email: $data->email,
             global: $data->global,
             components: $data->components,
+            meta: $data->meta,
         );
 
         return SubscriberResource::make($subscriber->fresh());

--- a/src/Http/Resources/Component.php
+++ b/src/Http/Resources/Component.php
@@ -21,7 +21,10 @@ class Component extends JsonApiResource
                 'value' => $this->status?->value,
             ],
             'enabled' => $this->enabled,
-            'meta' => $this->meta,
+            'meta' => $this->when(
+                $this->resource->relationLoaded('meta'),
+                fn () => $this->meta->pluck('value', 'key'),
+            ),
             'created' => [
                 'human' => $this->created_at?->diffForHumans(),
                 'string' => $this->created_at?->toDateTimeString(),

--- a/src/Http/Resources/ComponentGroup.php
+++ b/src/Http/Resources/ComponentGroup.php
@@ -18,6 +18,10 @@ class ComponentGroup extends JsonApiResource
             'order_direction' => $this->order_direction,
             'collapsed' => $this->collapsed,
             'visible' => $this->visible,
+            'meta' => $this->when(
+                $this->resource->relationLoaded('meta'),
+                fn () => $this->meta->pluck('value', 'key'),
+            ),
             'created' => [
                 'human' => $this->created_at?->diffForHumans(),
                 'string' => $this->created_at?->toDateTimeString(),

--- a/src/Http/Resources/Incident.php
+++ b/src/Http/Resources/Incident.php
@@ -20,6 +20,10 @@ class Incident extends JsonApiResource
             'visible' => $this->visible,
             'stickied' => $this->stickied,
             'notifications' => $this->notifications,
+            'meta' => $this->when(
+                $this->resource->relationLoaded('meta'),
+                fn () => $this->meta->pluck('value', 'key'),
+            ),
             'components_count' => $this->whenCounted('components', function () {
                 return $this->components_count;
             }),

--- a/src/Http/Resources/Schedule.php
+++ b/src/Http/Resources/Schedule.php
@@ -14,6 +14,10 @@ class Schedule extends JsonApiResource
             'id' => $this->id,
             'name' => $this->name,
             'message' => $this->message,
+            'meta' => $this->when(
+                $this->resource->relationLoaded('meta'),
+                fn () => $this->meta->pluck('value', 'key'),
+            ),
             'status' => [
                 'human' => $this->status->getLabel(),
                 'value' => $this->status->value,

--- a/src/Http/Resources/Subscriber.php
+++ b/src/Http/Resources/Subscriber.php
@@ -19,6 +19,10 @@ class Subscriber extends JsonApiResource
                 'human' => $this->email_verified_at?->diffForHumans(),
                 'string' => $this->email_verified_at?->toDateTimeString(),
             ],
+            'meta' => $this->when(
+                $this->resource->relationLoaded('meta'),
+                fn () => $this->meta->pluck('value', 'key'),
+            ),
             'created' => [
                 'human' => $this->created_at?->diffForHumans(),
                 'string' => $this->created_at?->toDateTimeString(),

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -3,6 +3,8 @@
 namespace Cachet\Models;
 
 use Cachet\Cachet;
+use Cachet\Concerns\HasMeta;
+use Cachet\Concerns\Metable;
 use Cachet\Database\Factories\ComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ResourceOrderColumnEnum;
@@ -37,9 +39,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property ?Carbon $updated_at
  * @property ?Carbon $deleted_at
  * @property bool $enabled
- * @property array<string, mixed> $meta
  * @property ?ComponentGroup $componentGroup
  * @property-read Collection<int, ComponentCheck> $checks
+ * @property-read Collection<int, Meta> $meta
  * @property-read IncidentComponent|null $pivot
  *
  * @method static Builder<static>|static checked()
@@ -49,11 +51,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static Builder<static>|static status(ComponentStatusEnum $status)
  * @method static ComponentFactory factory($count = null, $state = [])
  */
-class Component extends Model
+class Component extends Model implements Metable
 {
     /** @use HasFactory<ComponentFactory> */
     use HasFactory;
 
+    use HasMeta;
     use SoftDeletes;
 
     /** @var array<string, string> */
@@ -62,7 +65,6 @@ class Component extends Model
         'status' => ComponentStatusEnum::class,
         'order' => 'int',
         'enabled' => 'bool',
-        'meta' => 'json',
     ];
 
     /** @var list<string> */
@@ -74,7 +76,6 @@ class Component extends Model
         'status',
         'component_group_id',
         'enabled',
-        'meta',
         'checked',
         'checked_at',
     ];

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -2,7 +2,9 @@
 
 namespace Cachet\Models;
 
+use Cachet\Concerns\HasMeta;
 use Cachet\Concerns\HasVisibility;
+use Cachet\Concerns\Metable;
 use Cachet\Database\Factories\ComponentGroupFactory;
 use Cachet\Enums\ComponentGroupVisibilityEnum;
 use Cachet\Enums\ComponentStatusEnum;
@@ -25,14 +27,16 @@ use Illuminate\Support\Collection;
  * @property ComponentGroupVisibilityEnum $collapsed
  * @property ResourceVisibilityEnum $visible
  * @property Collection<int, Component> $components
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Meta> $meta
  *
  * @method static ComponentGroupFactory factory($count = null, $state = [])
  */
-class ComponentGroup extends Model
+class ComponentGroup extends Model implements Metable
 {
     /** @use HasFactory<ComponentGroupFactory> */
     use HasFactory;
 
+    use HasMeta;
     use HasVisibility;
 
     /** @var array<string, string> */

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -3,7 +3,9 @@
 namespace Cachet\Models;
 
 use Cachet\Cachet;
+use Cachet\Concerns\HasMeta;
 use Cachet\Concerns\HasVisibility;
+use Cachet\Concerns\Metable;
 use Cachet\Database\Factories\IncidentFactory;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
@@ -50,6 +52,7 @@ use Illuminate\Support\Str;
  * @property ?Component $component
  * @property Collection<int, Component> $components
  * @property Collection<int, Update> $updates
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Meta> $meta
  * @property-read Carbon $timestamp
  * @property-read IncidentComponent $pivot
  *
@@ -58,11 +61,12 @@ use Illuminate\Support\Str;
  * @method static Builder<static>|static unresolved()
  * @method static Builder<static>|static stickied()
  */
-class Incident extends Model
+class Incident extends Model implements Metable
 {
     /** @use HasFactory<IncidentFactory> */
     use HasFactory;
 
+    use HasMeta;
     use HasVisibility;
     use SoftDeletes;
 

--- a/src/Models/Meta.php
+++ b/src/Models/Meta.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cachet\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $id
+ * @property string $key
+ * @property mixed $value
+ * @property int $meta_id
+ * @property string $meta_type
+ * @property-read Model $meta
+ */
+class Meta extends Model
+{
+    /** @var string */
+    protected $table = 'meta';
+
+    /** @var array<string, string> */
+    protected $casts = [
+        'value' => 'json',
+    ];
+
+    /** @var list<string> */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * Get the parent model that owns the metadata.
+     *
+     * @return MorphTo<Model, $this>
+     */
+    public function meta(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -5,6 +5,8 @@ namespace Cachet\Models;
 use Cachet\Actions\Schedule\NotifyScheduleCompletedSubscribers;
 use Cachet\Actions\Schedule\NotifyScheduleRescheduledSubscribers;
 use Cachet\Cachet;
+use Cachet\Concerns\HasMeta;
+use Cachet\Concerns\Metable;
 use Cachet\Database\Factories\ScheduleFactory;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\QueryBuilders\ScheduleBuilder;
@@ -33,6 +35,7 @@ use Illuminate\Support\Collection;
  * @property ?Carbon $deleted_at
  * @property Collection<int, Component> $components
  * @property Collection<int, Update> $updates
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Meta> $meta
  *
  * @method static ScheduleFactory factory($count = null, $state = [])
  * @method static ScheduleBuilder incomplete()
@@ -40,11 +43,12 @@ use Illuminate\Support\Collection;
  * @method static ScheduleBuilder inTheFuture()
  * @method static ScheduleBuilder inThePast()
  */
-class Schedule extends Model
+class Schedule extends Model implements Metable
 {
     /** @use HasFactory<ScheduleFactory> */
     use HasFactory;
 
+    use HasMeta;
     use SoftDeletes;
 
     /**

--- a/src/Models/Subscriber.php
+++ b/src/Models/Subscriber.php
@@ -2,6 +2,8 @@
 
 namespace Cachet\Models;
 
+use Cachet\Concerns\HasMeta;
+use Cachet\Concerns\Metable;
 use Cachet\Database\Factories\SubscriberFactory;
 use Cachet\Events\Subscribers\SubscriberCreated;
 use Cachet\Events\Subscribers\SubscriberUnsubscribed;
@@ -29,11 +31,12 @@ use Illuminate\Support\Facades\URL;
  * @property ?string $phone_number
  * @property ?string $slack_webhook_url
  * @property Collection<int, Component> $components
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Meta> $meta
  */
-class Subscriber extends Model implements MustVerifyEmailContract
+class Subscriber extends Model implements Metable, MustVerifyEmailContract
 {
     /** @use HasFactory<SubscriberFactory> */
-    use HasFactory, MustVerifyEmail, Notifiable;
+    use HasFactory, HasMeta, MustVerifyEmail, Notifiable;
 
     /** @var array<string, string> */
     protected $casts = [

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -72,12 +72,63 @@ it('can get a component group with components', function () {
     $response->assertJsonFragment(['id' => $componentGroup->id]);
 });
 
+it('can filter component groups by meta', function () {
+    ComponentGroup::factory(5)->create();
+    $group = ComponentGroup::factory()->create();
+    $group->syncMeta(['region' => 'eu-west']);
+
+    $query = http_build_query(['filter' => ['meta' => ['region' => 'eu-west']]]);
+
+    $response = getJson('/status/api/component-groups?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $group->id);
+});
+
+it('can include meta on a component group', function () {
+    $group = ComponentGroup::factory()->create();
+    $group->syncMeta(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+
+    $response = getJson('/status/api/component-groups/'.$group->id.'?include=meta');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.meta', [
+        'region' => 'eu-west',
+        'priority' => 3,
+        'critical' => true,
+    ]);
+});
+
+it('does not include meta on a component group by default', function () {
+    $group = ComponentGroup::factory()->create();
+    $group->syncMeta(['region' => 'eu-west']);
+
+    $response = getJson('/status/api/component-groups/'.$group->id);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('data.attributes.meta');
+});
+
 it('cannot create a component group when not authenticated', function () {
     $response = postJson('/status/api/component-groups', [
         'name' => 'New Group',
     ]);
 
     $response->assertUnauthorized();
+});
+
+it('can create a component group with meta', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
+
+    $response = postJson('/status/api/component-groups', [
+        'name' => 'New Group',
+        'meta' => ['region' => 'eu-west', 'priority' => 3, 'critical' => true],
+    ]);
+
+    $response->assertCreated();
+    expect(ComponentGroup::query()->firstWhere('name', 'New Group')->metaValues())
+        ->toBe(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
 });
 
 it('cannot create a component group without the token ability', function () {

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -152,6 +152,61 @@ it('can filter components by disabled', function () {
     $response->assertJsonMissing(['id' => $component->id]);
 });
 
+it('can filter components by meta', function () {
+    Component::factory(5)->create();
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west']);
+
+    $query = http_build_query([
+        'filter' => [
+            'meta' => ['region' => 'eu-west'],
+        ],
+    ]);
+
+    $response = getJson('/status/api/components?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $component->id);
+});
+
+it('can create a component with meta', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
+    $response = postJson('/status/api/components', [
+        'name' => 'Test',
+        'meta' => ['region' => 'eu-west', 'priority' => 3, 'critical' => true],
+    ]);
+
+    $response->assertCreated();
+    expect(Component::query()->firstWhere('name', 'Test')->metaValues())
+        ->toBe(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+});
+
+it('can include meta on a component', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+
+    $response = getJson('/status/api/components/'.$component->id.'?include=meta');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.meta', [
+        'region' => 'eu-west',
+        'priority' => 3,
+        'critical' => true,
+    ]);
+});
+
+it('does not include meta on a component by default', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west']);
+
+    $response = getJson('/status/api/components/'.$component->id);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('data.attributes.meta');
+});
+
 it('can get a component', function () {
     Component::factory(5)->create();
     $component = Component::factory()->create();

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -170,6 +170,24 @@ it('can filter components by meta', function () {
     $response->assertJsonPath('data.0.attributes.id', $component->id);
 });
 
+it('can filter components by typed meta values', function () {
+    Component::factory(5)->create();
+    $component = Component::factory()->create();
+    $component->syncMeta(['priority' => 3, 'critical' => true]);
+
+    $query = http_build_query([
+        'filter' => [
+            'meta' => ['priority' => 3, 'critical' => 'true'],
+        ],
+    ]);
+
+    $response = getJson('/status/api/components?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $component->id);
+});
+
 it('can create a component with meta', function () {
     Sanctum::actingAs(User::factory()->create(), ['components.manage']);
 

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -164,6 +164,63 @@ it('can filter incidents by occurred at date', function () {
     $response->assertJsonPath('data.0.attributes.id', $incident->id);
 });
 
+it('can filter incidents by meta', function () {
+    Incident::factory(5)->create();
+    $incident = Incident::factory()->create();
+    $incident->syncMeta(['region' => 'eu-west']);
+
+    $query = http_build_query([
+        'filter' => [
+            'meta' => ['region' => 'eu-west'],
+        ],
+    ]);
+
+    $response = getJson('/status/api/incidents?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $incident->id);
+});
+
+it('can create an incident with meta', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $response = postJson('/status/api/incidents', [
+        'name' => 'Test',
+        'message' => 'Something happened.',
+        'status' => IncidentStatusEnum::investigating->value,
+        'meta' => ['region' => 'eu-west', 'priority' => 3, 'critical' => true],
+    ]);
+
+    $response->assertCreated();
+    expect(Incident::query()->firstWhere('name', 'Test')->metaValues())
+        ->toBe(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+});
+
+it('can include meta on an incident', function () {
+    $incident = Incident::factory()->create();
+    $incident->syncMeta(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+
+    $response = getJson('/status/api/incidents/'.$incident->id.'?include=meta');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.meta', [
+        'region' => 'eu-west',
+        'priority' => 3,
+        'critical' => true,
+    ]);
+});
+
+it('does not include meta on an incident by default', function () {
+    $incident = Incident::factory()->create();
+    $incident->syncMeta(['region' => 'eu-west']);
+
+    $response = getJson('/status/api/incidents/'.$incident->id);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('data.attributes.meta');
+});
+
 it('can get an incident', function () {
     Incident::factory(5)->create();
     $incident = Incident::factory()->create();

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -186,6 +186,63 @@ it('can filter schedules by multiple statuses', function () {
     $response->assertJsonPath('data.1.attributes.id', $scheduleInProgress->id);
 });
 
+it('can filter schedules by meta', function () {
+    Schedule::factory(5)->create();
+    $schedule = Schedule::factory()->create();
+    $schedule->syncMeta(['region' => 'eu-west']);
+
+    $query = http_build_query([
+        'filter' => [
+            'meta' => ['region' => 'eu-west'],
+        ],
+    ]);
+
+    $response = getJson('/status/api/schedules?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $schedule->id);
+});
+
+it('can create a schedule with meta', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $response = postJson('/status/api/schedules', [
+        'name' => 'Test',
+        'message' => 'Scheduled maintenance.',
+        'scheduled_at' => now()->addDay()->toDateTimeString(),
+        'meta' => ['region' => 'eu-west', 'priority' => 3, 'critical' => true],
+    ]);
+
+    $response->assertCreated();
+    expect(Schedule::query()->firstWhere('name', 'Test')->metaValues())
+        ->toBe(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+});
+
+it('can include meta on a schedule', function () {
+    $schedule = Schedule::factory()->create();
+    $schedule->syncMeta(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+
+    $response = getJson('/status/api/schedules/'.$schedule->id.'?include=meta');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.meta', [
+        'region' => 'eu-west',
+        'priority' => 3,
+        'critical' => true,
+    ]);
+});
+
+it('does not include meta on a schedule by default', function () {
+    $schedule = Schedule::factory()->create();
+    $schedule->syncMeta(['region' => 'eu-west']);
+
+    $response = getJson('/status/api/schedules/'.$schedule->id);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('data.attributes.meta');
+});
+
 it('can get a schedule', function () {
     $schedule = Schedule::factory()->create();
 

--- a/tests/Feature/Api/SubscriberTest.php
+++ b/tests/Feature/Api/SubscriberTest.php
@@ -119,6 +119,65 @@ it('can get a subscriber with components', function () {
     $response->assertJsonFragment(['id' => $subscriber->id]);
 });
 
+it('can filter subscribers by meta', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    Subscriber::factory(5)->create();
+    $subscriber = Subscriber::factory()->create();
+    $subscriber->syncMeta(['region' => 'eu-west']);
+
+    $query = http_build_query(['filter' => ['meta' => ['region' => 'eu-west']]]);
+
+    $response = getJson('/status/api/subscribers?'.$query);
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.id', $subscriber->id);
+});
+
+it('can include meta on a subscriber', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->create();
+    $subscriber->syncMeta(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+
+    $response = getJson('/status/api/subscribers/'.$subscriber->id.'?include=meta');
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.meta', [
+        'region' => 'eu-west',
+        'priority' => 3,
+        'critical' => true,
+    ]);
+});
+
+it('does not include meta on a subscriber by default', function () {
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->create();
+    $subscriber->syncMeta(['region' => 'eu-west']);
+
+    $response = getJson('/status/api/subscribers/'.$subscriber->id);
+
+    $response->assertOk();
+    $response->assertJsonMissingPath('data.attributes.meta');
+});
+
+it('can create a subscriber with meta', function () {
+    Notification::fake();
+
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $response = postJson('/status/api/subscribers', [
+        'email' => 'james@alt-three.com',
+        'meta' => ['region' => 'eu-west', 'priority' => 3, 'critical' => true],
+    ]);
+
+    $response->assertCreated();
+    expect(Subscriber::query()->firstWhere('email', 'james@alt-three.com')->metaValues())
+        ->toBe(['region' => 'eu-west', 'priority' => 3, 'critical' => true]);
+});
+
 it('cannot create a subscriber when not authenticated', function () {
     $response = postJson('/status/api/subscribers', [
         'email' => 'james@alt-three.com',

--- a/tests/Feature/Filament/Resources/ComponentResourceTest.php
+++ b/tests/Feature/Filament/Resources/ComponentResourceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Resources\Components\Pages\CreateComponent;
+use Cachet\Filament\Resources\Components\Pages\EditComponent;
+use Cachet\Models\Component;
+use Filament\Facades\Filament;
+use Workbench\App\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('cachet'));
+
+    actingAs(User::factory()->create(['is_admin' => true]));
+});
+
+it('stores meta as key/value pairs when creating a component from the dashboard', function () {
+    livewire(CreateComponent::class)
+        ->fillForm([
+            'name' => 'Dashboard Component',
+            'status' => ComponentStatusEnum::operational,
+            'enabled' => true,
+        ])
+        ->set('data.meta', [
+            ['key' => 'region', 'value' => 'eu-west-1'],
+            ['key' => 'awake', 'value' => '1'],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $component = Component::query()->firstWhere('name', 'Dashboard Component');
+
+    expect($component->metaValues())->toBe([
+        'region' => 'eu-west-1',
+        'awake' => '1',
+    ]);
+});
+
+it('updates meta when editing a component from the dashboard', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west-1', 'stale' => 'yes']);
+
+    livewire(EditComponent::class, ['record' => $component->getKey()])
+        ->assertFormSet(['meta' => ['region' => 'eu-west-1', 'stale' => 'yes']])
+        ->fillForm([
+            'meta' => ['region' => 'us-east-1'],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($component->fresh()->metaValues())->toBe([
+        'region' => 'us-east-1',
+    ]);
+});
+
+it('is filterable through the API after being written from the dashboard', function () {
+    livewire(CreateComponent::class)
+        ->fillForm([
+            'name' => 'Filterable Component',
+            'status' => ComponentStatusEnum::operational,
+            'enabled' => true,
+            'meta' => ['region' => 'eu-west-1'],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $response = $this->getJson('/status/api/components?include=meta&filter[meta][region]=eu-west-1');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJsonPath('data.0.attributes.meta', ['region' => 'eu-west-1']);
+});

--- a/tests/Feature/Filament/Resources/ComponentResourceTest.php
+++ b/tests/Feature/Filament/Resources/ComponentResourceTest.php
@@ -41,7 +41,9 @@ it('stores meta as key/value pairs when creating a component from the dashboard'
 });
 
 it('updates meta when editing a component from the dashboard', function () {
-    $component = Component::factory()->create();
+    $component = Component::factory()->create([
+        'description' => 'A short description.',
+    ]);
     $component->syncMeta(['region' => 'eu-west-1', 'stale' => 'yes']);
 
     livewire(EditComponent::class, ['record' => $component->getKey()])

--- a/tests/Unit/Filters/MetaFilterTest.php
+++ b/tests/Unit/Filters/MetaFilterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Cachet\Filters\MetaFilter;
+use Cachet\Models\Component;
+
+it('filters records matching every provided key', function () {
+    $match = Component::factory()->create();
+    $match->syncMeta(['region' => 'eu-west', 'tier' => 'gold']);
+
+    $other = Component::factory()->create();
+    $other->syncMeta(['region' => 'eu-west', 'tier' => 'silver']);
+
+    Component::factory()->create();
+
+    expect(applyMetaFilter(['region' => 'eu-west', 'tier' => 'gold'])->pluck('id')->all())
+        ->toBe([$match->id]);
+});
+
+it('ignores empty and non-scalar values', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west']);
+
+    expect(applyMetaFilter([])->count())->toBe(1)
+        ->and(applyMetaFilter(['region' => ['nested']])->count())->toBe(1);
+});
+
+function applyMetaFilter(array $value)
+{
+    $query = Component::query();
+
+    (new MetaFilter)($query, $value, 'meta');
+
+    return $query->get();
+}

--- a/tests/Unit/Filters/MetaFilterTest.php
+++ b/tests/Unit/Filters/MetaFilterTest.php
@@ -24,6 +24,24 @@ it('ignores empty and non-scalar values', function () {
         ->and(applyMetaFilter(['region' => ['nested']])->count())->toBe(1);
 });
 
+it('matches integer, float and boolean values from query-string input', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['priority' => 3, 'uptime' => 99.9, 'critical' => true]);
+
+    expect(applyMetaFilter(['priority' => '3'])->pluck('id')->all())->toBe([$component->id])
+        ->and(applyMetaFilter(['uptime' => '99.9'])->pluck('id')->all())->toBe([$component->id])
+        ->and(applyMetaFilter(['critical' => 'true'])->pluck('id')->all())->toBe([$component->id])
+        ->and(applyMetaFilter(['priority' => '4'])->count())->toBe(0)
+        ->and(applyMetaFilter(['critical' => 'false'])->count())->toBe(0);
+});
+
+it('still matches string values that look numeric', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['build' => '42']);
+
+    expect(applyMetaFilter(['build' => '42'])->pluck('id')->all())->toBe([$component->id]);
+});
+
 function applyMetaFilter(array $value)
 {
     $query = Component::query();

--- a/tests/Unit/Models/ComponentGroupTest.php
+++ b/tests/Unit/Models/ComponentGroupTest.php
@@ -200,3 +200,11 @@ it('reports operational for a group without components', function () {
 
     expect($group->worstComponentStatus())->toBe(ComponentStatusEnum::operational);
 });
+
+it('has meta', function () {
+    $group = ComponentGroup::factory()->withMeta()->create();
+
+    expect($group->metaValues())->toBe([
+        'foo' => 'bar',
+    ]);
+});

--- a/tests/Unit/Models/ComponentTest.php
+++ b/tests/Unit/Models/ComponentTest.php
@@ -24,13 +24,12 @@ it('has incidents', function () {
     expect($component->incidents)->toHaveCount(2);
 });
 
-it('casts meta to json', function () {
+it('has meta', function () {
     $component = Component::factory()->withMeta()->create();
 
-    expect($component)
-        ->meta->toBe([
-            'foo' => 'bar',
-        ]);
+    expect($component->metaValues())->toBe([
+        'foo' => 'bar',
+    ]);
 });
 
 it('can scope to disabled components', function () {

--- a/tests/Unit/Models/ComponentTest.php
+++ b/tests/Unit/Models/ComponentTest.php
@@ -5,6 +5,7 @@ use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
+use Cachet\Models\Meta;
 
 it('has a group', function () {
     $component = Component::factory()->forGroup([
@@ -30,6 +31,18 @@ it('has meta', function () {
     expect($component->metaValues())->toBe([
         'foo' => 'bar',
     ]);
+});
+
+it('keeps meta when soft deleted and purges it when force deleted', function () {
+    $component = Component::factory()->withMeta()->create();
+
+    $component->delete();
+
+    expect(Meta::query()->where('meta_id', $component->id)->count())->toBe(1);
+
+    $component->forceDelete();
+
+    expect(Meta::query()->where('meta_id', $component->id)->count())->toBe(0);
 });
 
 it('can scope to disabled components', function () {

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -22,6 +22,14 @@ it('will set default guid', function () {
     expect($incident)->guid->not()->toBeNull();
 });
 
+it('has meta', function () {
+    $incident = Incident::factory()->withMeta()->create();
+
+    expect($incident->metaValues())->toBe([
+        'foo' => 'bar',
+    ]);
+});
+
 it('can scope to a specific status', function () {
     Incident::factory()->sequence(
         ['status' => IncidentStatusEnum::investigating],

--- a/tests/Unit/Models/ScheduleTest.php
+++ b/tests/Unit/Models/ScheduleTest.php
@@ -17,6 +17,14 @@ it('has components', function () {
         ->components->toHaveCount(2);
 });
 
+it('has meta', function () {
+    $schedule = Schedule::factory()->withMeta()->create();
+
+    expect($schedule->metaValues())->toBe([
+        'foo' => 'bar',
+    ]);
+});
+
 it('can get incomplete schedules', function () {
     $scheduleA = Schedule::factory()->inTheFuture()->create();
     Schedule::factory()->inProgress()->create();

--- a/tests/Unit/Models/SubscriberTest.php
+++ b/tests/Unit/Models/SubscriberTest.php
@@ -57,3 +57,11 @@ it('has components', function () {
         ->and($subscriber->components()->first())
         ->toBeInstanceOf(Component::class);
 });
+
+it('has meta', function () {
+    $subscriber = Subscriber::factory()->withMeta()->create();
+
+    expect($subscriber->metaValues())->toBe([
+        'foo' => 'bar',
+    ]);
+});

--- a/tests/Unit/Models/SubscriberTest.php
+++ b/tests/Unit/Models/SubscriberTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Events\Subscribers\SubscriberVerified;
 use Cachet\Models\Component;
+use Cachet\Models\Meta;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\VerifySubscriberEmail;
 use Illuminate\Support\Facades\Event;
@@ -64,4 +65,12 @@ it('has meta', function () {
     expect($subscriber->metaValues())->toBe([
         'foo' => 'bar',
     ]);
+});
+
+it('purges meta when deleted', function () {
+    $subscriber = Subscriber::factory()->withMeta()->create();
+
+    $subscriber->delete();
+
+    expect(Meta::query()->where('meta_id', $subscriber->id)->where('meta_type', 'subscriber')->count())->toBe(0);
 });


### PR DESCRIPTION
Introduce a shared, filterable metadata capability, backed by the existing
polymorphic `meta` table, for incidents, schedules, components, component
groups and subscribers.

- Add a `Meta` model and a `HasMeta` concern (with a `Metable` contract)
  exposing a `meta()` morph relation, `metaValues()` and `syncMeta()`. Values
  are cast to JSON so they retain their original type when read back.
- Register the metadata-aware models in the morph map and migrate the existing
  `components.meta` JSON column into the polymorphic `meta` table, then drop
  the column. The `meta.value` column is widened to nullable text.
- Persist metadata from the Filament resources via a `KeyValue` field and a
  shared page concern.
- Accept `meta` on the create/update request data and sync it in the actions.
- Expose `meta` as an optional API include (`?include=meta`) that renders the
  metadata as a key/value object, rather than always loading it.
- Add a reusable `MetaFilter` so the API endpoints can filter by metadata
  (e.g. `?filter[meta][region]=eu-west`).
- Document the metadata filter and include on the relevant API endpoints.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjXufhWofngDAxRAgsxzyN