### PR TITLE
Rebuild metrics when the cache holds a corrupt value

### DIFF
--- a/resources/views/components/metric.blade.php
+++ b/resources/views/components/metric.blade.php
@@ -3,7 +3,9 @@
 ])
 
 @use('\Cachet\Enums\MetricViewEnum')
+@use('\Cachet\Models\Metric')
 
+@if ($metric instanceof Metric)
 <div x-data="chart_{{ $metric->id }}"
      class="group relative overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-zinc-900/10 dark:bg-zinc-900 dark:ring-white/15">
     <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/40 to-transparent" aria-hidden="true"></div>
@@ -69,3 +71,4 @@
         }))
     })
 </script>
+@endif

--- a/src/View/Components/Metrics.php
+++ b/src/View/Components/Metrics.php
@@ -27,20 +27,28 @@ class Metrics extends Component
     {
         $cacheKey = 'cachet::metrics.'.(auth()->check() ? 'users' : 'guests');
 
-        $metrics = Cache::remember($cacheKey, self::CACHE_TTL, fn (): Collection => $this->prepareMetrics());
-
-        // A cached entry left by another cache store, or otherwise corrupt, can
-        // deserialize to something other than a collection of metrics. Rather
-        // than let the view fatal on it, drop it and rebuild from the database.
-        if (! $metrics instanceof Collection || $metrics->contains(fn ($metric): bool => ! $metric instanceof Metric)) {
-            Cache::forget($cacheKey);
-
-            $metrics = $this->prepareMetrics();
-        }
+        $cached = Cache::remember($cacheKey, self::CACHE_TTL, fn (): Collection => $this->prepareMetrics());
 
         return view('cachet::components.metrics', [
-            'metrics' => $metrics,
+            'metrics' => $this->validMetrics($cached, $cacheKey),
         ]);
+    }
+
+    /**
+     * Return the cached metrics, or rebuild them from the database when the
+     * cached value is not a collection of metrics. A stale entry left behind
+     * after switching cache stores can deserialize to something else entirely,
+     * which would otherwise fatal the view reading properties off each item.
+     */
+    private function validMetrics(mixed $cached, string $cacheKey): Collection
+    {
+        if ($cached instanceof Collection && $cached->every(fn (mixed $metric): bool => $metric instanceof Metric)) {
+            return $cached;
+        }
+
+        Cache::forget($cacheKey);
+
+        return $this->prepareMetrics();
     }
 
     /**
@@ -50,8 +58,8 @@ class Metrics extends Component
     {
         $metrics = $this->metrics(Carbon::now()->subDays(30));
 
-        $metrics->each(function (Metric $metric): void {
-            $metric->metricPoints->transform(fn ($point): array => [
+        $metrics->each(function ($metric) {
+            $metric->metricPoints->transform(fn ($point) => [
                 'x' => $point->created_at->utc(),
                 'y' => $point->value,
             ]);

--- a/src/View/Components/Metrics.php
+++ b/src/View/Components/Metrics.php
@@ -27,25 +27,37 @@ class Metrics extends Component
     {
         $cacheKey = 'cachet::metrics.'.(auth()->check() ? 'users' : 'guests');
 
-        $metrics = Cache::remember($cacheKey, self::CACHE_TTL, function () {
-            $startDate = Carbon::now()->subDays(30);
+        $metrics = Cache::remember($cacheKey, self::CACHE_TTL, fn (): Collection => $this->prepareMetrics());
 
-            $metrics = $this->metrics($startDate);
+        // A cached entry left by another cache store, or otherwise corrupt, can
+        // deserialize to something other than a collection of metrics. Rather
+        // than let the view fatal on it, drop it and rebuild from the database.
+        if (! $metrics instanceof Collection || $metrics->contains(fn ($metric): bool => ! $metric instanceof Metric)) {
+            Cache::forget($cacheKey);
 
-            // Convert each metric point to Chart.js format (x, y)
-            $metrics->each(function ($metric) {
-                $metric->metricPoints->transform(fn ($point) => [
-                    'x' => $point->created_at->utc(),
-                    'y' => $point->value,
-                ]);
-            });
-
-            return $metrics;
-        });
+            $metrics = $this->prepareMetrics();
+        }
 
         return view('cachet::components.metrics', [
             'metrics' => $metrics,
         ]);
+    }
+
+    /**
+     * Build the metrics collection with each point cast to Chart.js format.
+     */
+    private function prepareMetrics(): Collection
+    {
+        $metrics = $this->metrics(Carbon::now()->subDays(30));
+
+        $metrics->each(function (Metric $metric): void {
+            $metric->metricPoints->transform(fn ($point): array => [
+                'x' => $point->created_at->utc(),
+                'y' => $point->value,
+            ]);
+        });
+
+        return $metrics;
     }
 
     /**

--- a/tests/Unit/Views/MetricsTest.php
+++ b/tests/Unit/Views/MetricsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\Metric;
+use Cachet\Models\MetricPoint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Cache;
+
+it('rebuilds the metrics when the cache holds a corrupt value', function () {
+    $metric = Metric::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'display_chart' => true,
+        'show_when_empty' => true,
+    ]);
+    MetricPoint::factory()->count(2)->create(['metric_id' => $metric->id]);
+
+    // A stale entry left by another cache store deserializes to strings, not
+    // metrics — the view would fatal reading ->id on each.
+    Cache::put('cachet::metrics.guests', collect(['not-a-metric']), 30);
+
+    $html = Blade::render('<x-cachet::metrics />');
+
+    expect($html)->toContain('chart_'.$metric->id);
+});
+
+it('caches a valid metrics collection', function () {
+    $metric = Metric::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'display_chart' => true,
+        'show_when_empty' => true,
+    ]);
+
+    Blade::render('<x-cachet::metrics />');
+
+    expect(Cache::get('cachet::metrics.guests'))
+        ->toBeInstanceOf(Collection::class)
+        ->first()->toBeInstanceOf(Metric::class);
+});

--- a/tests/Unit/Views/MetricsTest.php
+++ b/tests/Unit/Views/MetricsTest.php
@@ -24,6 +24,12 @@ it('rebuilds the metrics when the cache holds a corrupt value', function () {
     expect($html)->toContain('chart_'.$metric->id);
 });
 
+it('renders nothing when the metric component is given a non-metric', function () {
+    $html = Blade::render('<x-cachet::metric :metric="$metric" />', ['metric' => 'not-a-metric']);
+
+    expect(trim($html))->toBe('');
+});
+
 it('caches a valid metrics collection', function () {
     $metric = Metric::factory()->create([
         'visible' => ResourceVisibilityEnum::guest,


### PR DESCRIPTION
Fixes a status-page `Attempt to read property "id" on string` fatal in `resources/views/components/metric.blade.php`.

## Root cause

`View\Components\Metrics` caches the metric collection under a fixed key (`cachet::metrics.users` / `.guests`). If the entry under that key is **stale or incompatible** — most easily produced by switching cache stores, which is exactly what happened while bringing a deployment up — it can deserialize to something other than a collection of `Metric` models. The view then iterates it and reads `->id` / `->name` on each element; when an element is a string, the whole status page 500s until the entry's short TTL expires (which is why it appears as a burst).

The rendering path itself is sound — I verified it round-trips correctly through tagged Redis with the igbinary serializer under tenancy, plaintext and authenticated. The failure is a bad cache *value*, not bad code.

## Fix

Validate the value returned from the cache. If it isn't a `Collection` of `Metric` models, forget the key and rebuild from the database — so a corrupt entry degrades to one fresh query instead of a fatal. The build logic is extracted into `prepareMetrics()` and shared between the cache miss and the rebuild.

## Tests

`tests/Unit/Views/MetricsTest`:
- Seeds a guest-visible metric, plants a **corrupt** value (`collect(['not-a-metric'])`) under `cachet::metrics.guests` — the exact production symptom — and asserts the component still renders the real metric instead of fataling.
- Asserts a valid render caches a proper `Collection` of `Metric` models.

Existing status-page/metrics/view tests pass.

## Note for the reporter

This hardens against a recurrence. The immediate relief for a live site already showing it is to clear the cache (`php artisan cache:clear` or flush the cache store) — that evicts the bad entry now; this change stops a bad entry from taking the page down in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b

---
_Generated by [Claude Code](https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b)_