### PR TITLE
Add a cachet:assets command to publish assets

### DIFF
--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Cachet;
 
 use BladeUI\Icons\Factory;
+use Cachet\Commands\AssetsCommand;
 use Cachet\Commands\CheckComponentsCommand;
 use Cachet\Commands\MakeUserCommand;
 use Cachet\Commands\NotifyCompletedSchedulesCommand;
@@ -269,6 +270,7 @@ class CachetCoreServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                AssetsCommand::class,
                 CheckComponentsCommand::class,
                 MakeUserCommand::class,
                 NotifyCompletedSchedulesCommand::class,

--- a/src/Commands/AssetsCommand.php
+++ b/src/Commands/AssetsCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Cachet\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class AssetsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cachet:assets';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Publish Cachet's assets";
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(Filesystem $filesystem): int
+    {
+        $filesystem->copyDirectory(
+            __DIR__.'/../../public',
+            public_path('vendor/cachethq/cachet'),
+        );
+
+        $this->info('Cachet assets published.');
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Unit/Commands/AssetsCommandTest.php
+++ b/tests/Unit/Commands/AssetsCommandTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+it('publishes the assets', function () {
+    $target = public_path('vendor/cachethq/cachet');
+    File::deleteDirectory($target);
+
+    $this->artisan('cachet:assets')
+        ->expectsOutput('Cachet assets published.')
+        ->assertExitCode(0);
+
+    expect(File::isDirectory($target))->toBeTrue()
+        ->and(File::exists($target.'/favicon.ico'))->toBeTrue();
+
+    File::deleteDirectory($target);
+});


### PR DESCRIPTION
## Summary

Adds a first-class `cachet:assets` command that publishes Cachet's compiled public assets into the application (`public/vendor/cachethq/cachet`), mirroring the convention other Laravel packages follow (e.g. `filament:assets`).

Today this requires remembering the publish tag (`vendor:publish --tag=cachet-assets`). A dedicated command is easier to wire into a deploy pipeline or a Composer `post-autoload-dump` hook so assets are refreshed whenever the package is installed/updated.

## Details

- `Cachet\Commands\AssetsCommand` — copies the package's `public/` directory to the app's public path.
- Registered alongside the other `cachet:*` commands.

## Tests

Feature test asserts the command runs, reports success, and lands the assets (`tests/Unit/Commands/AssetsCommandTest.php`). Full command suite + architecture test green, Pint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b)_