### PR TITLE
Implement FilamentUser on the User model

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -8,6 +8,8 @@ use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
 use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -27,7 +29,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property ?string $app_authentication_secret
  * @property ?array $app_authentication_recovery_codes
  */
-class User extends Authenticatable implements CachetUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasLocalePreference, MustVerifyEmail
+class User extends Authenticatable implements CachetUser, FilamentUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasLocalePreference, MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, InteractsWithAppAuthentication, InteractsWithAppAuthenticationRecovery, MustVerifyEmailTrait, Notifiable;
@@ -67,6 +69,14 @@ class User extends Authenticatable implements CachetUser, HasAppAuthentication, 
             'password' => 'hashed',
             'is_admin' => 'bool',
         ];
+    }
+
+    /**
+     * Determine if the user can access the given Filament panel.
+     */
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Filament 5.6 denies panel access with a 403 outside the `local` environment when the authenticated user model does not implement the `FilamentUser` contract (`Filament\Http\Middleware\Authenticate`). `Cachet\Models\User` doesn't implement it, so any production install that updates to Filament ≥ 5.6 loses access to the dashboard entirely.

The test suite doesn't catch this because Testbench's workbench skeleton runs with `APP_ENV=local`, where Filament skips the check.

## What changed

- `Cachet\Models\User` now implements `Filament\Models\Contracts\FilamentUser`, with `canAccessPanel()` returning `true` — preserving the existing semantics where any authenticated user may access the dashboard.

Split out of #389 (the MCP server PR), where it originally landed; it's independent of MCP and worth releasing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157S7dDNDwYuqWsqeg1DB94