### PR TITLE
Fix component_id column type in component_checks migration

### DIFF
--- a/database/migrations/2025_09_14_000000_create_component_checks_table.php
+++ b/database/migrations/2025_09_14_000000_create_component_checks_table.php
@@ -13,13 +13,15 @@ return new class extends Migration
     {
         Schema::create('component_checks', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('component_id')->constrained('components')->cascadeOnDelete();
+            $table->unsignedInteger('component_id');
             $table->unsignedTinyInteger('status');
             $table->boolean('successful')->default(false);
             $table->unsignedSmallInteger('response_code')->nullable();
             $table->unsignedInteger('response_time')->nullable();
             $table->timestamp('checked_at');
             $table->timestamps();
+
+            $table->foreign('component_id')->references('id')->on('components')->cascadeOnDelete();
         });
     }
 

--- a/tests/Unit/Database/ComponentChecksTableTest.php
+++ b/tests/Unit/Database/ComponentChecksTableTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+it('creates component_id with the same column type as components.id', function () {
+    $componentsId = collect(Schema::getColumns('components'))->firstWhere('name', 'id');
+    $componentId = collect(Schema::getColumns('component_checks'))->firstWhere('name', 'component_id');
+
+    expect($componentId['type'])->toBe($componentsId['type']);
+});
+
+it('constrains component_id to components.id with cascading deletes', function () {
+    $foreignKey = collect(Schema::getForeignKeys('component_checks'))
+        ->first(fn (array $key) => $key['columns'] === ['component_id']);
+
+    expect($foreignKey)->not->toBeNull()
+        ->and($foreignKey['foreign_table'])->toBe('components')
+        ->and($foreignKey['foreign_columns'])->toBe(['id'])
+        ->and(strtolower($foreignKey['on_delete']))->toBe('cascade');
+});


### PR DESCRIPTION
## Summary
Corrects the `component_id` column type in the `component_checks` table migration to match the actual type of the `components.id` column, and adds a test to prevent future regressions.

Fixes https://github.com/cachethq/core/issues/366

## Changes
- Changed `component_id` from `foreignId()` (which creates an `unsignedBigInteger`) to `unsignedInteger()` to match the `components.id` column type
- Moved the foreign key constraint definition to explicit syntax using `$table->foreign()` for clarity
- Added unit test `ComponentChecksTableTest.php` that verifies:
  - The `component_id` column type matches `components.id` type
  - The foreign key constraint exists with correct references and cascading delete behavior

## Implementation Details
The migration now uses explicit foreign key definition rather than the fluent `foreignId()` helper, allowing us to specify the correct column type (`unsignedInteger`) while maintaining the cascading delete constraint.

https://claude.ai/code/session_0185KaU2ZQ8RR5JEW8S3F5qH