### PR TITLE
Stop two factories from generating values that flake on Postgres

### DIFF
--- a/database/factories/ComponentFactory.php
+++ b/database/factories/ComponentFactory.php
@@ -22,7 +22,7 @@ class ComponentFactory extends Factory
     {
         return [
             'name' => fake()->word,
-            'description' => fake()->paragraph,
+            'description' => fake()->text(200),
             'status' => ComponentStatusEnum::performance_issues->value,
             'order' => 0,
             'component_group_id' => null,

--- a/database/factories/WebhookSubscriptionFactory.php
+++ b/database/factories/WebhookSubscriptionFactory.php
@@ -21,7 +21,7 @@ class WebhookSubscriptionFactory extends Factory
     {
         return [
             'url' => fake()->url,
-            'secret' => fake()->randomAscii(),
+            'secret' => fake()->sha256(),
             'description' => fake()->sentence(),
             'send_all_events' => false,
             'selected_events' => [],


### PR DESCRIPTION
Two factory defaults occasionally generate values that fail on Postgres but slip through on SQLite, which is why they only ever flaked the pgsql CI matrix and passed everywhere else.

### `ComponentFactory` — description overflow
`description` was `fake()->paragraph`, which can exceed the column's `varchar(255)`. Postgres rejects it:

```
ERROR: value too long for type character varying(255)
```

SQLite doesn't enforce the length, so it passed there. Bounded to `fake()->text(200)` (guaranteed ≤ 200 chars). `incidents.message` and `incident_updates.message` also use `fake()->paragraph` but are `longText`, so they're left as-is.

### `WebhookSubscriptionFactory` — falsy `"0"` secret
`secret` was `fake()->randomAscii()` — a **single** ASCII character in the 33–126 range, which includes `48` = `"0"`. spatie/webhook-server guards dispatch with `if ($this->signWebhook && empty($this->secret))`, and in PHP **`empty("0") === true`**, so whenever the factory rolled `"0"` the dispatch tests threw:

```
Could not call the webhook because no secret has been set.
```

Replaced with `fake()->sha256()` — a non-degenerate 64-character secret, closer to a real signing secret anyway.

### Verification
Full suite green (`863 passed`), pint clean. Both were ~1-in-N dice rolls (94 for the secret, variable for the description), which is why they surfaced as intermittent pgsql-only reds rather than consistent failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b

---
_Generated by [Claude Code](https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b)_