### PR TITLE
Package configuration improvements

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -193,12 +193,14 @@ return [
      | Cachet Webhooks
      |--------------------------------------------------------------------------
      |
-     | Configure how Cachet sends webhooks for events.
+     | Configure how Cachet sends webhooks for events. When the connection or
+     | queue name is null, the application's default queue connection and
+     | queue are used.
      |
      */
     'webhooks' => [
-        'queue_connection' => env('CACHET_WEBHOOK_QUEUE_CONNECTION', 'default'),
-        'queue_name' => env('CACHET_WEBHOOK_QUEUE_NAME', 'webhooks'),
+        'queue_connection' => env('CACHET_WEBHOOK_QUEUE_CONNECTION'),
+        'queue_name' => env('CACHET_WEBHOOK_QUEUE_NAME'),
 
         'logs' => [
             'prune_logs_after_days' => 30,

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -6,6 +6,7 @@ use Cachet\Http\Middleware\AuthenticateMcpIfProtected;
 use Cachet\Http\Middleware\EnsureApiIsEnabled;
 use Cachet\Http\Middleware\EnsureMcpIsEnabled;
 use Cachet\Http\Middleware\ForceJsonResponse;
+use Cachet\Http\Middleware\SetStatusPageLocale;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
 return [
@@ -78,6 +79,7 @@ return [
      */
     'middleware' => [
         'web',
+        SetStatusPageLocale::class,
         //        \Cachet\Http\Middleware\AuthenticateRemoteUser::class,
     ],
 

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -179,6 +179,30 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Cachet Migrations
+     |--------------------------------------------------------------------------
+     |
+     | Whether Cachet loads its migrations into the application's migrator.
+     | Disable this when the host application manages Cachet's migrations
+     | itself.
+     |
+     */
+    'run_migrations' => env('CACHET_RUN_MIGRATIONS', true),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Cachet Schedules
+     |--------------------------------------------------------------------------
+     |
+     | Whether Cachet registers its scheduled tasks (beacon, notifications,
+     | pruning) with the application's scheduler. Disable this when the
+     | host application schedules these commands itself.
+     |
+     */
+    'register_schedules' => env('CACHET_REGISTER_SCHEDULES', true),
+
+    /*
+     |--------------------------------------------------------------------------
      | Cachet Component Checks
      |--------------------------------------------------------------------------
      |

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -128,7 +128,11 @@ class CachetCoreServiceProvider extends ServiceProvider
     private function registerResources(): void
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cachet');
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        if (config('cachet.run_migrations', true)) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
+
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'cachet');
 
         $this->configureRateLimiting();
@@ -288,6 +292,10 @@ class CachetCoreServiceProvider extends ServiceProvider
     private function registerSchedules(): void
     {
         if (! $this->app->runningInConsole()) {
+            return;
+        }
+
+        if (! config('cachet.register_schedules', true)) {
             return;
         }
 

--- a/src/Http/Middleware/SetStatusPageLocale.php
+++ b/src/Http/Middleware/SetStatusPageLocale.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cachet\Http\Middleware;
+
+use Cachet\Settings\AppSettings;
+use Closure;
+use Illuminate\Http\Request;
+
+class SetStatusPageLocale
+{
+    public function __construct(private AppSettings $settings) {}
+
+    /**
+     * Apply the instance-wide locale setting to the current request.
+     *
+     * Wrapped in rescue() so a missing settings table (pre-setup, pre-migration) is not fatal.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        rescue(function (): void {
+            if (array_key_exists($this->settings->locale, config('cachet.supported_locales', []))) {
+                app()->setLocale($this->settings->locale);
+            }
+        }, report: false);
+
+        return $next($request);
+    }
+}

--- a/src/Models/WebhookSubscription.php
+++ b/src/Models/WebhookSubscription.php
@@ -74,8 +74,8 @@ class WebhookSubscription extends Model
                 'subscription_id' => $this->getKey(),
                 'event' => $event->value,
             ])
-            ->onConnection(config('cachet.webhooks.queue.connection'))
-            ->onQueue(config('cachet.webhooks.queue.name'))
+            ->onConnection(config('cachet.webhooks.queue_connection'))
+            ->onQueue(config('cachet.webhooks.queue_name'))
             ->useSecret($this->secret);
     }
 

--- a/tests/Feature/ProviderConfigTest.php
+++ b/tests/Feature/ProviderConfigTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Cachet\CachetCoreServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
+
+it('loads the package migrations by default', function () {
+    $corePath = realpath(dirname((new ReflectionClass(CachetCoreServiceProvider::class))->getFileName()).'/../database/migrations');
+
+    expect(collect(app('migrator')->paths())->map(fn (string $path) => realpath($path)))
+        ->toContain($corePath);
+});
+
+it('registers the package schedules by default', function () {
+    $commands = collect(app(Schedule::class)->events())
+        ->map(fn ($event) => $event->command ?? '');
+
+    expect($commands->filter(fn (string $command) => str_contains($command, 'cachet:beacon')))->not->toBeEmpty();
+});

--- a/tests/Feature/ProviderConfigTogglesTest.php
+++ b/tests/Feature/ProviderConfigTogglesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Cachet\Tests\Feature;
+
+use Cachet\CachetCoreServiceProvider;
+use Cachet\Tests\TestCase;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Application;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use ReflectionClass;
+
+class ProviderConfigTogglesTest extends TestCase
+{
+    protected function disableMigrations(Application $app): void
+    {
+        $app['config']->set('cachet.run_migrations', false);
+    }
+
+    protected function disableSchedules(Application $app): void
+    {
+        $app['config']->set('cachet.register_schedules', false);
+    }
+
+    #[DefineEnvironment('disableMigrations')]
+    public function test_it_does_not_load_the_package_migrations_when_disabled(): void
+    {
+        $corePath = realpath(dirname((new ReflectionClass(CachetCoreServiceProvider::class))->getFileName()).'/../database/migrations');
+
+        $paths = array_map(fn (string $path) => realpath($path), $this->app['migrator']->paths());
+
+        $this->assertNotContains($corePath, $paths);
+    }
+
+    #[DefineEnvironment('disableSchedules')]
+    public function test_it_does_not_register_the_package_schedules_when_disabled(): void
+    {
+        $commands = collect($this->app->make(Schedule::class)->events())
+            ->map(fn ($event) => $event->command ?? '')
+            ->filter(fn (string $command) => str_contains($command, 'cachet:'));
+
+        $this->assertEmpty($commands);
+    }
+}

--- a/tests/Feature/StatusPage/StatusPageTest.php
+++ b/tests/Feature/StatusPage/StatusPageTest.php
@@ -10,6 +10,16 @@ it('renders the status page', function () {
         ->assertOk();
 });
 
+it('renders the status page in the configured locale', function () {
+    $settings = app(AppSettings::class);
+    $settings->locale = 'de';
+    $settings->save();
+
+    $this->get(route('cachet.status-page'))->assertOk();
+
+    expect(app()->getLocale())->toBe('de');
+});
+
 it('does not error when the from query parameter is malformed', function () {
     $this->get(route('cachet.status-page', ['from' => '2024-04-15/']))
         ->assertOk();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\QueryBuilder\QueryBuilderServiceProvider;
+use Spatie\WebhookServer\WebhookServerServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
@@ -52,6 +53,7 @@ abstract class TestCase extends Orchestra
             WidgetsServiceProvider::class,
             ScrambleServiceProvider::class,
             QueryBuilderServiceProvider::class,
+            WebhookServerServiceProvider::class,
         ]);
 
         // Laravel apps register providers in alphabetical order, so we do the same here for consistency.

--- a/tests/Unit/Http/Middleware/SetStatusPageLocaleTest.php
+++ b/tests/Unit/Http/Middleware/SetStatusPageLocaleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Cachet\Http\Middleware\SetStatusPageLocale;
+use Cachet\Settings\AppSettings;
+use Illuminate\Http\Request;
+
+beforeEach(function () {
+    config(['cachet.supported_locales' => [
+        'en' => 'English',
+        'fr' => 'Français',
+        'de' => 'Deutsch',
+    ]]);
+
+    app()->setLocale('en');
+});
+
+it('applies the app settings locale when it is supported', function () {
+    $settings = app(AppSettings::class);
+    $settings->locale = 'fr';
+    $settings->save();
+
+    app(SetStatusPageLocale::class)->handle(Request::create('/'), fn () => null);
+
+    expect(app()->getLocale())->toBe('fr');
+});
+
+it('leaves the app locale untouched when the setting is not a supported locale', function () {
+    $settings = app(AppSettings::class);
+    $settings->locale = 'xx';
+    $settings->save();
+
+    app(SetStatusPageLocale::class)->handle(Request::create('/'), fn () => null);
+
+    expect(app()->getLocale())->toBe('en');
+});
+
+it('passes the request through to the next middleware', function () {
+    $request = Request::create('/');
+    $called = false;
+
+    app(SetStatusPageLocale::class)->handle($request, function ($passed) use (&$called, $request) {
+        expect($passed)->toBe($request);
+        $called = true;
+
+        return 'ok';
+    });
+
+    expect($called)->toBeTrue();
+});

--- a/tests/Unit/Models/WebhookSubscriptionTest.php
+++ b/tests/Unit/Models/WebhookSubscriptionTest.php
@@ -2,11 +2,40 @@
 
 use Cachet\Enums\WebhookEventEnum;
 use Cachet\Models\WebhookSubscription;
+use Illuminate\Support\Facades\Bus;
+use Spatie\WebhookServer\CallWebhookJob;
 
 it('can have attempts', function () {
     $subscription = WebhookSubscription::factory()->hasAttempts(2)->create();
 
     expect($subscription->attempts)->toHaveCount(2);
+});
+
+it('dispatches webhook calls on the configured queue connection and queue', function () {
+    config()->set('cachet.webhooks.queue_connection', 'redis');
+    config()->set('cachet.webhooks.queue_name', 'hooks');
+
+    Bus::fake();
+
+    $subscription = WebhookSubscription::factory()->create();
+
+    $subscription->makeCall(WebhookEventEnum::component_created, ['name' => 'API'])->dispatch();
+
+    Bus::assertDispatched(CallWebhookJob::class, function (CallWebhookJob $job) {
+        return $job->connection === 'redis' && $job->queue === 'hooks';
+    });
+});
+
+it('dispatches webhook calls on the default queue connection and queue when not configured', function () {
+    Bus::fake();
+
+    $subscription = WebhookSubscription::factory()->create();
+
+    $subscription->makeCall(WebhookEventEnum::component_created, ['name' => 'API'])->dispatch();
+
+    Bus::assertDispatched(CallWebhookJob::class, function (CallWebhookJob $job) {
+        return $job->connection === null && $job->queue === null;
+    });
 });
 
 it('can scope based on given event', function () {


### PR DESCRIPTION
Small configuration fixes and additions:

- **Fix webhook queue config keys never being applied.** `WebhookSubscription::makeCall()` read `cachet.webhooks.queue.connection` / `queue.name`, but the config file defines `queue_connection` / `queue_name`, so the configured values were silently ignored and webhook calls always ran on the default connection and queue. The model now reads the documented keys. Both default to `null` (the application's default connection/queue), preserving the current effective behaviour while making the `CACHET_WEBHOOK_QUEUE_*` env vars work.
- **Apply the locale setting to the public status page.** `AppSettings->locale` was editable from the dashboard but never applied outside the dashboard panel. A new `SetStatusPageLocale` middleware in the default status page stack applies it when it's one of the supported locales, wrapped in `rescue()` so a missing settings table (pre-setup) is not fatal.
- **Add `cachet.run_migrations` and `cachet.register_schedules`** (both default `true`). Host applications that manage Cachet's migrations or scheduled tasks themselves can disable either without patching the package, matching the opt-out behaviour offered by other first-party packages.

All changes covered by Pest tests; full suite green (`composer test:unit`, 859 passed) and Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b

---
_Generated by [Claude Code](https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b)_