### PR TITLE
Fix API documentation and request handling mismatches

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -3,6 +3,7 @@
 use App\Models\User;
 use Cachet\Http\Middleware\AuthenticateApiIfProtected;
 use Cachet\Http\Middleware\EnsureApiIsEnabled;
+use Cachet\Http\Middleware\ForceJsonResponse;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
 return [
@@ -91,6 +92,7 @@ return [
      |
      */
     'api_middleware' => [
+        ForceJsonResponse::class,
         EnsureApiIsEnabled::class,
         AuthenticateApiIfProtected::class,
         SubstituteBindings::class,

--- a/src/Data/Casts/FlexibleDateTimeCast.php
+++ b/src/Data/Casts/FlexibleDateTimeCast.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Cachet\Data\Casts;
+
+use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
+use DateTimeInterface;
+use Spatie\LaravelData\Casts\Cast;
+use Spatie\LaravelData\Casts\Uncastable;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataProperty;
+
+/**
+ * Casts any date value accepted by the "date" validation rule, such as
+ * "2023-11-07 05:31:56" or ISO 8601 ("2023-11-07T05:31:56Z"), to Carbon.
+ */
+final class FlexibleDateTimeCast implements Cast
+{
+    public function cast(DataProperty $property, mixed $value, array $properties, CreationContext $context): DateTimeInterface|Uncastable
+    {
+        if ($value instanceof DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        if (! is_string($value) && ! is_int($value) && ! is_float($value)) {
+            return Uncastable::create();
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (InvalidFormatException) {
+            return Uncastable::create();
+        }
+    }
+}

--- a/src/Data/Requests/Component/CreateComponentRequestData.php
+++ b/src/Data/Requests/Component/CreateComponentRequestData.php
@@ -31,25 +31,14 @@ final class CreateComponentRequestData extends BaseData
             'order' => ['int', 'min:0'],
             'enabled' => ['boolean'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
-        ];
-    }
-
-    /**
-     * Specify body parameter documentation for Scribe.
-     */
-    public function bodyParameters(): array
-    {
-        return [
-            'status' => [
-                'description' => 'The status of the component. See [Component Statuses](/v3.x/guide/components#component-statuses) for more information.',
-                'example' => '1',
-                'required' => false,
-                'schema' => [
-                    'type' => 'integer',
-                    'enum' => ComponentStatusEnum::cases(),
-                ],
-            ],
         ];
     }
 }

--- a/src/Data/Requests/Component/UpdateComponentRequestData.php
+++ b/src/Data/Requests/Component/UpdateComponentRequestData.php
@@ -31,6 +31,13 @@ final class UpdateComponentRequestData extends BaseData
             'order' => ['int', 'min:0'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],
             'enabled' => ['boolean'],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/CreateComponentGroupRequestData.php
@@ -43,22 +43,14 @@ final class CreateComponentGroupRequestData extends BaseData
             ],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
-        ];
-    }
-
-    public function bodyParameters(): array
-    {
-        return [
-            'collapsed' => [
-                'description' => 'The collapsed state of the component group on the status page.',
-                'example' => '0',
-                'required' => false,
-                'schema' => [
-                    'type' => 'integer',
-                    'enum' => ComponentGroupVisibilityEnum::cases(),
-                ],
-            ],
         ];
     }
 }

--- a/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
+++ b/src/Data/Requests/ComponentGroup/UpdateComponentGroupRequestData.php
@@ -42,22 +42,14 @@ final class UpdateComponentGroupRequestData extends BaseData
             ],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
-        ];
-    }
-
-    public function bodyParameters(): array
-    {
-        return [
-            'collapsed' => [
-                'description' => 'The collapsed state of the component group on the status page.',
-                'example' => '0',
-                'required' => false,
-                'schema' => [
-                    'type' => 'integer',
-                    'enum' => ComponentGroupVisibilityEnum::cases(),
-                ],
-            ],
         ];
     }
 }

--- a/src/Data/Requests/Incident/CreateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/CreateIncidentRequestData.php
@@ -50,13 +50,30 @@ final class CreateIncidentRequestData extends BaseData
             'visible' => ['boolean'],
             'stickied' => ['boolean'],
             'notifications' => ['boolean'],
+            /**
+             * The date/time the incident occurred, e.g. "2023-11-07 05:31:56" or ISO 8601. Defaults to now.
+             */
             'occurred_at' => ['nullable', 'date'],
+            /**
+             * Key/value variables passed to the incident template when rendering the message.
+             *
+             * @var array<string, mixed>
+             *
+             * @example {"reason": "scheduled maintenance"}
+             */
             'template_vars' => ['array'],
             'component_id' => [Rule::exists('components', 'id')],
             'component_status' => ['nullable', Rule::enum(ComponentStatusEnum::class), 'required_with:component_id'],
             'components' => ['array'],
-            'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
-            'components.*.status' => ['required_with:components', 'int', Rule::enum(ComponentStatusEnum::class)],
+            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.status' => ['required', 'int', Rule::enum(ComponentStatusEnum::class)],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/Incident/UpdateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/UpdateIncidentRequestData.php
@@ -31,7 +31,17 @@ final class UpdateIncidentRequestData extends BaseData
             'visible' => ['boolean'],
             'stickied' => ['boolean'],
             'notifications' => ['boolean'],
+            /**
+             * The date/time the incident occurred, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'occurred_at' => ['nullable', 'date'],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/Metric/CreateMetricPointRequestData.php
+++ b/src/Data/Requests/Metric/CreateMetricPointRequestData.php
@@ -17,6 +17,11 @@ final class CreateMetricPointRequestData extends BaseData
     {
         return [
             'value' => ['required', 'numeric'],
+            /**
+             * The date/time or Unix timestamp the metric point was recorded at. Defaults to now.
+             *
+             * @example "2023-11-07 05:31:56"
+             */
             'timestamp' => ['nullable', new ValidTimestamp],
         ];
     }

--- a/src/Data/Requests/Metric/CreateMetricRequestData.php
+++ b/src/Data/Requests/Metric/CreateMetricRequestData.php
@@ -5,6 +5,7 @@ namespace Cachet\Data\Requests\Metric;
 use Cachet\Data\BaseData;
 use Cachet\Enums\MetricTypeEnum;
 use Cachet\Rules\FactorOfSixty;
+use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 final class CreateMetricRequestData extends BaseData
@@ -25,9 +26,12 @@ final class CreateMetricRequestData extends BaseData
         return [
             'name' => ['required', 'string', 'max:255'],
             'suffix' => ['required', 'string', 'max:255'],
+            'calc_type' => ['nullable', Rule::enum(MetricTypeEnum::class)],
             'description' => ['string'],
             'default_value' => ['decimal:1,2'],
+            'display_chart' => ['nullable', 'boolean'],
             'threshold' => ['int', 'min:0', 'max:60', new FactorOfSixty],
+            'places' => ['int', 'min:0', 'max:4'],
         ];
     }
 }

--- a/src/Data/Requests/Schedule/CreateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/CreateScheduleRequestData.php
@@ -3,13 +3,13 @@
 namespace Cachet\Data\Requests\Schedule;
 
 use Cachet\Data\BaseData;
+use Cachet\Data\Casts\FlexibleDateTimeCast;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Carbon\Carbon;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
-use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 final class CreateScheduleRequestData extends BaseData
@@ -17,9 +17,9 @@ final class CreateScheduleRequestData extends BaseData
     public function __construct(
         public readonly string $name,
         public readonly string $message,
-        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        #[WithCast(FlexibleDateTimeCast::class)]
         public readonly Carbon $scheduledAt,
-        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        #[WithCast(FlexibleDateTimeCast::class)]
         public readonly ?Carbon $completedAt = null,
         public readonly ?ScheduleStatusEnum $status = null,
         public readonly bool $notifications = false,
@@ -34,12 +34,25 @@ final class CreateScheduleRequestData extends BaseData
         return [
             'name' => ['required', 'string', 'max:255'],
             'message' => ['required', 'string'],
+            /**
+             * The date/time the maintenance window starts, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'scheduled_at' => ['required', 'date'],
+            /**
+             * The date/time the maintenance window ends, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'completed_at' => ['nullable', 'date'],
             'notifications' => ['boolean'],
             'components' => ['array'],
-            'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
-            'components.*.status' => ['required_with:components', 'int', Rule::enum(ComponentStatusEnum::class)],
+            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.status' => ['required', 'int', Rule::enum(ComponentStatusEnum::class)],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
@@ -3,13 +3,13 @@
 namespace Cachet\Data\Requests\Schedule;
 
 use Cachet\Data\BaseData;
+use Cachet\Data\Casts\FlexibleDateTimeCast;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Carbon\Carbon;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
-use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 final class UpdateScheduleRequestData extends BaseData
@@ -18,9 +18,9 @@ final class UpdateScheduleRequestData extends BaseData
         public readonly ?string $name = null,
         public readonly ?string $message = null,
         public readonly ?ScheduleStatusEnum $status = null,
-        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        #[WithCast(FlexibleDateTimeCast::class)]
         public readonly ?Carbon $scheduledAt = null,
-        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        #[WithCast(FlexibleDateTimeCast::class)]
         public readonly ?Carbon $completedAt = null,
         #[DataCollectionOf(ScheduleComponentRequestData::class)]
         public readonly ?array $components = null,
@@ -33,11 +33,24 @@ final class UpdateScheduleRequestData extends BaseData
         return [
             'name' => ['string', 'max:255'],
             'message' => ['string'],
+            /**
+             * The date/time the maintenance window starts, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'scheduled_at' => ['nullable', 'date'],
+            /**
+             * The date/time the maintenance window ends, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'completed_at' => ['nullable', 'date'],
             'components' => ['array'],
-            'components.*.id' => ['required_with:components', 'int', 'exists:components,id'],
-            'components.*.status' => ['required_with:components', Rule::enum(ComponentStatusEnum::class)],
+            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.status' => ['required', Rule::enum(ComponentStatusEnum::class)],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/ScheduleUpdate/CreateScheduleUpdateRequestData.php
+++ b/src/Data/Requests/ScheduleUpdate/CreateScheduleUpdateRequestData.php
@@ -3,16 +3,16 @@
 namespace Cachet\Data\Requests\ScheduleUpdate;
 
 use Cachet\Data\BaseData;
+use Cachet\Data\Casts\FlexibleDateTimeCast;
 use Carbon\Carbon;
 use Spatie\LaravelData\Attributes\WithCast;
-use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
 
 final class CreateScheduleUpdateRequestData extends BaseData
 {
     public function __construct(
         public readonly string $message,
-        #[WithCast(DateTimeInterfaceCast::class, format: 'Y-m-d H:i:s')]
+        #[WithCast(FlexibleDateTimeCast::class)]
         public readonly ?Carbon $completedAt = null,
     ) {}
 
@@ -20,6 +20,9 @@ final class CreateScheduleUpdateRequestData extends BaseData
     {
         return [
             'message' => ['required', 'string'],
+            /**
+             * The date/time the maintenance window ended, e.g. "2023-11-07 05:31:56" or ISO 8601.
+             */
             'completed_at' => ['nullable', 'date'],
         ];
     }

--- a/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/CreateSubscriberRequestData.php
@@ -25,6 +25,13 @@ final class CreateSubscriberRequestData extends BaseData
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
             'verified' => ['bool'],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
+++ b/src/Data/Requests/Subscriber/UpdateSubscriberRequestData.php
@@ -23,6 +23,13 @@ final class UpdateSubscriberRequestData extends BaseData
             'global' => ['bool'],
             'components' => ['array'],
             'components.*' => ['int', 'min:0', Rule::exists('components', 'id')],
+            /**
+             * Key/value metadata to store against the resource.
+             *
+             * @var array<string, mixed>|null
+             *
+             * @example {"cluster": "eu-west"}
+             */
             'meta' => ['nullable', 'array'],
         ];
     }

--- a/src/Http/Middleware/ForceJsonResponse.php
+++ b/src/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ForceJsonResponse
+{
+    /**
+     * Force the API to always respond with JSON, regardless of the Accept
+     * header, so errors are never rendered as HTML or redirects.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}

--- a/tests/Architecture/DataTest.php
+++ b/tests/Architecture/DataTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use Cachet\Data\BaseData;
+use Cachet\Data\Casts\FlexibleDateTimeCast;
 use Spatie\LaravelData\Data;
 
 test('data test')
     ->expect('Cachet\Data')
     ->toBeClasses()
     ->toExtend(BaseData::class)
+    ->ignoring(FlexibleDateTimeCast::class)
     ->toBeFinal()
     ->ignoring(BaseData::class);
 

--- a/tests/Feature/Api/MetricTest.php
+++ b/tests/Feature/Api/MetricTest.php
@@ -192,6 +192,39 @@ it('can create a metric', function () {
     ]);
 });
 
+it('can create a metric with a calc type, display chart and places', function () {
+    Sanctum::actingAs(User::factory()->create(), ['metrics.manage']);
+
+    $response = postJson('/status/api/metrics', [
+        'name' => 'New Metric',
+        'suffix' => 'cups of tea',
+        'calc_type' => 1,
+        'display_chart' => true,
+        'places' => 3,
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('metrics', [
+        'name' => 'New Metric',
+        'calc_type' => 1,
+        'display_chart' => true,
+        'places' => 3,
+    ]);
+});
+
+it('cannot create a metric with invalid places', function () {
+    Sanctum::actingAs(User::factory()->create(), ['metrics.manage']);
+
+    $response = postJson('/status/api/metrics', [
+        'name' => 'New Metric',
+        'suffix' => 'cups of tea',
+        'places' => 10,
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['places']);
+});
+
 it('cannot update a metric if not authenticated', function () {
     $metric = Metric::factory()->create();
 

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -322,6 +322,61 @@ it('can create a schedule', function () {
     $this->assertDatabaseCount('schedule_components', 0);
 });
 
+it('can create a schedule with ISO 8601 dates', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $response = postJson('/status/api/schedules', [
+        'name' => 'New Scheduled Maintenance',
+        'message' => 'Something will go wrong.',
+        'scheduled_at' => '2033-11-07T05:31:56Z',
+        'completed_at' => '2033-11-08T05:31:56Z',
+    ]);
+
+    $response->assertCreated();
+    $response->assertJson([
+        'data' => [
+            'attributes' => [
+                'scheduled' => [
+                    'string' => '2033-11-07 05:31:56',
+                ],
+                'completed' => [
+                    'string' => '2033-11-08 05:31:56',
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('responds with a JSON validation error when the Accept header is not set', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $response = $this->post('/status/api/schedules', [
+        'name' => 'Missing Message and Scheduled At',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertHeader('Content-Type', 'application/json');
+    $response->assertJsonValidationErrors(['message', 'scheduled_at']);
+});
+
+it('cannot create a schedule with a component missing a status', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $component = Component::factory()->create();
+
+    $response = postJson('/status/api/schedules', [
+        'name' => 'New Scheduled Maintenance',
+        'message' => 'Something will go wrong.',
+        'scheduled_at' => now()->addWeek()->toDateTimeString(),
+        'components' => [
+            ['id' => $component->id],
+        ],
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrors(['components.0.status']);
+});
+
 it('can create a schedule with components', function () {
     Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
 


### PR DESCRIPTION
Fixes cachethq/cachet#4618.

The API reference is generated from this repo via Scramble, so the broken `create schedule` example (and several similar issues found while reviewing the rest of the API docs) are fixed at the source.

## Issues from cachethq/cachet#4618

1. **Errors required an `Accept: application/json` header** — a new `ForceJsonResponse` middleware now leads the `api_middleware` group, so the API always returns JSON errors (422/401) instead of HTML redirects. This also resolves the error-handling complaints in cachethq/cachet#4587. Note: installs that have already published `config/cachet.php` need to add the middleware manually.
2. **ISO 8601 dates were rejected** despite the docs showing them — schedule and schedule update date fields used a rigid `Y-m-d H:i:s` cast. A new `FlexibleDateTimeCast` (Carbon-based) accepts exactly what the `date` validation rule allows, so the documented ISO example now works as-is.
3. **`components[].status` appeared optional in the docs** — Scramble doesn't translate `required_with`, so the generated example omitted it. The wildcard rules now use plain `required` (identical runtime behavior) and the schema emits `required: ["id", "status"]`.

## Additional fixes from reviewing the rest of the API docs

- `meta` was documented as an array of strings on all create/update endpoints; it's now documented as a nullable key/value object with a description and example.
- `CreateMetricRequestData` accepted `calc_type`, `display_chart` and `places` with no validation rules — they were unvalidated and invisible in the docs. Now validated (enum / boolean / int 0–4) and documented.
- `template_vars` on incident creation is now documented as a key/value object.
- Metric point `timestamp` now documents that it accepts a date/time or Unix timestamp and defaults to now.
- Date fields now describe their accepted formats.
- Removed dead `bodyParameters()` methods left over from Scribe.

## Tests

New tests cover ISO 8601 schedule creation, JSON validation errors without an `Accept` header, rejection of components missing a status, and validation of the new metric fields. Full suite (752 passed) and PHPStan are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)