### PR TITLE
Add DemoMetricSeeder to push live metric points in demo mode

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,7 +21,6 @@ use Cachet\Settings\CustomizationSettings;
 use Cachet\Settings\ThemeSettings;
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -139,7 +138,7 @@ EOF
         ]);
 
         $metric = Metric::create([
-            'name' => 'Cachet API Requests',
+            'name' => DemoMetricSeeder::METRIC_NAME,
             'suffix' => 'req/s',
             'description' => 'The number of requests to the Cachet API.',
             'default_view' => MetricViewEnum::today,
@@ -149,10 +148,14 @@ EOF
             'default_value' => 0,
         ]);
 
-        $metric->metricPoints()->createMany(Arr::map(range(1, 60), fn (int $i) => [
-            'value' => random_int(1, 100),
-            'created_at' => now()->subMinutes(random_int(0, $i * 60)),
-        ]));
+        $metricPointTimestamps = collect(range(30 * 24, 25, -1))->map(fn (int $hours) => now()->subHours($hours))
+            ->concat(collect(range(24 * 12, 13, -1))->map(fn (int $intervals) => now()->subMinutes($intervals * 5)))
+            ->concat(collect(range(60, 0, -1))->map(fn (int $minutes) => now()->subMinutes($minutes)));
+
+        $metric->metricPoints()->createMany($metricPointTimestamps->map(fn ($timestamp) => [
+            'value' => DemoMetricSeeder::valueAt($timestamp),
+            'created_at' => $timestamp,
+        ])->all());
 
         tap(Incident::create([
             'name' => 'DNS Provider Outage',

--- a/database/seeders/DemoMetricSeeder.php
+++ b/database/seeders/DemoMetricSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Cachet\Database\Seeders;
+
+use Cachet\Models\Metric;
+use DateTimeInterface;
+use Illuminate\Database\Seeder;
+
+class DemoMetricSeeder extends Seeder
+{
+    /**
+     * The name of the metric created by the demo DatabaseSeeder.
+     */
+    public const METRIC_NAME = 'Cachet API Requests';
+
+    /**
+     * Push a fresh metric point onto the demo metric, if it still exists.
+     */
+    public function run(): void
+    {
+        $metric = Metric::query()->where('name', self::METRIC_NAME)->first();
+
+        if ($metric === null) {
+            return;
+        }
+
+        $metric->metricPoints()->create([
+            'value' => self::valueAt(now()),
+        ]);
+    }
+
+    /**
+     * Calculate a realistic request rate for the given time: a daily traffic
+     * curve peaking at 15:00 UTC, with a little random jitter on top.
+     */
+    public static function valueAt(DateTimeInterface $timestamp): float
+    {
+        $secondsIntoDay = ((int) $timestamp->format('H') * 3600)
+            + ((int) $timestamp->format('i') * 60)
+            + (int) $timestamp->format('s');
+
+        $dailyCycle = cos(2 * M_PI * ($secondsIntoDay - (15 * 3600)) / 86400);
+
+        $value = 45 + (30 * $dailyCycle) + (random_int(-80, 80) / 10);
+
+        return round(max($value, 1), 2);
+    }
+}

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -10,6 +10,7 @@ use Cachet\Commands\NotifyLongRunningIncidentsCommand;
 use Cachet\Commands\SendBeaconCommand;
 use Cachet\Commands\VersionCommand;
 use Cachet\Database\Seeders\DatabaseSeeder;
+use Cachet\Database\Seeders\DemoMetricSeeder;
 use Cachet\Listeners\SendWebhookListener;
 use Cachet\Listeners\WebhookCallEventListener;
 use Cachet\Models\ComponentCheck;
@@ -283,6 +284,11 @@ class CachetCoreServiceProvider extends ServiceProvider
                 '--class' => DatabaseSeeder::class,
                 '--force',
             ])->everyThirtyMinutes()->when($demoMode);
+
+            $schedule->command('db:seed', [
+                '--class' => DemoMetricSeeder::class,
+                '--force',
+            ])->everyMinute()->when($demoMode);
         });
     }
 

--- a/tests/Unit/Commands/ConsoleTest.php
+++ b/tests/Unit/Commands/ConsoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Database\Seeders\DatabaseSeeder;
+use Cachet\Database\Seeders\DemoMetricSeeder;
 use Illuminate\Console\Scheduling\Schedule;
 
 it('registers a scheduled job', function () {
@@ -9,12 +10,18 @@ it('registers a scheduled job', function () {
 
     $events = collect($schedule->events())->keyBy('command')->keys()->all();
 
-    // Build the expected scheduled command
+    // Build the expected scheduled commands
     $scheduledCommand = sprintf("'%s' 'artisan' db:seed --class='%s' --force",
         PHP_BINARY,
         DatabaseSeeder::class,
     );
 
+    $demoMetricCommand = sprintf("'%s' 'artisan' db:seed --class='%s' --force",
+        PHP_BINARY,
+        DemoMetricSeeder::class,
+    );
+
     expect($events)
-        ->toContain($scheduledCommand);
+        ->toContain($scheduledCommand)
+        ->toContain($demoMetricCommand);
 });

--- a/tests/Unit/Database/DemoMetricSeederTest.php
+++ b/tests/Unit/Database/DemoMetricSeederTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Cachet\Database\Seeders\DemoMetricSeeder;
+use Cachet\Models\Metric;
+use Cachet\Models\MetricPoint;
+
+it('pushes a metric point onto the demo metric', function () {
+    $metric = Metric::factory()->create(['name' => DemoMetricSeeder::METRIC_NAME]);
+
+    $this->seed(DemoMetricSeeder::class);
+
+    expect($metric->metricPoints()->count())->toBe(1)
+        ->and($metric->metricPoints()->first()->value)->toBeGreaterThanOrEqual(1);
+});
+
+it('does nothing when the demo metric has been deleted', function () {
+    Metric::factory()->create(['name' => 'Some Other Metric']);
+
+    $this->seed(DemoMetricSeeder::class);
+
+    expect(MetricPoint::query()->count())->toBe(0);
+});


### PR DESCRIPTION
## What

Adds a `DemoMetricSeeder` that runs **every minute** in demo mode and appends a fresh point to the "Cachet API Requests" demo metric, so visitors can watch the metric chart update live — demonstrating that metrics actually work.

- The seeder looks the metric up by name and **no-ops if it has been deleted** during the demo, so the scheduled run never errors. The every-30-minutes `DatabaseSeeder` reset recreates it.
- Registered alongside the existing demo-mode schedule in `CachetCoreServiceProvider`, guarded by the same `cachet.demo_mode` check.

## Nicer demo data

The demo metric previously seeded `random_int(1, 100)` noise. Both seeders now share `DemoMetricSeeder::valueAt()` — a daily traffic curve peaking at 15:00 UTC (~45 req/s baseline ±30, with light jitter, floored at 1). `DatabaseSeeder` backfills:

- 30 days of hourly points
- 24 hours of 5-minute points
- the last hour per-minute

so today/week/month chart views all look realistic. Because the live per-minute points use the same curve, they continue the line seamlessly between demo resets instead of jumping.

## Tests

- `DemoMetricSeederTest`: pushes a point when the metric exists; creates nothing when it has been deleted.
- `ConsoleTest`: asserts both demo-mode scheduled commands are registered.

Full suite: 675 passed (2,963 assertions), PHPStan and Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)