### PR TITLE
Make incident status canonical and derive component status from impacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,3 +122,14 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ## HTTP Requests
 
 - Never use the `request()` helper. Inject `Illuminate\Http\Request` into the controller method and read input from `$request` (e.g. `$request->integer('per_page', 15)`).
+
+## The Current User
+
+- Never call `auth()` inside a model or an action. Resolving the current user is the caller's job, and reaching for it deeper down couples domain code to an HTTP session it should know nothing about.
+- Models and actions that need a user accept one as a parameter, typed `?Authenticatable`.
+- Controllers, Filament pages, jobs, commands and views are the right places to resolve the user, using `Cachet::user()` where a request-bound guard is needed.
+
+## Transactions
+
+- Any action that writes more than once — a model plus its pivots, a change plus its audit record — wraps the writes in `DB::transaction()`, so a failure part-way through cannot leave orphaned or half-populated rows.
+- Events describing the completed change are dispatched after the transaction commits, never inside it.

--- a/database/migrations/2026_07_25_000001_create_component_status_changes_table.php
+++ b/database/migrations/2026_07_25_000001_create_component_status_changes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('component_status_changes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('component_id');
+            $table->unsignedTinyInteger('old_status')->nullable();
+            $table->unsignedTinyInteger('new_status');
+            $table->string('source');
+            $table->nullableMorphs('causer');
+            $table->text('reason')->nullable();
+            $table->timestamps();
+
+            $table->foreign('component_id')->references('id')->on('components')->cascadeOnDelete();
+            $table->index(['component_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('component_status_changes');
+    }
+};

--- a/database/migrations/2026_07_25_000002_add_constraints_to_component_pivots.php
+++ b/database/migrations/2026_07_25_000002_add_constraints_to_component_pivots.php
@@ -1,0 +1,80 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The pivots that link a component to whatever is impacting it.
+     *
+     * @var array<string, string>
+     */
+    private const PIVOTS = [
+        'incident_components' => 'incident_id',
+        'schedule_components' => 'schedule_id',
+    ];
+
+    /**
+     * Run the migrations.
+     *
+     * Now that these rows decide what the status page displays, a component may
+     * only be attached to a given incident or schedule once. Duplicates that
+     * predate the constraint are collapsed to their most severe impact, which
+     * is the one that would have won anyway.
+     */
+    public function up(): void
+    {
+        foreach (self::PIVOTS as $table => $parentKey) {
+            $this->deduplicate($table, $parentKey);
+
+            Schema::table($table, function (Blueprint $table) use ($parentKey) {
+                $table->unique([$parentKey, 'component_id']);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach (self::PIVOTS as $table => $parentKey) {
+            Schema::table($table, function (Blueprint $table) use ($parentKey) {
+                $table->dropUnique([$parentKey, 'component_id']);
+            });
+        }
+    }
+
+    /**
+     * Collapse duplicate rows, keeping the most severe impact of each pair.
+     */
+    private function deduplicate(string $table, string $parentKey): void
+    {
+        DB::table($table)
+            ->select($parentKey, 'component_id')
+            ->groupBy($parentKey, 'component_id')
+            ->havingRaw('count(*) > 1')
+            ->get()
+            ->each(function (object $duplicate) use ($table, $parentKey) {
+                $keep = DB::table($table)
+                    ->where($parentKey, $duplicate->{$parentKey})
+                    ->where('component_id', $duplicate->component_id)
+                    ->get()
+                    ->sortByDesc(fn (object $row) => [
+                        ComponentStatusEnum::tryFrom((int) $row->component_status)?->severity() ?? 0,
+                        $row->id,
+                    ])
+                    ->first();
+
+                DB::table($table)
+                    ->where($parentKey, $duplicate->{$parentKey})
+                    ->where('component_id', $duplicate->component_id)
+                    ->where('id', '!=', $keep->id)
+                    ->delete();
+            });
+    }
+};

--- a/database/migrations/2026_07_25_000003_backfill_incident_status_from_updates.php
+++ b/database/migrations/2026_07_25_000003_backfill_incident_status_from_updates.php
@@ -1,0 +1,55 @@
+<?php
+
+use Cachet\Models\Incident;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * An incident's status used to live in its updates and be resolved when
+     * read; only a `fixed` update ever wrote the column. Now that the column is
+     * canonical, any incident whose updates moved it on without resolving it
+     * would revert to whatever status it was opened with. This aligns the
+     * column with the newest status-bearing update, by the same rule the
+     * application now keeps it in step with.
+     */
+    public function up(): void
+    {
+        $statuses = [];
+
+        DB::table('updates')
+            ->where('updateable_type', Relation::getMorphAlias(Incident::class))
+            ->whereNotNull('status')
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->select(['updateable_id', 'status'])
+            ->chunk(1000, function ($updates) use (&$statuses): void {
+                foreach ($updates as $update) {
+                    $statuses[$update->updateable_id] = $update->status;
+                }
+            });
+
+        collect($statuses)
+            ->groupBy(fn (int $status): int => $status, preserveKeys: true)
+            ->each(function ($incidents, int $status): void {
+                $incidents->keys()->chunk(1000)->each(fn ($ids) => DB::table('incidents')
+                    ->whereIn('id', $ids->all())
+                    ->where(fn ($query) => $query->where('status', '!=', $status)->orWhereNull('status'))
+                    ->update(['status' => $status]));
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * The previous statuses were never stored, so there is nothing to restore.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2026_07_26_000001_backfill_component_status_and_make_it_required.php
+++ b/database/migrations/2026_07_26_000001_backfill_component_status_and_make_it_required.php
@@ -1,0 +1,41 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Component status used to be nullable and was treated as "unknown" at read
+     * time. Backfill those rows explicitly so the column can become required
+     * and callers no longer need to carry null-specific logic forever.
+     */
+    public function up(): void
+    {
+        DB::table('components')
+            ->whereNull('status')
+            ->update(['status' => ComponentStatusEnum::unknown->value]);
+
+        Schema::table('components', function (Blueprint $table) {
+            $table->unsignedInteger('status')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * The original nulls were not preserved, so only the schema nullability can
+     * be restored here.
+     */
+    public function down(): void
+    {
+        Schema::table('components', function (Blueprint $table) {
+            $table->unsignedInteger('status')->nullable()->change();
+        });
+    }
+};

--- a/resources/lang/en/component.php
+++ b/resources/lang/en/component.php
@@ -39,6 +39,12 @@ return [
         'under_maintenance' => 'Under maintenance',
         'unknown' => 'Unknown',
     ],
+    'status_source' => [
+        'manual' => 'Manual',
+        'monitor' => 'Monitoring',
+        'import' => 'Import',
+        'system' => 'System',
+    ],
     'overview' => [
         'operational_components_label' => 'Operational components',
         'operational_components_description' => 'Components that are fully operational.',

--- a/resources/lang/en/schedule.php
+++ b/resources/lang/en/schedule.php
@@ -42,6 +42,7 @@ return [
             'action_label' => 'Add component',
             'header' => 'Affected components',
             'component_label' => 'Component',
+            'status_label' => 'Status during maintenance',
         ],
     ],
     'add_update' => [

--- a/resources/views/components/component-group.blade.php
+++ b/resources/views/components/component-group.blade.php
@@ -2,7 +2,7 @@
 
 {{ \Cachet\Facades\CachetView::renderHook(\Cachet\View\RenderHook::STATUS_PAGE_COMPONENT_GROUPS_BEFORE) }}
 @php($groupStatus = $componentGroup->worstComponentStatus())
-<li x-data x-disclosure @if ($componentGroup->isExpanded()) default-open @endif>
+<li x-data x-disclosure @if ($componentGroup->isExpanded(auth()->user())) default-open @endif>
     <button x-disclosure:button class="relative flex w-full items-center justify-between gap-3 py-3 pl-8 pr-4 text-left transition hover:bg-zinc-50/60 dark:hover:bg-white/[0.02] sm:py-4 sm:pl-9 sm:pr-6">
         <span class="absolute left-2 top-1/2 -translate-y-1/2 text-zinc-400 dark:text-zinc-500 sm:left-3">
             <x-heroicon-m-chevron-right ::class="$disclosure.isOpen && 'rotate-90'" class="size-3.5 transition" />

--- a/resources/views/components/component.blade.php
+++ b/resources/views/components/component.blade.php
@@ -35,12 +35,12 @@
                  @focusout="tooltipOpen = false"
                  class="relative shrink-0">
                 <div x-ref="badgeAnchor">
-                    @if ($component->incidents_count > 0 && $component->latest_unresolved_incident)
-                        <a href="{{ route('cachet.status-page.incident', [$component->latest_unresolved_incident]) }}" class="inline-flex text-sm font-medium {{ $component->latest_status->getTextColorClasses() }}">
+                    @if ($component->impacting_incident)
+                        <a href="{{ route('cachet.status-page.incident', [$component->impacting_incident]) }}" class="inline-flex text-sm font-medium {{ $component->latest_status->getTextColorClasses() }}">
                             {{ $component->latest_status->getLabel() }}
                         </a>
                     @else
-                        <span class="text-sm font-medium {{ $status->getTextColorClasses() }}">{{ $status->getLabel() }}</span>
+                        <span class="text-sm font-medium {{ $component->latest_status->getTextColorClasses() }}">{{ $component->latest_status->getLabel() }}</span>
                     @endif
                 </div>
 

--- a/src/Actions/Component/ChangeComponentStatus.php
+++ b/src/Actions/Component/ChangeComponentStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Cachet\Actions\Component;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
+use Cachet\Events\Components\ComponentStatusWasChanged;
+use Cachet\Models\Component;
+use Illuminate\Database\Eloquent\Model;
+
+class ChangeComponentStatus
+{
+    /**
+     * Change a component's baseline status, recording what caused it.
+     *
+     * Every writer of the status column goes through here — the dashboard, the
+     * API, MCP, the monitor and imports — so the status-changed event fires for
+     * all of them rather than only the ones that happen to call an action, and
+     * so there is always a record of who or what asserted the change.
+     */
+    public function handle(
+        Component $component,
+        ComponentStatusEnum $status,
+        ComponentStatusSourceEnum $source = ComponentStatusSourceEnum::Manual,
+        ?Model $causer = null,
+        ?string $reason = null,
+    ): Component {
+        $oldStatus = $component->getAttribute('status');
+
+        if ($oldStatus === $status) {
+            return $component;
+        }
+
+        $component->update(['status' => $status]);
+
+        $component->statusChanges()->create([
+            'old_status' => $oldStatus,
+            'new_status' => $status,
+            'source' => $source,
+            'reason' => $reason,
+            'causer_type' => $causer?->getMorphClass(),
+            'causer_id' => $causer?->getKey(),
+        ]);
+
+        ComponentStatusWasChanged::dispatch($component, $oldStatus, $status, $source);
+
+        return $component;
+    }
+}

--- a/src/Actions/Component/ChangeComponentStatus.php
+++ b/src/Actions/Component/ChangeComponentStatus.php
@@ -6,7 +6,9 @@ use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Events\Components\ComponentStatusWasChanged;
 use Cachet\Models\Component;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class ChangeComponentStatus
 {
@@ -17,12 +19,15 @@ class ChangeComponentStatus
      * API, MCP, the monitor and imports — so the status-changed event fires for
      * all of them rather than only the ones that happen to call an action, and
      * so there is always a record of who or what asserted the change.
+     *
+     * The status and its record are written together, and the event is only
+     * announced once both have committed.
      */
     public function handle(
         Component $component,
         ComponentStatusEnum $status,
         ComponentStatusSourceEnum $source = ComponentStatusSourceEnum::Manual,
-        ?Model $causer = null,
+        Authenticatable|Model|null $causer = null,
         ?string $reason = null,
     ): Component {
         $oldStatus = $component->getAttribute('status');
@@ -31,16 +36,18 @@ class ChangeComponentStatus
             return $component;
         }
 
-        $component->update(['status' => $status]);
+        DB::transaction(function () use ($component, $status, $source, $causer, $reason, $oldStatus): void {
+            $component->update(['status' => $status]);
 
-        $component->statusChanges()->create([
-            'old_status' => $oldStatus,
-            'new_status' => $status,
-            'source' => $source,
-            'reason' => $reason,
-            'causer_type' => $causer?->getMorphClass(),
-            'causer_id' => $causer?->getKey(),
-        ]);
+            $component->statusChanges()->create([
+                'old_status' => $oldStatus,
+                'new_status' => $status,
+                'source' => $source,
+                'reason' => $reason,
+                'causer_type' => $causer instanceof Model ? $causer->getMorphClass() : null,
+                'causer_id' => $causer instanceof Model ? $causer->getKey() : null,
+            ]);
+        });
 
         ComponentStatusWasChanged::dispatch($component, $oldStatus, $status, $source);
 

--- a/src/Actions/Component/ChangeComponentStatus.php
+++ b/src/Actions/Component/ChangeComponentStatus.php
@@ -22,6 +22,12 @@ class ChangeComponentStatus
      *
      * The status and its record are written together, and the event is only
      * announced once both have committed.
+     *
+     * Anything else the caller was going to save on the component is passed in
+     * as `$attributes` and written in the same statement, so a single edit is
+     * one write and one `ComponentUpdated` event rather than two.
+     *
+     * @param  array<string, mixed>  $attributes
      */
     public function handle(
         Component $component,
@@ -29,15 +35,17 @@ class ChangeComponentStatus
         ComponentStatusSourceEnum $source = ComponentStatusSourceEnum::Manual,
         Authenticatable|Model|null $causer = null,
         ?string $reason = null,
+        array $attributes = [],
     ): Component {
         $oldStatus = $component->getAttribute('status');
+        $changed = $oldStatus !== $status;
 
-        if ($oldStatus === $status) {
-            return $component;
-        }
+        DB::transaction(function () use ($component, $status, $source, $causer, $reason, $oldStatus, $changed, $attributes): void {
+            $component->update([...$attributes, 'status' => $status]);
 
-        DB::transaction(function () use ($component, $status, $source, $causer, $reason, $oldStatus): void {
-            $component->update(['status' => $status]);
+            if (! $changed) {
+                return;
+            }
 
             $component->statusChanges()->create([
                 'old_status' => $oldStatus,
@@ -49,7 +57,9 @@ class ChangeComponentStatus
             ]);
         });
 
-        ComponentStatusWasChanged::dispatch($component, $oldStatus, $status, $source);
+        if ($changed) {
+            ComponentStatusWasChanged::dispatch($component, $oldStatus, $status, $source);
+        }
 
         return $component;
     }

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -21,19 +21,22 @@ class UpdateComponent
     public function handle(Component $component, UpdateComponentRequestData $data, ?Authenticatable $user = null): Component
     {
         DB::transaction(function () use ($component, $data, $user): void {
-            $component->update($data->except('meta', 'status')->toArray());
+            $attributes = $data->except('meta', 'status')->toArray();
 
-            if ($data->meta !== null) {
-                $component->syncMeta($data->meta);
-            }
-
-            if ($data->status !== null) {
+            if ($data->status === null) {
+                $component->update($attributes);
+            } else {
                 $this->changeComponentStatus->handle(
                     $component,
                     $data->status,
                     ComponentStatusSourceEnum::Manual,
                     $user,
+                    attributes: $attributes,
                 );
+            }
+
+            if ($data->meta !== null) {
+                $component->syncMeta($data->meta);
             }
         });
 

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -5,6 +5,8 @@ namespace Cachet\Actions\Component;
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
 use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Models\Component;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
 
 class UpdateComponent
 {
@@ -16,22 +18,24 @@ class UpdateComponent
     /**
      * Handle the action.
      */
-    public function handle(Component $component, UpdateComponentRequestData $data): Component
+    public function handle(Component $component, UpdateComponentRequestData $data, ?Authenticatable $user = null): Component
     {
-        $component->update($data->except('meta', 'status')->toArray());
+        DB::transaction(function () use ($component, $data, $user): void {
+            $component->update($data->except('meta', 'status')->toArray());
 
-        if ($data->meta !== null) {
-            $component->syncMeta($data->meta);
-        }
+            if ($data->meta !== null) {
+                $component->syncMeta($data->meta);
+            }
 
-        if ($data->status !== null) {
-            $this->changeComponentStatus->handle(
-                $component,
-                $data->status,
-                ComponentStatusSourceEnum::Manual,
-                auth()->user(),
-            );
-        }
+            if ($data->status !== null) {
+                $this->changeComponentStatus->handle(
+                    $component,
+                    $data->status,
+                    ComponentStatusSourceEnum::Manual,
+                    $user,
+                );
+            }
+        });
 
         return $component->fresh();
     }

--- a/src/Actions/Component/UpdateComponent.php
+++ b/src/Actions/Component/UpdateComponent.php
@@ -3,29 +3,33 @@
 namespace Cachet\Actions\Component;
 
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
-use Cachet\Events\Components\ComponentStatusWasChanged;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Models\Component;
 
 class UpdateComponent
 {
+    public function __construct(private ChangeComponentStatus $changeComponentStatus)
+    {
+        //
+    }
+
     /**
      * Handle the action.
      */
     public function handle(Component $component, UpdateComponentRequestData $data): Component
     {
-        $oldStatus = $component->status;
-
-        $component->update($data->except('meta')->toArray());
+        $component->update($data->except('meta', 'status')->toArray());
 
         if ($data->meta !== null) {
             $component->syncMeta($data->meta);
         }
 
-        if ($component->wasChanged('status')) {
-            ComponentStatusWasChanged::dispatch(
+        if ($data->status !== null) {
+            $this->changeComponentStatus->handle(
                 $component,
-                $oldStatus,
-                $component->status
+                $data->status,
+                ComponentStatusSourceEnum::Manual,
+                auth()->user(),
             );
         }
 

--- a/src/Actions/Incident/CreateIncident.php
+++ b/src/Actions/Incident/CreateIncident.php
@@ -8,6 +8,7 @@ use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Models\IncidentTemplate;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class CreateIncident
@@ -30,23 +31,28 @@ class CreateIncident
             $data = $data->withMessage($this->parseTemplate($template, $data));
         }
 
-        return tap(Incident::create(array_merge(
-            ['guid' => Str::uuid()],
-            $data->except('components', 'meta')->toArray()
-        )), function (Incident $incident) use ($data) {
-            if ($data->components) {
-                $components = collect($data->components)->map(fn (IncidentComponentRequestData $component) => [
-                    'component_id' => $component->id,
-                    'component_status' => $component->status,
-                ])->all();
+        $incident = DB::transaction(function () use ($data): Incident {
+            return tap(Incident::create(array_merge(
+                ['guid' => Str::uuid()],
+                $data->except('components', 'meta')->toArray()
+            )), function (Incident $incident) use ($data) {
+                if ($data->components) {
+                    $components = collect($data->components)
+                        ->mapWithKeys(fn (IncidentComponentRequestData $component) => [
+                            $component->id => ['component_status' => $component->status],
+                        ])
+                        ->all();
 
-                $incident->components()->sync($components);
-            }
+                    $incident->components()->sync($components);
+                }
 
-            $incident->syncMeta($data->meta ?? []);
-
-            $this->notifyIncidentSubscribers->handle($incident);
+                $incident->syncMeta($data->meta ?? []);
+            });
         });
+
+        $this->notifyIncidentSubscribers->handle($incident);
+
+        return $incident;
     }
 
     /**

--- a/src/Actions/Incident/SyncIncidentStatus.php
+++ b/src/Actions/Incident/SyncIncidentStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Cachet\Actions\Incident;
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Models\Incident;
+
+class SyncIncidentStatus
+{
+    /**
+     * Align an incident's status with its most recent status-bearing update.
+     *
+     * The incident's own column is the canonical status: updates drive it at
+     * write time rather than being consulted at read time. An incident with no
+     * status-bearing updates keeps whatever status it was given directly.
+     */
+    public function handle(Incident $incident): Incident
+    {
+        $status = $incident->updates()
+            ->whereNotNull('status')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->value('status');
+
+        if ($status === null) {
+            return $incident;
+        }
+
+        $status = $status instanceof IncidentStatusEnum ? $status : IncidentStatusEnum::from((int) $status);
+
+        if ($incident->status !== $status) {
+            $incident->update(['status' => $status]);
+        }
+
+        return $incident;
+    }
+}

--- a/src/Actions/Integrations/ImportOhDearFeed.php
+++ b/src/Actions/Integrations/ImportOhDearFeed.php
@@ -2,7 +2,9 @@
 
 namespace Cachet\Actions\Integrations;
 
+use Cachet\Actions\Component\ChangeComponentStatus;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Enums\ExternalProviderEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
@@ -30,13 +32,21 @@ class ImportOhDearFeed
     private function importSites(array $sites, ?int $componentGroupId): void
     {
         foreach ($sites as $site) {
-            Component::updateOrCreate(
+            $status = $site['status'] === 'up' ? ComponentStatusEnum::operational : ComponentStatusEnum::partial_outage;
+
+            $component = Component::updateOrCreate(
                 ['link' => $site['url']],
                 [
                     'name' => $site['label'],
                     'component_group_id' => $componentGroupId,
-                    'status' => $site['status'] === 'up' ? ComponentStatusEnum::operational : ComponentStatusEnum::partial_outage,
                 ]
+            );
+
+            app(ChangeComponentStatus::class)->handle(
+                $component,
+                $status,
+                ComponentStatusSourceEnum::Import,
+                reason: ExternalProviderEnum::OhDear->value,
             );
         }
     }

--- a/src/Actions/Integrations/ImportOhDearFeed.php
+++ b/src/Actions/Integrations/ImportOhDearFeed.php
@@ -12,6 +12,11 @@ use Illuminate\Support\Carbon;
 
 class ImportOhDearFeed
 {
+    public function __construct(private ChangeComponentStatus $changeComponentStatus)
+    {
+        //
+    }
+
     /**
      * Import an OhDear feed.
      */
@@ -33,20 +38,22 @@ class ImportOhDearFeed
     {
         foreach ($sites as $site) {
             $status = $site['status'] === 'up' ? ComponentStatusEnum::operational : ComponentStatusEnum::partial_outage;
+            $attributes = ['name' => $site['label'], 'component_group_id' => $componentGroupId];
 
-            $component = Component::updateOrCreate(
-                ['link' => $site['url']],
-                [
-                    'name' => $site['label'],
-                    'component_group_id' => $componentGroupId,
-                ]
-            );
+            $component = Component::firstOrNew(['link' => $site['url']]);
 
-            app(ChangeComponentStatus::class)->handle(
+            if (! $component->exists) {
+                $component->fill([...$attributes, 'status' => $status])->save();
+
+                continue;
+            }
+
+            $this->changeComponentStatus->handle(
                 $component,
                 $status,
                 ComponentStatusSourceEnum::Import,
                 reason: ExternalProviderEnum::OhDear->value,
+                attributes: $attributes,
             );
         }
     }

--- a/src/Actions/Schedule/CreateSchedule.php
+++ b/src/Actions/Schedule/CreateSchedule.php
@@ -5,6 +5,7 @@ namespace Cachet\Actions\Schedule;
 use Cachet\Data\Requests\Schedule\CreateScheduleRequestData;
 use Cachet\Data\Requests\Schedule\ScheduleComponentRequestData;
 use Cachet\Models\Schedule;
+use Illuminate\Support\Facades\DB;
 
 class CreateSchedule
 {
@@ -19,19 +20,24 @@ class CreateSchedule
     public function handle(CreateScheduleRequestData $data): Schedule
     {
         /** @phpstan-ignore-next-line argument.type */
-        return tap(Schedule::create($data->except('components', 'meta')->toArray()), function (Schedule $schedule) use ($data) {
-            if ($data->components) {
-                $components = collect($data->components)->map(fn (ScheduleComponentRequestData $component) => [
-                    'component_id' => $component->id,
-                    'component_status' => $component->status,
-                ])->all();
+        $schedule = DB::transaction(function () use ($data): Schedule {
+            return tap(Schedule::create($data->except('components', 'meta')->toArray()), function (Schedule $schedule) use ($data) {
+                if ($data->components) {
+                    $components = collect($data->components)
+                        ->mapWithKeys(fn (ScheduleComponentRequestData $component) => [
+                            $component->id => ['component_status' => $component->status],
+                        ])
+                        ->all();
 
-                $schedule->components()->sync($components);
-            }
+                    $schedule->components()->sync($components);
+                }
 
-            $schedule->syncMeta($data->meta ?? []);
-
-            $this->notifyScheduleSubscribers->handle($schedule);
+                $schedule->syncMeta($data->meta ?? []);
+            });
         });
+
+        $this->notifyScheduleSubscribers->handle($schedule);
+
+        return $schedule;
     }
 }

--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -20,10 +20,11 @@ class UpdateSchedule
         }
 
         if ($data->components) {
-            $components = collect($data->components)->map(fn (ScheduleComponentRequestData $component) => [
-                'component_id' => $component->id,
-                'component_status' => $component->status,
-            ])->all();
+            $components = collect($data->components)
+                ->mapWithKeys(fn (ScheduleComponentRequestData $component) => [
+                    $component->id => ['component_status' => $component->status],
+                ])
+                ->all();
 
             $schedule->components()->sync($components);
         }

--- a/src/Actions/Update/CreateUpdate.php
+++ b/src/Actions/Update/CreateUpdate.php
@@ -2,11 +2,10 @@
 
 namespace Cachet\Actions\Update;
 
+use Cachet\Actions\Incident\SyncIncidentStatus;
 use Cachet\Actions\Schedule\NotifyScheduleCompletedSubscribers;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
-use Cachet\Enums\ComponentStatusEnum;
-use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
@@ -18,6 +17,7 @@ class CreateUpdate
         private NotifyIncidentUpdateSubscribers $notifyIncidentUpdateSubscribers,
         private NotifyScheduleUpdateSubscribers $notifyScheduleUpdateSubscribers,
         private NotifyScheduleCompletedSubscribers $notifyScheduleCompletedSubscribers,
+        private SyncIncidentStatus $syncIncidentStatus,
     ) {
         //
     }
@@ -31,9 +31,8 @@ class CreateUpdate
 
         $resource->updates()->save($update);
 
-        if ($resource instanceof Incident && $data->status === IncidentStatusEnum::fixed) {
-            $resource->update(['status' => IncidentStatusEnum::fixed]);
-            $this->updateComponentsToOperational($resource);
+        if ($resource instanceof Incident) {
+            $this->syncIncidentStatus->handle($resource);
         }
 
         $this->notifyIncidentUpdateSubscribers->handle($update);
@@ -72,17 +71,5 @@ class CreateUpdate
         }
 
         return false;
-    }
-
-    /**
-     * Set all linked components back to operational when an incident is fixed.
-     */
-    private function updateComponentsToOperational(Incident $incident): void
-    {
-        $incident->components()->each(function ($component) use ($incident) {
-            $incident->components()->updateExistingPivot($component->id, [
-                'component_status' => ComponentStatusEnum::operational,
-            ]);
-        });
     }
 }

--- a/src/Actions/Update/CreateUpdate.php
+++ b/src/Actions/Update/CreateUpdate.php
@@ -10,6 +10,8 @@ use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
 use Cachet\Models\Update;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
 
 class CreateUpdate
 {
@@ -25,15 +27,20 @@ class CreateUpdate
     /**
      * Handle the action.
      */
-    public function handle(Incident|Schedule $resource, CreateIncidentUpdateRequestData|CreateScheduleUpdateRequestData $data): Update
+    public function handle(Incident|Schedule $resource, CreateIncidentUpdateRequestData|CreateScheduleUpdateRequestData $data, ?Authenticatable $user = null): Update
     {
-        $update = new Update(array_merge(['user_id' => auth()->id()], $data->except('completedAt')->toArray()));
+        $update = new Update(array_merge(
+            ['user_id' => $user?->getAuthIdentifier()],
+            $data->except('completedAt')->toArray()
+        ));
 
-        $resource->updates()->save($update);
+        DB::transaction(function () use ($resource, $update): void {
+            $resource->updates()->save($update);
 
-        if ($resource instanceof Incident) {
-            $this->syncIncidentStatus->handle($resource);
-        }
+            if ($resource instanceof Incident) {
+                $this->syncIncidentStatus->handle($resource);
+            }
+        });
 
         $this->notifyIncidentUpdateSubscribers->handle($update);
 

--- a/src/Actions/Update/DeleteUpdate.php
+++ b/src/Actions/Update/DeleteUpdate.php
@@ -2,15 +2,28 @@
 
 namespace Cachet\Actions\Update;
 
+use Cachet\Actions\Incident\SyncIncidentStatus;
+use Cachet\Models\Incident;
 use Cachet\Models\Update;
 
 class DeleteUpdate
 {
+    public function __construct(private SyncIncidentStatus $syncIncidentStatus)
+    {
+        //
+    }
+
     /**
      * Handle the action.
      */
     public function handle(Update $update): void
     {
+        $incident = $update->updateable;
+
         $update->delete();
+
+        if ($incident instanceof Incident) {
+            $this->syncIncidentStatus->handle($incident);
+        }
     }
 }

--- a/src/Actions/Update/EditUpdate.php
+++ b/src/Actions/Update/EditUpdate.php
@@ -2,12 +2,19 @@
 
 namespace Cachet\Actions\Update;
 
+use Cachet\Actions\Incident\SyncIncidentStatus;
 use Cachet\Data\Requests\IncidentUpdate\EditIncidentUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\EditScheduleUpdateRequestData;
+use Cachet\Models\Incident;
 use Cachet\Models\Update;
 
 class EditUpdate
 {
+    public function __construct(private SyncIncidentStatus $syncIncidentStatus)
+    {
+        //
+    }
+
     /**
      * Handle the action.
      */
@@ -15,6 +22,12 @@ class EditUpdate
     {
         return tap($update, function (Update $update) use ($data) {
             $update->update($data->toArray());
+
+            $incident = $update->updateable;
+
+            if ($incident instanceof Incident) {
+                $this->syncIncidentStatus->handle($incident);
+            }
         });
     }
 }

--- a/src/Data/Requests/Component/CreateComponentRequestData.php
+++ b/src/Data/Requests/Component/CreateComponentRequestData.php
@@ -12,7 +12,7 @@ final class CreateComponentRequestData extends BaseData
     public function __construct(
         public readonly string $name,
         public readonly ?string $description = null,
-        public readonly ?ComponentStatusEnum $status = null,
+        public readonly ComponentStatusEnum $status = ComponentStatusEnum::unknown,
         public readonly ?string $link = null,
         public readonly ?int $order = null,
         public readonly bool $enabled = true,

--- a/src/Data/Requests/Incident/CreateIncidentRequestData.php
+++ b/src/Data/Requests/Incident/CreateIncidentRequestData.php
@@ -70,7 +70,7 @@ final class CreateIncidentRequestData extends BaseData
             'component_id' => [Rule::exists('components', 'id')],
             'component_status' => ['nullable', Rule::enum(ComponentStatusEnum::class), 'required_with:component_id'],
             'components' => ['array'],
-            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.id' => ['required', 'int', 'distinct', 'exists:components,id'],
             'components.*.status' => ['required', 'int', Rule::enum(ComponentStatusEnum::class)],
             /**
              * Key/value metadata to store against the resource.

--- a/src/Data/Requests/Schedule/CreateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/CreateScheduleRequestData.php
@@ -50,7 +50,7 @@ final class CreateScheduleRequestData extends BaseData
             'published_at' => ['nullable', 'date'],
             'notifications' => ['boolean'],
             'components' => ['array'],
-            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.id' => ['required', 'int', 'distinct', 'exists:components,id'],
             'components.*.status' => ['required', 'int', Rule::enum(ComponentStatusEnum::class)],
             /**
              * Key/value metadata to store against the resource.

--- a/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
+++ b/src/Data/Requests/Schedule/UpdateScheduleRequestData.php
@@ -48,7 +48,7 @@ final class UpdateScheduleRequestData extends BaseData
              */
             'published_at' => ['nullable', 'date'],
             'components' => ['array'],
-            'components.*.id' => ['required', 'int', 'exists:components,id'],
+            'components.*.id' => ['required', 'int', 'distinct', 'exists:components,id'],
             'components.*.status' => ['required', Rule::enum(ComponentStatusEnum::class)],
             /**
              * Key/value metadata to store against the resource.

--- a/src/Enums/ComponentStatusSourceEnum.php
+++ b/src/Enums/ComponentStatusSourceEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Cachet\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum ComponentStatusSourceEnum: string implements HasLabel
+{
+    case Manual = 'manual';
+    case Monitor = 'monitor';
+    case Import = 'import';
+    case System = 'system';
+
+    public function getLabel(): string
+    {
+        return __("cachet::component.status_source.{$this->value}");
+    }
+}

--- a/src/Events/Components/ComponentStatusWasChanged.php
+++ b/src/Events/Components/ComponentStatusWasChanged.php
@@ -4,6 +4,7 @@ namespace Cachet\Events\Components;
 
 use Cachet\Concerns\SendsWebhook;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Enums\WebhookEventEnum;
 use Cachet\Models\Component;
 use Illuminate\Broadcasting\Channel;
@@ -19,8 +20,12 @@ class ComponentStatusWasChanged
     /**
      * Create a new event instance.
      */
-    public function __construct(public Component $component, public ComponentStatusEnum $oldStatus, public ComponentStatusEnum $newStatus)
-    {
+    public function __construct(
+        public Component $component,
+        public ?ComponentStatusEnum $oldStatus,
+        public ComponentStatusEnum $newStatus,
+        public ComponentStatusSourceEnum $source = ComponentStatusSourceEnum::Manual,
+    ) {
         //
     }
 
@@ -40,8 +45,9 @@ class ComponentStatusWasChanged
     {
         return [
             'component_id' => $this->component->getKey(),
-            'old_status' => $this->oldStatus->value,
+            'old_status' => $this->oldStatus?->value,
             'new_status' => $this->newStatus->value,
+            'source' => $this->source->value,
         ];
     }
 

--- a/src/Filament/Resources/Components/Pages/EditComponent.php
+++ b/src/Filament/Resources/Components/Pages/EditComponent.php
@@ -2,10 +2,15 @@
 
 namespace Cachet\Filament\Resources\Components\Pages;
 
+use Cachet\Actions\Component\ChangeComponentStatus;
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Filament\Concerns\InteractsWithMeta;
 use Cachet\Filament\Resources\Components\ComponentResource;
+use Cachet\Models\Component;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditComponent extends EditRecord
 {
@@ -28,6 +33,31 @@ class EditComponent extends EditRecord
     protected function mutateFormDataBeforeSave(array $data): array
     {
         return $this->extractMetaFormData($data);
+    }
+
+    /**
+     * Route a status change through the action so it is recorded and announced
+     * like every other status change, rather than being saved straight to the
+     * column by the form.
+     */
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $status = $data['status'] ?? null;
+
+        unset($data['status']);
+
+        $record = parent::handleRecordUpdate($record, $data);
+
+        if ($status !== null && $record instanceof Component) {
+            app(ChangeComponentStatus::class)->handle(
+                $record,
+                $status instanceof ComponentStatusEnum ? $status : ComponentStatusEnum::from((int) $status),
+                ComponentStatusSourceEnum::Manual,
+                auth()->user(),
+            );
+        }
+
+        return $record;
     }
 
     protected function afterSave(): void

--- a/src/Filament/Resources/Components/Pages/EditComponent.php
+++ b/src/Filament/Resources/Components/Pages/EditComponent.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Resources\Components\Pages;
 
 use Cachet\Actions\Component\ChangeComponentStatus;
+use Cachet\Cachet;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Filament\Concerns\InteractsWithMeta;
@@ -11,6 +12,7 @@ use Cachet\Models\Component;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 class EditComponent extends EditRecord
 {
@@ -42,22 +44,19 @@ class EditComponent extends EditRecord
      */
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
-        $status = $data['status'] ?? null;
+        $status = Arr::pull($data, 'status');
 
-        unset($data['status']);
-
-        $record = parent::handleRecordUpdate($record, $data);
-
-        if ($status !== null && $record instanceof Component) {
-            app(ChangeComponentStatus::class)->handle(
-                $record,
-                $status instanceof ComponentStatusEnum ? $status : ComponentStatusEnum::from((int) $status),
-                ComponentStatusSourceEnum::Manual,
-                auth()->user(),
-            );
+        if ($status === null || ! $record instanceof Component) {
+            return parent::handleRecordUpdate($record, $data);
         }
 
-        return $record;
+        return app(ChangeComponentStatus::class)->handle(
+            $record,
+            $status instanceof ComponentStatusEnum ? $status : ComponentStatusEnum::from((int) $status),
+            ComponentStatusSourceEnum::Manual,
+            Cachet::user(),
+            attributes: $data,
+        );
     }
 
     protected function afterSave(): void

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Resources\Incidents;
 
 use Cachet\Actions\Update\CreateUpdate as CreateIncidentUpdateAction;
+use Cachet\Cachet;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
@@ -219,7 +220,7 @@ class IncidentResource extends Resource
             ->label(__('cachet::incident.list.actions.record_update'))
             ->color('info')
             ->action(function (CreateIncidentUpdateAction $createIncidentUpdate, Incident $record, array $data) {
-                $createIncidentUpdate->handle($record, CreateIncidentUpdateRequestData::from($data));
+                $createIncidentUpdate->handle($record, CreateIncidentUpdateRequestData::from($data), Cachet::user());
 
                 Notification::make()
                     ->title(__('cachet::incident.record_update.success_title'))

--- a/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
@@ -51,12 +51,14 @@ class ComponentsRelationManager extends RelationManager
                         fn (Select $select) => $select->placeholder(__('Select a component')),
                     )
                     ->multiple()
-                    ->mutateFormDataUsing(function (array $data): array {
-                        // Set a default component_status value (Operational)
-                        $data['component_status'] = ComponentStatusEnum::operational->value;
-
-                        return $data;
-                    }),
+                    ->schema(fn (array $schema): array => [
+                        ...$schema,
+                        Select::make('component_status')
+                            ->options(ComponentStatusEnum::class)
+                            ->default(ComponentStatusEnum::under_maintenance->value)
+                            ->required()
+                            ->label(__('cachet::schedule.form.add_component.status_label')),
+                    ]),
             ])
             ->recordActions([
                 DetachAction::make(),

--- a/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
@@ -51,8 +51,8 @@ class ComponentsRelationManager extends RelationManager
                         fn (Select $select) => $select->placeholder(__('Select a component')),
                     )
                     ->multiple()
-                    ->schema(fn (array $schema): array => [
-                        ...$schema,
+                    ->schema(fn (AttachAction $action): array => [
+                        $action->getRecordSelect(),
                         Select::make('component_status')
                             ->options(ComponentStatusEnum::class)
                             ->default(ComponentStatusEnum::under_maintenance->value)

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -19,7 +19,6 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
-use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
@@ -84,8 +83,11 @@ class ScheduleResource extends Resource
                                 ->relationship('component', 'name')
                                 ->disableOptionsWhenSelectedInSiblingRepeaterItems()
                                 ->label(__('cachet::schedule.form.add_component.component_label')),
-                            Hidden::make('component_status')
-                                ->default(ComponentStatusEnum::operational->value),
+                            Select::make('component_status')
+                                ->options(ComponentStatusEnum::class)
+                                ->default(ComponentStatusEnum::under_maintenance->value)
+                                ->required()
+                                ->label(__('cachet::schedule.form.add_component.status_label')),
                         ])
                         ->label(__('cachet::schedule.form.add_component.header'))
                         ->columnSpanFull(),

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Resources\Schedules;
 
 use Cachet\Actions\Update\CreateUpdate;
+use Cachet\Cachet;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
@@ -177,7 +178,7 @@ class ScheduleResource extends Resource
             ->label(__('cachet::schedule.list.actions.record_update'))
             ->color('info')
             ->action(function (CreateUpdate $createUpdate, Schedule $record, array $data) {
-                $createUpdate->handle($record, CreateScheduleUpdateRequestData::from($data));
+                $createUpdate->handle($record, CreateScheduleUpdateRequestData::from($data), Cachet::user());
 
                 Notification::make()
                     ->title(__('cachet::schedule.add_update.success_title'))

--- a/src/Filament/Widgets/Components.php
+++ b/src/Filament/Widgets/Components.php
@@ -2,7 +2,9 @@
 
 namespace Cachet\Filament\Widgets;
 
+use Cachet\Actions\Component\ChangeComponentStatus;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
 use Filament\Forms\Components\ToggleButtons;
@@ -82,7 +84,12 @@ class Components extends Widget implements HasSchemas
             ->inline()
             ->live()
             ->options(ComponentStatusEnum::class)
-            ->afterStateUpdated(fn (ComponentStatusEnum $state) => $component->update(['status' => $state]));
+            ->afterStateUpdated(fn (ComponentStatusEnum $state) => app(ChangeComponentStatus::class)->handle(
+                $component,
+                $state,
+                ComponentStatusSourceEnum::Manual,
+                auth()->user(),
+            ));
     }
 
     protected function loadComponentGroups(): Collection

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -92,6 +92,7 @@ class ComponentController extends Controller
         $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
 
         return Component::query()
+            ->with(['unresolvedIncidents', 'activeMaintenance'])
             ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
             ->where(function ($query) use ($visibleGroups): void {
                 $query->whereNull('component_group_id')

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -72,7 +72,7 @@ class ComponentController extends Controller
             'group',
             AllowedInclude::callback('incidents', function (BelongsToMany $query): void {
                 /** @var BelongsToMany<Incident, Component> $query */
-                $query->visible($this->isAuthenticated());
+                $query->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'));
             }),
             'meta',
         ];

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Component\CreateComponent;
 use Cachet\Actions\Component\DeleteComponent;
 use Cachet\Actions\Component\UpdateComponent;
+use Cachet\Cachet;
 use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\Component\CreateComponentRequestData;
@@ -130,11 +131,11 @@ class ComponentController extends Controller
     /**
      * Update Component
      */
-    public function update(UpdateComponentRequestData $data, Component $component, UpdateComponent $updateComponentAction)
+    public function update(Request $request, UpdateComponentRequestData $data, Component $component, UpdateComponent $updateComponentAction)
     {
         $this->guard('components.manage');
 
-        $updateComponentAction->handle($component, $data);
+        $updateComponentAction->handle($component, $data, Cachet::user($request));
 
         return ComponentResource::make($component->fresh());
     }

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -64,8 +64,8 @@ class IncidentController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request)
     {
-        $incidents = QueryBuilder::for(Incident::query()->with('updates')->visible($this->isAuthenticated())
-            ->when(! $this->tokenCan('incidents.manage'), fn (Builder $query) => $query->published()))
+        $incidents = QueryBuilder::for(Incident::query()->with('updates')
+            ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage')))
             ->allowedIncludes($this->allowedIncludes())
             ->allowedFilters([
                 'name',

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -83,12 +83,18 @@ class IncidentUpdateController extends Controller
     }
 
     /**
-     * Abort with a 404 when the parent incident is not visible to the caller.
+     * Abort with a 404 when the parent incident is not readable by the caller.
+     *
+     * An embargoed incident must not leak its updates either, so publication is
+     * checked here on exactly the same terms as the incident endpoints.
      */
     protected function ensureIncidentVisible(Incident $incident): void
     {
         abort_unless(
-            Incident::query()->visible($this->isAuthenticated())->whereKey($incident->getKey())->exists(),
+            Incident::query()
+                ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'))
+                ->whereKey($incident->getKey())
+                ->exists(),
             Response::HTTP_NOT_FOUND,
         );
     }

--- a/src/Http/Controllers/Api/IncidentUpdateController.php
+++ b/src/Http/Controllers/Api/IncidentUpdateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Actions\Update\DeleteUpdate;
 use Cachet\Actions\Update\EditUpdate;
+use Cachet\Cachet;
 use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
@@ -55,11 +56,11 @@ class IncidentUpdateController extends Controller
     /**
      * Create Incident Update
      */
-    public function store(CreateIncidentUpdateRequestData $data, Incident $incident, CreateUpdate $createUpdateAction)
+    public function store(Request $request, CreateIncidentUpdateRequestData $data, Incident $incident, CreateUpdate $createUpdateAction)
     {
         $this->guard('incident-updates.manage');
 
-        $update = $createUpdateAction->handle($incident, $data);
+        $update = $createUpdateAction->handle($incident, $data, Cachet::user($request));
 
         return UpdateResource::make($update);
     }

--- a/src/Http/Controllers/Api/ScheduleUpdateController.php
+++ b/src/Http/Controllers/Api/ScheduleUpdateController.php
@@ -5,6 +5,7 @@ namespace Cachet\Http\Controllers\Api;
 use Cachet\Actions\Update\CreateUpdate;
 use Cachet\Actions\Update\DeleteUpdate;
 use Cachet\Actions\Update\EditUpdate;
+use Cachet\Cachet;
 use Cachet\Concerns\GuardsApiAbilities;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\EditScheduleUpdateRequestData;
@@ -50,11 +51,11 @@ class ScheduleUpdateController extends Controller
     /**
      * Create Schedule Update
      */
-    public function store(CreateScheduleUpdateRequestData $data, Schedule $schedule, CreateUpdate $createUpdateAction)
+    public function store(Request $request, CreateScheduleUpdateRequestData $data, Schedule $schedule, CreateUpdate $createUpdateAction)
     {
         $this->guard('schedule-updates.manage');
 
-        $update = $createUpdateAction->handle($schedule, $data);
+        $update = $createUpdateAction->handle($schedule, $data, Cachet::user($request));
 
         return UpdateResource::make($update);
     }

--- a/src/Http/Controllers/RssController.php
+++ b/src/Http/Controllers/RssController.php
@@ -30,7 +30,7 @@ class RssController
                 'statusPageName' => $appSettings->name,
                 'statusAbout' => $appSettings->about,
                 'incidents' => Incident::query()
-                    ->guests()
+                    ->viewableBy(false)
                     ->with('updates')
                     ->when($appSettings->recent_incidents_only, function ($query) use ($appSettings) {
                         $query->where(function ($query) use ($appSettings) {

--- a/src/Http/Controllers/StatusPage/StatusPageController.php
+++ b/src/Http/Controllers/StatusPage/StatusPageController.php
@@ -34,7 +34,7 @@ class StatusPageController
      */
     public function show(Incident $incident): View
     {
-        abort_if(! $incident->isPublished() && ! auth()->check(), 404);
+        abort_unless($incident->isViewableBy(auth()->check(), includeUnpublished: auth()->check()), 404);
 
         return view('cachet::status-page.incident', [
             'incident' => $incident->loadMissing([

--- a/src/Http/Resources/Component.php
+++ b/src/Http/Resources/Component.php
@@ -17,8 +17,8 @@ class Component extends JsonApiResource
             'link' => $this->link,
             'order' => $this->order,
             'status' => [
-                'human' => $this->status?->getLabel(),
-                'value' => $this->status?->value,
+                'human' => $this->status->getLabel(),
+                'value' => $this->status->value,
             ],
             'latest_status' => [
                 'human' => $this->latest_status->getLabel(),

--- a/src/Http/Resources/Component.php
+++ b/src/Http/Resources/Component.php
@@ -20,6 +20,10 @@ class Component extends JsonApiResource
                 'human' => $this->status?->getLabel(),
                 'value' => $this->status?->value,
             ],
+            'latest_status' => [
+                'human' => $this->latest_status->getLabel(),
+                'value' => $this->latest_status->value,
+            ],
             'enabled' => $this->enabled,
             'meta' => $this->when(
                 $this->resource->relationLoaded('meta'),

--- a/src/Jobs/CheckComponent.php
+++ b/src/Jobs/CheckComponent.php
@@ -66,9 +66,9 @@ class CheckComponent implements ShouldQueue
             'checked_at' => $checkedAt,
         ]);
 
-        $this->component->update(['checked_at' => $checkedAt]);
-
         if ($this->component->isUnderMaintenance()) {
+            $this->component->update(['checked_at' => $checkedAt]);
+
             return;
         }
 
@@ -76,6 +76,7 @@ class CheckComponent implements ShouldQueue
             $this->component,
             $result->status,
             ComponentStatusSourceEnum::Monitor,
+            attributes: ['checked_at' => $checkedAt],
         );
     }
 }

--- a/src/Jobs/CheckComponent.php
+++ b/src/Jobs/CheckComponent.php
@@ -2,8 +2,10 @@
 
 namespace Cachet\Jobs;
 
+use Cachet\Actions\Component\ChangeComponentStatus;
 use Cachet\Cachet;
 use Cachet\Data\Checks\CheckResult;
+use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Models\Component;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -28,6 +30,11 @@ class CheckComponent implements ShouldQueue
 
     /**
      * Execute the job.
+     *
+     * The check is always recorded, but the component's baseline status is left
+     * alone while a maintenance window is in progress: downtime is expected
+     * then, and reporting it as an outage is exactly what the window exists to
+     * prevent.
      */
     public function handle(): void
     {
@@ -59,9 +66,16 @@ class CheckComponent implements ShouldQueue
             'checked_at' => $checkedAt,
         ]);
 
-        $this->component->update([
-            'status' => $result->status,
-            'checked_at' => $checkedAt,
-        ]);
+        $this->component->update(['checked_at' => $checkedAt]);
+
+        if ($this->component->isUnderMaintenance()) {
+            return;
+        }
+
+        app(ChangeComponentStatus::class)->handle(
+            $this->component,
+            $result->status,
+            ComponentStatusSourceEnum::Monitor,
+        );
     }
 }

--- a/src/Mcp/Concerns/ScopesComponentVisibility.php
+++ b/src/Mcp/Concerns/ScopesComponentVisibility.php
@@ -25,6 +25,7 @@ trait ScopesComponentVisibility
         $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
 
         return Component::query()
+            ->with(['unresolvedIncidents', 'activeMaintenance'])
             ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
             ->where(function ($query) use ($visibleGroups): void {
                 $query->whereNull('component_group_id')

--- a/src/Mcp/Tools/Components/UpdateComponent.php
+++ b/src/Mcp/Tools/Components/UpdateComponent.php
@@ -3,6 +3,7 @@
 namespace Cachet\Mcp\Tools\Components;
 
 use Cachet\Actions\Component\UpdateComponent as UpdateComponentAction;
+use Cachet\Cachet;
 use Cachet\Data\Requests\Component\UpdateComponentRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Mcp\Concerns\GuardsMcpAbilities;
@@ -60,7 +61,9 @@ class UpdateComponent extends Tool
             $request->only(['name', 'description', 'status', 'link', 'order', 'enabled', 'component_group_id'])
         );
 
-        return Response::structured(['data' => $this->presentComponent($action->handle($component, $data))]);
+        return Response::structured([
+            'data' => $this->presentComponent($action->handle($component, $data, Cachet::user())),
+        ]);
     }
 
     public function shouldRegister(): bool

--- a/src/Mcp/Tools/IncidentUpdates/RecordIncidentUpdate.php
+++ b/src/Mcp/Tools/IncidentUpdates/RecordIncidentUpdate.php
@@ -3,6 +3,7 @@
 namespace Cachet\Mcp\Tools\IncidentUpdates;
 
 use Cachet\Actions\Update\CreateUpdate;
+use Cachet\Cachet;
 use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Mcp\Concerns\GuardsMcpAbilities;
@@ -52,7 +53,7 @@ class RecordIncidentUpdate extends Tool
 
         $data = CreateIncidentUpdateRequestData::validateAndCreate($request->only(['status', 'message']));
 
-        return Response::structured(['data' => $this->presentUpdate($action->handle($incident, $data))]);
+        return Response::structured(['data' => $this->presentUpdate($action->handle($incident, $data, Cachet::user()))]);
     }
 
     public function shouldRegister(): bool

--- a/src/Mcp/Tools/Incidents/GetIncident.php
+++ b/src/Mcp/Tools/Incidents/GetIncident.php
@@ -3,6 +3,7 @@
 namespace Cachet\Mcp\Tools\Incidents;
 
 use Cachet\Concerns\ChecksApiAuthentication;
+use Cachet\Mcp\Concerns\GuardsMcpAbilities;
 use Cachet\Mcp\Concerns\PresentsResources;
 use Cachet\Models\Incident;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -16,6 +17,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 class GetIncident extends Tool
 {
     use ChecksApiAuthentication;
+    use GuardsMcpAbilities;
     use PresentsResources;
 
     protected string $name = 'get_incident';
@@ -35,7 +37,7 @@ class GetIncident extends Tool
     public function handle(Request $request): Response|ResponseFactory
     {
         $incident = Incident::query()
-            ->visible($this->isAuthenticated())
+            ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'))
             ->with(['components', 'updates'])
             ->find($id = $request->integer('id'));
 

--- a/src/Mcp/Tools/Incidents/ListIncidents.php
+++ b/src/Mcp/Tools/Incidents/ListIncidents.php
@@ -4,6 +4,7 @@ namespace Cachet\Mcp\Tools\Incidents;
 
 use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Mcp\Concerns\GuardsMcpAbilities;
 use Cachet\Mcp\Concerns\InteractsWithPagination;
 use Cachet\Mcp\Concerns\PresentsResources;
 use Cachet\Models\Incident;
@@ -18,6 +19,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 class ListIncidents extends Tool
 {
     use ChecksApiAuthentication;
+    use GuardsMcpAbilities;
     use InteractsWithPagination;
     use PresentsResources;
 
@@ -43,7 +45,7 @@ class ListIncidents extends Tool
     public function handle(Request $request): ResponseFactory
     {
         $incidents = Incident::query()
-            ->visible($this->isAuthenticated())
+            ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'))
             ->when($request->filled('name'), fn ($query) => $query->where('name', 'like', '%'.$request->get('name').'%'))
             ->when($request->filled('status'), fn ($query) => $query->where('status', $request->integer('status')))
             ->latest()

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -134,7 +134,7 @@ class Component extends Model implements Metable
     /**
      * Get the published maintenance windows currently in progress for the component.
      *
-     * @return BelongsToMany<Schedule, $this>
+     * @return BelongsToMany<Schedule, $this, ScheduleComponent>
      */
     public function activeMaintenance(): BelongsToMany
     {
@@ -151,11 +151,12 @@ class Component extends Model implements Metable
     /**
      * Get the schedules for the component.
      *
-     * @return BelongsToMany<Schedule, $this>
+     * @return BelongsToMany<Schedule, $this, ScheduleComponent>
      */
     public function schedules(): BelongsToMany
     {
         return $this->belongsToMany(Schedule::class, 'schedule_components')
+            ->using(ScheduleComponent::class)
             ->withTimestamps()
             ->withPivot('component_status');
     }
@@ -250,9 +251,9 @@ class Component extends Model implements Metable
     public function latestStatus(): Attribute
     {
         return Attribute::get(function (): ComponentStatusEnum {
-            $baseline = $this->isUnderMaintenance()
-                ? ComponentStatusEnum::under_maintenance
-                : $this->status ?? ComponentStatusEnum::unknown;
+            $baseline = $this->activeMaintenanceImpact()
+                ?? $this->status
+                ?? ComponentStatusEnum::unknown;
 
             return $this->activeIncidentImpacts()
                 ->push($baseline)
@@ -288,6 +289,30 @@ class Component extends Model implements Metable
         }
 
         return $this->activeMaintenance()->exists();
+    }
+
+    /**
+     * The status the component takes on while maintenance is in progress.
+     *
+     * Each window says what its components should look like while it runs, and
+     * the most severe of any overlapping windows wins. Null when no window is
+     * in progress, in which case the baseline stands.
+     */
+    protected function activeMaintenanceImpact(): ?ComponentStatusEnum
+    {
+        $schedules = $this->relationLoaded('activeMaintenance')
+            ? $this->activeMaintenance
+            : $this->activeMaintenance()->get();
+
+        if ($schedules->isEmpty()) {
+            return null;
+        }
+
+        return $schedules
+            ->map(fn (Schedule $schedule) => $schedule->pivot->component_status)
+            ->filter()
+            ->sortByDesc(fn (ComponentStatusEnum $status) => $status->severity())
+            ->first() ?? ComponentStatusEnum::under_maintenance;
     }
 
     /**

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -11,6 +11,7 @@ use Cachet\Enums\ResourceOrderColumnEnum;
 use Cachet\Events\Components\ComponentCreated;
 use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
+use Cachet\QueryBuilders\ScheduleBuilder;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -139,7 +140,10 @@ class Component extends Model implements Metable
     {
         $relation = $this->schedules()->published();
 
-        $relation->getQuery()->inProgress();
+        /** @var ScheduleBuilder $query */
+        $query = $relation->getQuery();
+
+        $query->inProgress();
 
         return $relation;
     }
@@ -164,6 +168,16 @@ class Component extends Model implements Metable
     public function checks(): HasMany
     {
         return $this->hasMany(ComponentCheck::class);
+    }
+
+    /**
+     * Get the recorded changes to the component's baseline status.
+     *
+     * @return HasMany<ComponentStatusChange, $this>
+     */
+    public function statusChanges(): HasMany
+    {
+        return $this->hasMany(ComponentStatusChange::class);
     }
 
     /**
@@ -256,7 +270,7 @@ class Component extends Model implements Metable
     public function impactingIncident(): Attribute
     {
         return Attribute::get(fn (): ?Incident => $this->activeIncidents()
-            ->filter(fn (Incident $incident) => $incident->pivot?->component_status !== null)
+            ->filter(fn (Incident $incident) => $incident->pivot->component_status !== null)
             ->sortByDesc(fn (Incident $incident) => [
                 $incident->pivot->component_status->severity(),
                 $incident->created_at,
@@ -284,7 +298,7 @@ class Component extends Model implements Metable
     protected function activeIncidentImpacts(): SupportCollection
     {
         return $this->activeIncidents()
-            ->map(fn (Incident $incident) => $incident->pivot?->component_status)
+            ->map(fn (Incident $incident) => $incident->pivot->component_status)
             ->filter()
             ->values();
     }

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -265,18 +265,24 @@ class Component extends Model implements Metable
     /**
      * Get the incident responsible for the component's effective status, if any.
      *
-     * The most severe impact wins and the most recent breaks a tie, so the
-     * status badge always links to the incident it is actually reporting.
+     * The most severe impact wins and the most recent breaks a tie. Null when
+     * no incident is responsible — the baseline or a maintenance window may
+     * outrank every impact — so the badge never links to an incident that
+     * contradicts the status it is displaying.
      */
     public function impactingIncident(): Attribute
     {
-        return Attribute::get(fn (): ?Incident => $this->activeIncidents()
-            ->filter(fn (Incident $incident) => $incident->pivot->component_status !== null)
-            ->sortByDesc(fn (Incident $incident) => [
-                $incident->pivot->component_status->severity(),
-                $incident->created_at,
-            ])
-            ->first())->shouldCache();
+        return Attribute::get(function (): ?Incident {
+            $incident = $this->activeIncidents()
+                ->filter(fn (Incident $incident) => $incident->pivot->component_status !== null)
+                ->sortByDesc(fn (Incident $incident) => [
+                    $incident->pivot->component_status->severity(),
+                    $incident->created_at,
+                ])
+                ->first();
+
+            return $incident?->pivot->component_status === $this->latest_status ? $incident : null;
+        })->shouldCache();
     }
 
     /**

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection as SupportCollection;
 
 /**
  * @property int $id
@@ -31,6 +32,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property ?ComponentStatusEnum $status
  * @property ComponentStatusEnum $latest_status
  * @property-read ?Incident $latest_unresolved_incident
+ * @property-read ?Incident $impacting_incident
  * @property ?int $order
  * @property ?int $component_group_id
  * @property ?bool $checked
@@ -116,13 +118,30 @@ class Component extends Model implements Metable
     }
 
     /**
-     * Get the unresolved incidents for the component, newest first.
+     * Get the unresolved incidents publicly affecting the component, newest first.
+     *
+     * Embargoed and non-public incidents are excluded: an incident that nobody
+     * can read must not change what the status page shows.
      *
      * @return BelongsToMany<Incident, $this, IncidentComponent>
      */
     public function unresolvedIncidents(): BelongsToMany
     {
-        return $this->incidents()->unresolved()->latest();
+        return $this->incidents()->unresolved()->viewableBy(false)->latest();
+    }
+
+    /**
+     * Get the published maintenance windows currently in progress for the component.
+     *
+     * @return BelongsToMany<Schedule, $this>
+     */
+    public function activeMaintenance(): BelongsToMany
+    {
+        $relation = $this->schedules()->published();
+
+        $relation->getQuery()->inProgress();
+
+        return $relation;
     }
 
     /**
@@ -205,11 +224,83 @@ class Component extends Model implements Metable
     }
 
     /**
-     * Get the latest status for the component.
+     * Get the effective status for the component — what the status page shows.
+     *
+     * The `status` column is the baseline: what operators and monitoring assert
+     * about the component itself. Incidents and maintenance windows contribute
+     * impacts on top of it without ever writing to it, and the most severe of
+     * those wins. A maintenance window in progress replaces the baseline rather
+     * than competing with it, so expected downtime during the window does not
+     * surface as a real outage — an incident raised during it still does.
      */
     public function latestStatus(): Attribute
     {
-        return Attribute::get(fn () => $this->latest_unresolved_incident?->pivot->component_status ?? $this->status);
+        return Attribute::get(function (): ComponentStatusEnum {
+            $baseline = $this->isUnderMaintenance()
+                ? ComponentStatusEnum::under_maintenance
+                : $this->status ?? ComponentStatusEnum::unknown;
+
+            return $this->activeIncidentImpacts()
+                ->push($baseline)
+                ->sortByDesc(fn (ComponentStatusEnum $status) => $status->severity())
+                ->first();
+        })->shouldCache();
+    }
+
+    /**
+     * Get the incident responsible for the component's effective status, if any.
+     *
+     * The most severe impact wins and the most recent breaks a tie, so the
+     * status badge always links to the incident it is actually reporting.
+     */
+    public function impactingIncident(): Attribute
+    {
+        return Attribute::get(fn (): ?Incident => $this->activeIncidents()
+            ->filter(fn (Incident $incident) => $incident->pivot?->component_status !== null)
+            ->sortByDesc(fn (Incident $incident) => [
+                $incident->pivot->component_status->severity(),
+                $incident->created_at,
+            ])
+            ->first())->shouldCache();
+    }
+
+    /**
+     * Determine whether a published maintenance window is currently in progress.
+     */
+    public function isUnderMaintenance(): bool
+    {
+        if ($this->relationLoaded('activeMaintenance')) {
+            return $this->activeMaintenance->isNotEmpty();
+        }
+
+        return $this->activeMaintenance()->exists();
+    }
+
+    /**
+     * The statuses imposed on this component by the incidents affecting it.
+     *
+     * @return SupportCollection<int, ComponentStatusEnum>
+     */
+    protected function activeIncidentImpacts(): SupportCollection
+    {
+        return $this->activeIncidents()
+            ->map(fn (Incident $incident) => $incident->pivot?->component_status)
+            ->filter()
+            ->values();
+    }
+
+    /**
+     * The unresolved, publicly visible incidents affecting this component.
+     *
+     * Uses the eager-loaded relation when available to avoid a query per component.
+     *
+     * @return Collection<int, Incident>
+     */
+    protected function activeIncidents(): Collection
+    {
+        return $this->relationLoaded('unresolvedIncidents')
+            ? $this->unresolvedIncidents
+            : $this->unresolvedIncidents()->get();
     }
 
     /**
@@ -222,7 +313,7 @@ class Component extends Model implements Metable
             ResourceOrderColumnEnum::LastUpdated => $this->updated_at,
             ResourceOrderColumnEnum::Name => $this->name,
             ResourceOrderColumnEnum::Manual => $this->order,
-            default => $this->status->value,
+            default => $this->latest_status->severity(),
         };
     }
 

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Collection as SupportCollection;
  * @property string $name
  * @property ?string $description
  * @property ?string $link
- * @property ?ComponentStatusEnum $status
+ * @property ComponentStatusEnum $status
  * @property ComponentStatusEnum $latest_status
  * @property-read ?Incident $latest_unresolved_incident
  * @property-read ?Incident $impacting_incident
@@ -252,8 +252,7 @@ class Component extends Model implements Metable
     {
         return Attribute::get(function (): ComponentStatusEnum {
             $baseline = $this->activeMaintenanceImpact()
-                ?? $this->status
-                ?? ComponentStatusEnum::unknown;
+                ?? $this->status;
 
             return $this->activeIncidentImpacts()
                 ->push($baseline)

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -99,9 +99,7 @@ class ComponentGroup extends Model implements Metable
     public function worstComponentStatus(): ComponentStatusEnum
     {
         return $this->components
-            ->map(fn (Component $component) => ($component->incidents_count ?? 0) > 0
-                ? $component->latest_status
-                : $component->status)
+            ->map(fn (Component $component) => $component->latest_status)
             ->sortByDesc(fn (ComponentStatusEnum $status) => $status->severity())
             ->first() ?? ComponentStatusEnum::operational;
     }
@@ -114,6 +112,7 @@ class ComponentGroup extends Model implements Metable
 
         return Incident::query()
             ->unresolved()
+            ->viewableBy(auth()->check())
             ->whereHas('components', fn ($query) => $query->whereIn('components.id', $this->components->pluck('id')))
             ->exists();
     }

--- a/src/Models/ComponentGroup.php
+++ b/src/Models/ComponentGroup.php
@@ -12,6 +12,7 @@ use Cachet\Enums\ResourceOrderColumnEnum;
 use Cachet\Enums\ResourceOrderDirectionEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -84,11 +85,11 @@ class ComponentGroup extends Model implements Metable
         };
     }
 
-    public function isExpanded(): bool
+    public function isExpanded(?Authenticatable $user = null): bool
     {
         return match ($this->collapsed) {
             ComponentGroupVisibilityEnum::collapsed => false,
-            ComponentGroupVisibilityEnum::collapsed_unless_incident => $this->hasActiveIncident(),
+            ComponentGroupVisibilityEnum::collapsed_unless_incident => $this->hasActiveIncident($user),
             ComponentGroupVisibilityEnum::expanded => true,
         };
     }
@@ -104,15 +105,24 @@ class ComponentGroup extends Model implements Metable
             ->first() ?? ComponentStatusEnum::operational;
     }
 
-    public function hasActiveIncident(): bool
+    /**
+     * Determine whether an incident the given viewer can see is affecting the group.
+     *
+     * The eager-loaded count is only usable when it was scoped to the same
+     * viewer; anything else is answered with a query, so both paths agree.
+     */
+    public function hasActiveIncident(?Authenticatable $user = null): bool
     {
-        if ($this->components->every(fn (Component $component) => $component->hasAttribute('incidents_count'))) {
+        $countsMatchViewer = $user === null
+            && $this->components->every(fn (Component $component) => $component->hasAttribute('incidents_count'));
+
+        if ($countsMatchViewer) {
             return $this->components->contains(fn (Component $component) => $component->incidents_count > 0);
         }
 
         return Incident::query()
             ->unresolved()
-            ->viewableBy(auth()->check())
+            ->viewableBy($user !== null)
             ->whereHas('components', fn ($query) => $query->whereIn('components.id', $this->components->pluck('id')))
             ->exists();
     }

--- a/src/Models/ComponentStatusChange.php
+++ b/src/Models/ComponentStatusChange.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Cachet\Models;
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A record of a change to a component's baseline status, and what caused it.
+ *
+ * @property int $id
+ * @property int $component_id
+ * @property ?ComponentStatusEnum $old_status
+ * @property ComponentStatusEnum $new_status
+ * @property ComponentStatusSourceEnum $source
+ * @property ?string $reason
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
+ * @property Component $component
+ */
+class ComponentStatusChange extends Model
+{
+    /** @var array<string, string> */
+    protected $casts = [
+        'old_status' => ComponentStatusEnum::class,
+        'new_status' => ComponentStatusEnum::class,
+        'source' => ComponentStatusSourceEnum::class,
+    ];
+
+    /** @var list<string> */
+    protected $fillable = [
+        'component_id',
+        'old_status',
+        'new_status',
+        'source',
+        'reason',
+        'causer_type',
+        'causer_id',
+    ];
+
+    /**
+     * Get the component whose status changed.
+     *
+     * @return BelongsTo<Component, $this>
+     */
+    public function component(): BelongsTo
+    {
+        return $this->belongsTo(Component::class);
+    }
+
+    /**
+     * Get whoever or whatever caused the change.
+     */
+    public function causer(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -191,6 +191,8 @@ class Incident extends Model implements Metable
      * orthogonal, and this is the single place both are decided. Every read
      * surface — the API, MCP, RSS, the status page and the system status —
      * goes through it so none can forget one of the two.
+     *
+     * @param  Builder<static>  $query
      */
     public function scopeViewableBy(Builder $query, bool $authenticated, bool $includeUnpublished = false): void
     {

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -181,7 +181,41 @@ class Incident extends Model implements Metable
      */
     public function scopeUnresolved(Builder $query): void
     {
-        $query->whereIn('status', IncidentStatusEnum::unresolved());
+        $query->whereIn($this->qualifyColumn('status'), IncidentStatusEnum::unresolved());
+    }
+
+    /**
+     * Scope to the incidents a given viewer is allowed to see.
+     *
+     * Publication (when it may be seen) and visibility (who may see it) are
+     * orthogonal, and this is the single place both are decided. Every read
+     * surface — the API, MCP, RSS, the status page and the system status —
+     * goes through it so none can forget one of the two.
+     */
+    public function scopeViewableBy(Builder $query, bool $authenticated, bool $includeUnpublished = false): void
+    {
+        $query->visible($authenticated)
+            ->unless($includeUnpublished, fn (Builder $query) => $query->published());
+    }
+
+    /**
+     * Determine whether a given viewer is allowed to see this incident.
+     *
+     * The visibility attribute is read through `getAttribute()` because Eloquent
+     * itself declares a `$visible` property for serialisation, which would
+     * otherwise shadow the column when read from inside the model.
+     */
+    public function isViewableBy(bool $authenticated, bool $includeUnpublished = false): bool
+    {
+        $permitted = $authenticated
+            ? ResourceVisibilityEnum::visibleToUsers()
+            : ResourceVisibilityEnum::visibleToGuests();
+
+        if (! in_array($this->getAttribute('visible'), $permitted, true)) {
+            return false;
+        }
+
+        return $includeUnpublished || $this->isPublished();
     }
 
     /**
@@ -218,18 +252,17 @@ class Incident extends Model implements Metable
     }
 
     /**
-     * Determine the latest status of the incident.
+     * The incident's status.
+     *
+     * Retained for backwards compatibility: the status column is canonical and
+     * is kept in step with the latest status-bearing update at write time, so
+     * this is simply an alias for it.
      *
      * @return Attribute<IncidentStatusEnum|null, never>
      */
     protected function latestStatus(): Attribute
     {
-        return Attribute::make(
-            get: fn () => $this->updates
-                ->sortByDesc(fn (Update $update) => [$update->created_at, $update->id])
-                ->first()
-                ->status ?? $this->status
-        );
+        return Attribute::make(get: fn (): ?IncidentStatusEnum => $this->status);
     }
 
     /**

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Collection;
  * @property ?Carbon $deleted_at
  * @property Collection<int, Component> $components
  * @property Collection<int, Update> $updates
+ * @property-read ScheduleComponent|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Meta> $meta
  *
  * @method static ScheduleFactory factory($count = null, $state = [])

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -118,7 +118,7 @@ class Schedule extends Model implements Metable
                 $now = Carbon::now();
 
                 return match (true) {
-                    $this->scheduled_at->gte($now) => ScheduleStatusEnum::upcoming,
+                    $this->scheduled_at?->gt($now) === true => ScheduleStatusEnum::upcoming,
                     $this->completed_at === null,
                     $this->completed_at->gte($now) => ScheduleStatusEnum::in_progress,
                     default => ScheduleStatusEnum::complete,

--- a/src/Status.php
+++ b/src/Status.php
@@ -8,7 +8,7 @@ use Cachet\Enums\SystemStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Settings\AppSettings;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 class Status
 {
@@ -79,12 +79,7 @@ class Status
      */
     public function components(): object
     {
-        return $this->components ??= $this->countByEffectiveStatus(
-            Component::query()
-                ->where('enabled', true)
-                ->with(['unresolvedIncidents', 'activeMaintenance'])
-                ->get()
-        );
+        return $this->components ??= $this->tally();
     }
 
     /**
@@ -104,22 +99,49 @@ class Status
     }
 
     /**
-     * Tally the given components by their effective status.
+     * Tally the enabled components by their effective status.
      *
-     * @param  Collection<int, Component>  $components
+     * The database counts the baseline, which is all that most components have.
+     * Only those actually carrying an impact — an unresolved incident or a
+     * maintenance window in progress — are loaded, and each is moved out of its
+     * baseline bucket and into its effective one.
+     *
      * @return object{total: int, operational: int, performance_issues: int, partial_outage: int, major_outage: int, under_maintenance: int}
      */
-    private function countByEffectiveStatus(Collection $components): object
+    private function tally(): object
     {
-        $statuses = $components->map(fn (Component $component) => $component->latest_status);
+        $counts = Component::query()
+            ->enabled()
+            ->toBase()
+            ->selectRaw('status, count(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
 
-        return (object) [
-            'total' => $components->count(),
-            'operational' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::operational)->count(),
-            'performance_issues' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::performance_issues)->count(),
-            'partial_outage' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::partial_outage)->count(),
-            'major_outage' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::major_outage)->count(),
-            'under_maintenance' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::under_maintenance)->count(),
-        ];
+        $tally = collect(ComponentStatusEnum::cases())
+            ->mapWithKeys(fn (ComponentStatusEnum $status) => [
+                $status->name => (int) $counts->get($status->value, 0),
+            ]);
+
+        $total = $tally->sum();
+
+        Component::query()
+            ->enabled()
+            ->where(fn (Builder $query) => $query
+                ->whereHas('unresolvedIncidents')
+                ->orWhereHas('activeMaintenance'))
+            ->with(['unresolvedIncidents', 'activeMaintenance'])
+            ->each(function (Component $component) use (&$tally): void {
+                $baseline = $component->status ?? ComponentStatusEnum::unknown;
+                $effective = $component->latest_status;
+
+                if ($baseline === $effective) {
+                    return;
+                }
+
+                $tally[$baseline->name] = $tally[$baseline->name] - 1;
+                $tally[$effective->name] = $tally[$effective->name] + 1;
+            });
+
+        return (object) [...$tally->all(), 'total' => $total];
     }
 }

--- a/src/Status.php
+++ b/src/Status.php
@@ -98,8 +98,8 @@ class Status
             ->viewableBy(false)
             ->toBase()
             ->selectRaw('count(*) as total')
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as resolved', [IncidentStatusEnum::fixed->value])
-            ->selectRaw('sum(case when status is null or status <> ? then 1 else 0 end) as unresolved', [IncidentStatusEnum::fixed->value])
+            ->selectRaw('coalesce(sum(case when status = ? then 1 else 0 end), 0) as resolved', [IncidentStatusEnum::fixed->value])
+            ->selectRaw('coalesce(sum(case when status is null or status <> ? then 1 else 0 end), 0) as unresolved', [IncidentStatusEnum::fixed->value])
             ->first();
     }
 

--- a/src/Status.php
+++ b/src/Status.php
@@ -131,7 +131,7 @@ class Status
                 ->orWhereHas('activeMaintenance'))
             ->with(['unresolvedIncidents', 'activeMaintenance'])
             ->each(function (Component $component) use (&$tally): void {
-                $baseline = $component->status ?? ComponentStatusEnum::unknown;
+                $baseline = $component->status;
                 $effective = $component->latest_status;
 
                 if ($baseline === $effective) {

--- a/src/Status.php
+++ b/src/Status.php
@@ -8,8 +8,7 @@ use Cachet\Enums\SystemStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Settings\AppSettings;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
 
 class Status
 {
@@ -24,12 +23,12 @@ class Status
     {
         $components = $this->components();
 
-        if ($this->underMaintenance()) {
-            return SystemStatusEnum::under_maintenance;
-        }
-
         if ($this->majorOutage()) {
             return SystemStatusEnum::major_outage;
+        }
+
+        if ($this->underMaintenance()) {
+            return SystemStatusEnum::under_maintenance;
         }
 
         if ((int) $components->total - (int) $components->operational === 0) {
@@ -70,49 +69,57 @@ class Status
     }
 
     /**
-     * Get an overview of the components.
+     * Get an overview of the components, counted by their effective status.
      *
-     * @return object{total: int, operational: int, performance_issues: int, partial_outage: int, major_outage: int}
+     * Effective status is resolved per component so that incident impacts and
+     * maintenance windows reach the system status, rather than the banner
+     * disagreeing with the component list it sits above.
+     *
+     * @return object{total: int, operational: int, performance_issues: int, partial_outage: int, major_outage: int, under_maintenance: int}
      */
     public function components(): object
     {
-        return $this->components ??= Component::query()
-            ->toBase()
-            ->where('enabled', true)
-            ->selectRaw('count(*) as total')
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as operational', [ComponentStatusEnum::operational])
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as performance_issues', [ComponentStatusEnum::performance_issues])
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as partial_outage', [ComponentStatusEnum::partial_outage])
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as major_outage', [ComponentStatusEnum::major_outage])
-            ->selectRaw('sum(case when status = ? then 1 else 0 end) as under_maintenance', [ComponentStatusEnum::under_maintenance])
-            ->first();
+        return $this->components ??= $this->countByEffectiveStatus(
+            Component::query()
+                ->where('enabled', true)
+                ->with(['unresolvedIncidents', 'activeMaintenance'])
+                ->get()
+        );
     }
 
     /**
-     * Get an overview of the incidents.
+     * Get an overview of the incidents visible to the public.
      *
      * @return object{total: int, resolved: int, unresolved: int}
      */
     public function incidents(): object
     {
         return $this->incidents ??= Incident::query()
-            ->published()
+            ->viewableBy(false)
             ->toBase()
             ->selectRaw('count(*) as total')
-            ->selectRaw('sum(case when ? in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as resolved', [IncidentStatusEnum::fixed->value, 0])
-            ->selectRaw('sum(case when ? not in (incidents.status, coalesce(latest_update.status, ?)) then 1 else 0 end) as unresolved', [IncidentStatusEnum::fixed->value, 0])
-            ->joinSub(function (Builder $query) {
-                $query
-                    ->select('iu1.updateable_id', 'iu1.status')
-                    ->from('updates', 'iu1')
-                    ->joinSub(function (Builder $query) {
-                        $query->select('updateable_id')
-                            ->selectRaw('max(id) as max_id')
-                            ->from('updates')
-                            ->where('updates.updateable_type', Relation::getMorphAlias(Incident::class))
-                            ->groupBy('updateable_id');
-                    }, 'iu2', 'iu1.id', '=', 'iu2.max_id');
-            }, 'latest_update', 'latest_update.updateable_id', '=', 'incidents.id', 'left')
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as resolved', [IncidentStatusEnum::fixed->value])
+            ->selectRaw('sum(case when status is null or status <> ? then 1 else 0 end) as unresolved', [IncidentStatusEnum::fixed->value])
             ->first();
+    }
+
+    /**
+     * Tally the given components by their effective status.
+     *
+     * @param  Collection<int, Component>  $components
+     * @return object{total: int, operational: int, performance_issues: int, partial_outage: int, major_outage: int, under_maintenance: int}
+     */
+    private function countByEffectiveStatus(Collection $components): object
+    {
+        $statuses = $components->map(fn (Component $component) => $component->latest_status);
+
+        return (object) [
+            'total' => $components->count(),
+            'operational' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::operational)->count(),
+            'performance_issues' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::performance_issues)->count(),
+            'partial_outage' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::partial_outage)->count(),
+            'major_outage' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::major_outage)->count(),
+            'under_maintenance' => $statuses->filter(fn (ComponentStatusEnum $status) => $status === ComponentStatusEnum::under_maintenance)->count(),
+        ];
     }
 }

--- a/src/View/Components/Component.php
+++ b/src/View/Components/Component.php
@@ -25,7 +25,7 @@ class Component extends ViewComponent
     public function render(): View|Closure|string
     {
         return view('cachet::components.component', [
-            'status' => $this->component->status,
+            'status' => $this->component->latest_status,
         ]);
     }
 }

--- a/src/View/Components/ComponentGroups.php
+++ b/src/View/Components/ComponentGroups.php
@@ -20,8 +20,8 @@ class ComponentGroups extends ViewComponent
                 ->enabled()
                 ->whereNull('component_group_id')
                 ->orderBy('order')
-                ->with('unresolvedIncidents')
-                ->withCount(['incidents' => fn ($query) => $query->unresolved()])
+                ->with(['unresolvedIncidents', 'activeMaintenance'])
+                ->withCount(['incidents' => fn ($query) => $query->unresolved()->viewableBy(false)])
                 ->get(),
         ]);
     }
@@ -33,8 +33,9 @@ class ComponentGroups extends ViewComponent
     {
         return ComponentGroup::query()
             ->with([
-                'components' => fn ($query) => $query->enabled()->orderBy('order')->withCount(['incidents' => fn ($query) => $query->unresolved()]),
+                'components' => fn ($query) => $query->enabled()->orderBy('order')->withCount(['incidents' => fn ($query) => $query->unresolved()->viewableBy(false)]),
                 'components.unresolvedIncidents',
+                'components.activeMaintenance',
             ])
             ->visible(auth()->check())
             ->orderBy('order')

--- a/src/View/Components/IncidentTimeline.php
+++ b/src/View/Components/IncidentTimeline.php
@@ -85,8 +85,7 @@ class IncidentTimeline extends Component
                 'components',
                 'updates' => fn ($query) => $query->orderByDesc('created_at')->orderByDesc('id'),
             ])
-            ->visible(auth()->check())
-            ->published()
+            ->viewableBy(auth()->check())
             ->when($this->appSettings->recent_incidents_only, function ($query) {
                 $query->where(function ($query) {
                     $query->whereDate(

--- a/src/View/Components/Metrics.php
+++ b/src/View/Components/Metrics.php
@@ -80,7 +80,7 @@ class Metrics extends Component
             ])
             ->where('display_chart', true)
             ->where(fn (Builder $query) => $query->where('show_when_empty', true)->orWhereHas('metricPoints', fn (Builder $query) => $query->where('created_at', '>=', $startDate)))
-            ->orderBy('places')
+            ->orderBy('order')
             ->get();
     }
 }

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -597,6 +597,37 @@ it('does not include incidents hidden from guests on visible components', functi
     $response->assertJsonCount(1, 'included');
 });
 
+it('does not include incidents that are not yet published on visible components', function () {
+    $component = Component::factory()->enabled()->create();
+    $component->incidents()->attach(Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+    ]));
+    $component->incidents()->attach(Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addHour(),
+    ]));
+
+    $response = getJson('/status/api/components/'.$component->id.'?include=incidents');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'included');
+});
+
+it('includes unpublished incidents on visible components for incident managers', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $component = Component::factory()->enabled()->create();
+    $component->incidents()->attach(Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addHour(),
+    ]));
+
+    $response = getJson('/status/api/components/'.$component->id.'?include=incidents');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'included');
+});
+
 it('lists components in authenticated groups to callers presenting a bearer token', function () {
     $user = User::factory()->create();
     $token = $user->createToken('api')->plainTextToken;

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
@@ -607,4 +608,22 @@ it('lists components in authenticated groups to callers presenting a bearer toke
 
     $response->assertOk();
     $response->assertJsonCount(1, 'data');
+});
+
+it('exposes the baseline status alongside the effective status', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::identified,
+        'visible' => ResourceVisibilityEnum::guest,
+    ]);
+
+    $incident->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::major_outage,
+    ]);
+
+    getJson('/status/api/components/'.$component->id)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.status.value', ComponentStatusEnum::operational->value)
+        ->assertJsonPath('data.attributes.latest_status.value', ComponentStatusEnum::major_outage->value);
 });

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -593,3 +593,21 @@ it('lists authenticated incidents to callers presenting a bearer token', functio
     $response->assertOk();
     $response->assertJsonCount(2, 'data');
 });
+
+it('rejects a duplicate component in the same incident', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $component = Component::factory()->create();
+
+    postJson('/status/api/incidents', [
+        'name' => 'Duplicated',
+        'message' => 'The same component twice.',
+        'status' => IncidentStatusEnum::investigating->value,
+        'components' => [
+            ['id' => $component->id, 'status' => ComponentStatusEnum::major_outage->value],
+            ['id' => $component->id, 'status' => ComponentStatusEnum::partial_outage->value],
+        ],
+    ])->assertUnprocessable()->assertInvalid('components.1.id');
+
+    expect(Incident::query()->where('name', 'Duplicated')->exists())->toBeFalse();
+});

--- a/tests/Feature/Database/ComponentPivotConstraintsTest.php
+++ b/tests/Feature/Database/ComponentPivotConstraintsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Return the pivots to the state they were in before the constraint migration.
+ */
+function dropPivotUniques(): void
+{
+    Schema::table('incident_components', function (Blueprint $table) {
+        $table->dropUnique(['incident_id', 'component_id']);
+    });
+
+    Schema::table('schedule_components', function (Blueprint $table) {
+        $table->dropUnique(['schedule_id', 'component_id']);
+    });
+}
+
+/**
+ * Run the constraint migration over whatever rows are present.
+ */
+function applyPivotConstraints(): void
+{
+    $migration = require __DIR__.'/../../../database/migrations/2026_07_25_000002_add_constraints_to_component_pivots.php';
+
+    $migration->up();
+}
+
+it('collapses duplicate impacts to the most severe when the constraint is added', function () {
+    $component = Component::factory()->create();
+    $incident = Incident::factory()->create();
+
+    dropPivotUniques();
+
+    foreach ([ComponentStatusEnum::performance_issues, ComponentStatusEnum::major_outage, ComponentStatusEnum::operational] as $status) {
+        DB::table('incident_components')->insert([
+            'incident_id' => $incident->id,
+            'component_id' => $component->id,
+            'component_status' => $status->value,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    applyPivotConstraints();
+
+    $rows = DB::table('incident_components')
+        ->where('incident_id', $incident->id)
+        ->where('component_id', $component->id)
+        ->get();
+
+    expect($rows)->toHaveCount(1)
+        ->and((int) $rows->first()->component_status)->toBe(ComponentStatusEnum::major_outage->value);
+});
+
+it('leaves rows that are already unique alone', function () {
+    $component = Component::factory()->create();
+    $incident = Incident::factory()->create();
+
+    $incident->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::partial_outage,
+    ]);
+
+    dropPivotUniques();
+    applyPivotConstraints();
+
+    expect(DB::table('incident_components')->count())->toBe(1)
+        ->and((int) DB::table('incident_components')->first()->component_status)
+        ->toBe(ComponentStatusEnum::partial_outage->value);
+});
+
+it('refuses to attach the same component to an incident twice', function () {
+    $component = Component::factory()->create();
+    $incident = Incident::factory()->create();
+
+    $incident->components()->attach($component->id, ['component_status' => ComponentStatusEnum::major_outage]);
+    $incident->components()->attach($component->id, ['component_status' => ComponentStatusEnum::partial_outage]);
+})->throws(UniqueConstraintViolationException::class);

--- a/tests/Feature/Database/ComponentStatusBackfillTest.php
+++ b/tests/Feature/Database/ComponentStatusBackfillTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Component;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Return the status column to its pre-backfill nullable shape.
+ */
+function makeComponentStatusNullable(): void
+{
+    Schema::table('components', function (Blueprint $table) {
+        $table->unsignedInteger('status')->nullable()->change();
+    });
+}
+
+/**
+ * Run the component status backfill over whatever rows are present.
+ */
+function backfillComponentStatuses(): void
+{
+    $migration = require __DIR__.'/../../../database/migrations/2026_07_26_000001_backfill_component_status_and_make_it_required.php';
+
+    $migration->up();
+}
+
+it('backfills null component statuses to unknown before making the column required', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::major_outage]);
+
+    makeComponentStatusNullable();
+
+    DB::table('components')->where('id', $component->id)->update(['status' => null]);
+
+    backfillComponentStatuses();
+
+    expect($component->fresh()->status)->toBe(ComponentStatusEnum::unknown);
+});

--- a/tests/Feature/Database/IncidentStatusBackfillTest.php
+++ b/tests/Feature/Database/IncidentStatusBackfillTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Models\Incident;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Run the backfill over whatever rows are present.
+ */
+function backfillIncidentStatuses(): void
+{
+    $migration = require __DIR__.'/../../../database/migrations/2026_07_25_000003_backfill_incident_status_from_updates.php';
+
+    $migration->up();
+}
+
+/**
+ * Write a status straight to the column, as the pre-canonical code would have left it.
+ */
+function staleIncident(IncidentStatusEnum $status): Incident
+{
+    $incident = Incident::factory()->create();
+
+    DB::table('incidents')->where('id', $incident->id)->update(['status' => $status->value]);
+
+    return $incident->refresh();
+}
+
+it('aligns an incident with its newest status-bearing update', function () {
+    $incident = staleIncident(IncidentStatusEnum::investigating);
+
+    $incident->updates()->create(['status' => IncidentStatusEnum::identified, 'message' => 'Found it.']);
+    $incident->updates()->create(['status' => IncidentStatusEnum::watching, 'message' => 'Monitoring.']);
+
+    backfillIncidentStatuses();
+
+    expect($incident->fresh()->status)->toBe(IncidentStatusEnum::watching);
+});
+
+it('leaves an incident with no status-bearing updates alone', function () {
+    $incident = staleIncident(IncidentStatusEnum::investigating);
+
+    $incident->updates()->create(['status' => null, 'message' => 'A note.']);
+
+    backfillIncidentStatuses();
+
+    expect($incident->fresh()->status)->toBe(IncidentStatusEnum::investigating);
+});
+
+it('does not disturb the timestamps of the incidents it aligns', function () {
+    $incident = staleIncident(IncidentStatusEnum::investigating);
+
+    $incident->updates()->create(['status' => IncidentStatusEnum::fixed, 'message' => 'Done.']);
+
+    $updatedAt = $incident->fresh()->updated_at;
+
+    backfillIncidentStatuses();
+
+    expect($incident->fresh())
+        ->status->toBe(IncidentStatusEnum::fixed)
+        ->updated_at->toEqual($updatedAt);
+});
+
+it('backfills many incidents at once', function () {
+    $incidents = collect([IncidentStatusEnum::identified, IncidentStatusEnum::watching, IncidentStatusEnum::fixed])
+        ->map(function (IncidentStatusEnum $status) {
+            $incident = staleIncident(IncidentStatusEnum::investigating);
+            $incident->updates()->create(['status' => $status, 'message' => 'Update.']);
+
+            return [$incident, $status];
+        });
+
+    backfillIncidentStatuses();
+
+    $incidents->each(fn (array $pair) => expect($pair[0]->fresh()->status)->toBe($pair[1]));
+});

--- a/tests/Feature/Mcp/Tools/IncidentToolsTest.php
+++ b/tests/Feature/Mcp/Tools/IncidentToolsTest.php
@@ -161,7 +161,7 @@ it('records an incident update', function () {
     expect($incident->updates()->count())->toBe(1);
 });
 
-it('resolves the incident and its components when recording a fixed update', function () {
+it('resolves the incident but keeps the impact it recorded when a fixed update lands', function () {
     Sanctum::actingAs(User::factory()->create(), ['incident-updates.manage']);
 
     $component = Component::factory()->create(['status' => ComponentStatusEnum::major_outage]);
@@ -175,7 +175,7 @@ it('resolves the incident and its components when recording a fixed update', fun
     ])->assertOk();
 
     expect($incident->fresh()->status)->toBe(IncidentStatusEnum::fixed)
-        ->and($incident->incidentComponents()->first()->component_status)->toBe(ComponentStatusEnum::operational);
+        ->and($incident->incidentComponents()->first()->component_status)->toBe(ComponentStatusEnum::major_outage);
 });
 
 it('edits an incident update', function () {
@@ -314,6 +314,7 @@ it('overlays the displayed component status while an incident is unresolved', fu
         'name' => 'API Outage',
         'status' => IncidentStatusEnum::identified->value,
         'message' => 'The API is down.',
+        'visible' => true,
         'components' => [
             ['id' => $component->id, 'status' => ComponentStatusEnum::major_outage->value],
         ],
@@ -324,6 +325,29 @@ it('overlays the displayed component status while an incident is unresolved', fu
         ->assertStructuredContent(fn (AssertableJson $json) => $json
             ->where('data.status.name', 'operational')
             ->where('data.latest_status.name', 'major_outage')
+            ->etc());
+});
+
+it('keeps an incident nobody can see out of the displayed component status', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    CachetServer::tool(CreateIncident::class, [
+        'name' => 'Internal Outage',
+        'status' => IncidentStatusEnum::identified->value,
+        'message' => 'The API is down.',
+        'visible' => false,
+        'components' => [
+            ['id' => $component->id, 'status' => ComponentStatusEnum::major_outage->value],
+        ],
+    ])->assertOk();
+
+    CachetServer::tool(GetComponent::class, ['id' => $component->id])
+        ->assertOk()
+        ->assertStructuredContent(fn (AssertableJson $json) => $json
+            ->where('data.status.name', 'operational')
+            ->where('data.latest_status.name', 'operational')
             ->etc());
 });
 

--- a/tests/Feature/Publishing/IncidentPublishingTest.php
+++ b/tests/Feature/Publishing/IncidentPublishingTest.php
@@ -102,6 +102,8 @@ it('keeps unpublished incidents out of the timeline', function () {
 });
 
 it('exposes unpublished incidents to the mcp server for dashboard management', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
     Incident::factory()->create(['name' => 'Published now']);
     Incident::factory()->scheduled()->create(['name' => 'Prescheduled']);
 
@@ -111,9 +113,23 @@ it('exposes unpublished incidents to the mcp server for dashboard management', f
 });
 
 it('exposes a single unpublished incident to the mcp server', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
     $incident = Incident::factory()->scheduled()->create(['name' => 'Prescheduled']);
 
     CachetServer::tool(GetIncident::class, ['id' => $incident->id])
         ->assertOk()
         ->assertSee('Prescheduled');
+});
+
+it('hides unpublished incidents from an mcp caller that cannot manage incidents', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.read']);
+
+    Incident::factory()->create(['name' => 'Published now']);
+    Incident::factory()->scheduled()->create(['name' => 'Prescheduled']);
+
+    CachetServer::tool(ListIncidents::class)
+        ->assertOk()
+        ->assertStructuredContent(fn (AssertableJson $json) => $json->has('data', 1)->etc())
+        ->assertDontSee('Prescheduled');
 });

--- a/tests/Feature/Publishing/IncidentReadPolicyTest.php
+++ b/tests/Feature/Publishing/IncidentReadPolicyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\Status;
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
+it('keeps embargoed incidents out of the rss feed', function () {
+    Incident::factory()->create([
+        'name' => 'Embargoed Incident',
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addWeek(),
+    ]);
+
+    $this->get(route('cachet.rss'))
+        ->assertOk()
+        ->assertDontSee('Embargoed Incident');
+});
+
+it('keeps hidden incidents out of the rss feed', function () {
+    Incident::factory()->create([
+        'name' => 'Hidden Incident',
+        'visible' => ResourceVisibilityEnum::hidden,
+    ]);
+
+    $this->get(route('cachet.rss'))
+        ->assertOk()
+        ->assertDontSee('Hidden Incident');
+});
+
+it('hides an incident page from guests when it is not visible to them', function (ResourceVisibilityEnum $visibility) {
+    $incident = Incident::factory()->create(['visible' => $visibility]);
+
+    $this->get(route('cachet.status-page.incident', $incident))->assertNotFound();
+})->with([
+    'hidden' => [ResourceVisibilityEnum::hidden],
+    'authenticated only' => [ResourceVisibilityEnum::authenticated],
+]);
+
+it('keeps an incident nobody can see out of the system status', function (array $attributes) {
+    Component::factory()->create(['status' => ComponentStatusEnum::operational, 'enabled' => true]);
+
+    Incident::factory()->create([
+        'status' => IncidentStatusEnum::investigating,
+        ...$attributes,
+    ]);
+
+    expect((new Status)->incidents()->unresolved)->toBe(0);
+})->with([
+    'embargoed' => [['visible' => ResourceVisibilityEnum::guest, 'published_at' => now()->addWeek()]],
+    'hidden' => [['visible' => ResourceVisibilityEnum::hidden]],
+]);
+
+it('hides the updates of an embargoed incident from the api', function () {
+    $incident = Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addWeek(),
+    ]);
+
+    $incident->updates()->create(['status' => IncidentStatusEnum::investigating, 'message' => 'Looking into it.']);
+
+    $this->getJson('/status/api/incidents/'.$incident->id.'/updates')->assertNotFound();
+});
+
+it('exposes the updates of an embargoed incident to a token that can manage incidents', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $incident = Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addWeek(),
+    ]);
+
+    $incident->updates()->create(['status' => IncidentStatusEnum::investigating, 'message' => 'Looking into it.']);
+
+    $this->getJson('/status/api/incidents/'.$incident->id.'/updates')
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+});

--- a/tests/Unit/Actions/Component/ChangeComponentStatusTest.php
+++ b/tests/Unit/Actions/Component/ChangeComponentStatusTest.php
@@ -4,6 +4,7 @@ use Cachet\Actions\Component\ChangeComponentStatus;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ComponentStatusSourceEnum;
 use Cachet\Events\Components\ComponentStatusWasChanged;
+use Cachet\Events\Components\ComponentUpdated;
 use Cachet\Models\Component;
 use Illuminate\Support\Facades\Event;
 use Workbench\App\User;
@@ -60,6 +61,49 @@ it('does nothing when the status is unchanged', function () {
     app(ChangeComponentStatus::class)->handle($component, ComponentStatusEnum::operational);
 
     expect($component->statusChanges()->count())->toBe(0);
+
+    Event::assertNotDispatched(ComponentStatusWasChanged::class);
+});
+
+it('saves accompanying attributes in the same write', function () {
+    Event::fake([ComponentUpdated::class, ComponentStatusWasChanged::class]);
+
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational,
+        'name' => 'API',
+    ]);
+
+    app(ChangeComponentStatus::class)->handle(
+        $component,
+        ComponentStatusEnum::major_outage,
+        ComponentStatusSourceEnum::Manual,
+        attributes: ['name' => 'API v2'],
+    );
+
+    expect($component->fresh())
+        ->name->toBe('API v2')
+        ->status->toBe(ComponentStatusEnum::major_outage);
+
+    Event::assertDispatchedTimes(ComponentUpdated::class, 1);
+    Event::assertDispatchedTimes(ComponentStatusWasChanged::class, 1);
+});
+
+it('writes accompanying attributes even when the status is unchanged', function () {
+    Event::fake([ComponentStatusWasChanged::class]);
+
+    $component = Component::factory()->create([
+        'status' => ComponentStatusEnum::operational,
+        'name' => 'API',
+    ]);
+
+    app(ChangeComponentStatus::class)->handle(
+        $component,
+        ComponentStatusEnum::operational,
+        attributes: ['name' => 'API v2'],
+    );
+
+    expect($component->fresh()->name)->toBe('API v2')
+        ->and($component->statusChanges()->count())->toBe(0);
 
     Event::assertNotDispatched(ComponentStatusWasChanged::class);
 });

--- a/tests/Unit/Actions/Component/ChangeComponentStatusTest.php
+++ b/tests/Unit/Actions/Component/ChangeComponentStatusTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Cachet\Actions\Component\ChangeComponentStatus;
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ComponentStatusSourceEnum;
+use Cachet\Events\Components\ComponentStatusWasChanged;
+use Cachet\Models\Component;
+use Illuminate\Support\Facades\Event;
+use Workbench\App\User;
+
+it('records the change with its source and announces it', function () {
+    Event::fake([ComponentStatusWasChanged::class]);
+
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    app(ChangeComponentStatus::class)->handle(
+        $component,
+        ComponentStatusEnum::major_outage,
+        ComponentStatusSourceEnum::Monitor,
+        reason: 'Connection refused',
+    );
+
+    expect($component->fresh()->status)->toBe(ComponentStatusEnum::major_outage);
+
+    $change = $component->statusChanges()->sole();
+
+    expect($change)
+        ->old_status->toBe(ComponentStatusEnum::operational)
+        ->new_status->toBe(ComponentStatusEnum::major_outage)
+        ->source->toBe(ComponentStatusSourceEnum::Monitor)
+        ->reason->toBe('Connection refused');
+
+    Event::assertDispatched(
+        ComponentStatusWasChanged::class,
+        fn (ComponentStatusWasChanged $event) => $event->source === ComponentStatusSourceEnum::Monitor
+            && $event->oldStatus === ComponentStatusEnum::operational
+            && $event->newStatus === ComponentStatusEnum::major_outage,
+    );
+});
+
+it('attributes the change to whoever caused it', function () {
+    $user = User::factory()->create();
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    app(ChangeComponentStatus::class)->handle(
+        $component,
+        ComponentStatusEnum::partial_outage,
+        ComponentStatusSourceEnum::Manual,
+        $user,
+    );
+
+    expect($component->statusChanges()->sole()->causer->is($user))->toBeTrue();
+});
+
+it('does nothing when the status is unchanged', function () {
+    Event::fake([ComponentStatusWasChanged::class]);
+
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    app(ChangeComponentStatus::class)->handle($component, ComponentStatusEnum::operational);
+
+    expect($component->statusChanges()->count())->toBe(0);
+
+    Event::assertNotDispatched(ComponentStatusWasChanged::class);
+});

--- a/tests/Unit/Actions/Component/CreateComponentTest.php
+++ b/tests/Unit/Actions/Component/CreateComponentTest.php
@@ -20,7 +20,8 @@ it('can create a component', function () {
 
     expect($component)
         ->name->toBe($data->name)
-        ->description->toBe($data->description);
+        ->description->toBe($data->description)
+        ->status->toBe(ComponentStatusEnum::unknown);
 
     Event::assertDispatched(ComponentCreated::class, fn ($event) => $event->component->is($component));
 });

--- a/tests/Unit/Actions/Integrations/ImportOhDearFeedTest.php
+++ b/tests/Unit/Actions/Integrations/ImportOhDearFeedTest.php
@@ -7,7 +7,7 @@ use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Incident;
 
 it('can import an Oh Dear feed', function () {
-    $importOhDearFeed = new ImportOhDearFeed;
+    $importOhDearFeed = app(ImportOhDearFeed::class);
 
     $data = json_decode(file_get_contents(__DIR__.'/../../../stubs/ohdear-feed-php.json'), true);
 
@@ -29,7 +29,7 @@ it('can import an Oh Dear feed', function () {
 });
 
 it('reguards models after importing incidents', function () {
-    $importOhDearFeed = new ImportOhDearFeed;
+    $importOhDearFeed = app(ImportOhDearFeed::class);
 
     $data = json_decode(file_get_contents(__DIR__.'/../../../stubs/ohdear-feed-php.json'), true);
 

--- a/tests/Unit/Actions/Update/CreateUpdateTest.php
+++ b/tests/Unit/Actions/Update/CreateUpdateTest.php
@@ -5,6 +5,7 @@ use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
@@ -57,7 +58,7 @@ it('transitions parent incident status to fixed when incident update status is f
         ->status->toEqual(IncidentStatusEnum::fixed);
 });
 
-it('does not change parent incident status when incident update status is not fixed', function () {
+it('moves parent incident status to any status the update carries', function () {
     $incident = Incident::factory()->create([
         'status' => IncidentStatusEnum::investigating,
     ]);
@@ -70,12 +71,13 @@ it('does not change parent incident status when incident update status is not fi
     app(CreateUpdate::class)->handle($incident, $data);
 
     expect($incident->fresh())
-        ->status->toEqual(IncidentStatusEnum::investigating);
+        ->status->toEqual(IncidentStatusEnum::identified);
 });
 
-it('sets linked component status to operational when incident update status is fixed', function () {
+it('keeps the impact an incident recorded when its update resolves it', function () {
     $incident = Incident::factory()->create([
         'status' => IncidentStatusEnum::investigating,
+        'visible' => ResourceVisibilityEnum::guest,
     ]);
 
     $component = Component::factory()->create([
@@ -94,6 +96,8 @@ it('sets linked component status to operational when incident update status is f
     app(CreateUpdate::class)->handle($incident, $data);
 
     expect($incident->components()->first()->pivot->component_status)
+        ->toEqual(ComponentStatusEnum::major_outage)
+        ->and($component->fresh()->latest_status)
         ->toEqual(ComponentStatusEnum::operational);
 });
 

--- a/tests/Unit/Models/ComponentEffectiveStatusTest.php
+++ b/tests/Unit/Models/ComponentEffectiveStatusTest.php
@@ -81,6 +81,34 @@ it('replaces the baseline while maintenance is in progress', function () {
     expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::under_maintenance);
 });
 
+it('uses the status the maintenance window asked for', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $schedule = Schedule::factory()->create([
+        'scheduled_at' => now()->subHour(),
+        'completed_at' => now()->addHour(),
+    ]);
+
+    $schedule->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::performance_issues,
+    ]);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::performance_issues);
+});
+
+it('takes the most severe status across overlapping maintenance windows', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    foreach ([ComponentStatusEnum::performance_issues, ComponentStatusEnum::partial_outage] as $status) {
+        Schedule::factory()
+            ->create(['scheduled_at' => now()->subHour(), 'completed_at' => now()->addHour()])
+            ->components()
+            ->attach($component->id, ['component_status' => $status]);
+    }
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::partial_outage);
+});
+
 it('still surfaces an incident raised during maintenance', function () {
     $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
 

--- a/tests/Unit/Models/ComponentEffectiveStatusTest.php
+++ b/tests/Unit/Models/ComponentEffectiveStatusTest.php
@@ -46,6 +46,29 @@ it('keeps the baseline when an impact is less severe than it', function () {
     expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::major_outage);
 });
 
+it('links to no incident when the baseline is what is being shown', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::major_outage]);
+
+    publicIncident(ComponentStatusEnum::performance_issues, $component);
+
+    expect($component->fresh()->impacting_incident)->toBeNull();
+});
+
+it('links to no incident when maintenance is what is being shown', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    Schedule::factory()
+        ->create(['scheduled_at' => now()->subHour(), 'completed_at' => now()->addHour()])
+        ->components()
+        ->attach($component->id, ['component_status' => ComponentStatusEnum::major_outage]);
+
+    publicIncident(ComponentStatusEnum::performance_issues, $component);
+
+    expect($component->fresh())
+        ->latest_status->toBe(ComponentStatusEnum::major_outage)
+        ->impacting_incident->toBeNull();
+});
+
 it('ignores impacts from incidents that are embargoed or hidden', function (array $attributes) {
     $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
 

--- a/tests/Unit/Models/ComponentEffectiveStatusTest.php
+++ b/tests/Unit/Models/ComponentEffectiveStatusTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Models\Component;
+use Cachet\Models\Incident;
+use Cachet\Models\Schedule;
+
+function publicIncident(ComponentStatusEnum $impact, Component $component, array $attributes = []): Incident
+{
+    $incident = Incident::factory()->create([
+        'status' => IncidentStatusEnum::identified,
+        'visible' => ResourceVisibilityEnum::guest,
+        ...$attributes,
+    ]);
+
+    $incident->components()->attach($component->id, ['component_status' => $impact]);
+
+    return $incident;
+}
+
+it('shows the most severe impact rather than the most recent', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    publicIncident(ComponentStatusEnum::major_outage, $component, ['created_at' => now()->subHour()]);
+    publicIncident(ComponentStatusEnum::performance_issues, $component, ['created_at' => now()]);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::major_outage);
+});
+
+it('links the badge to the incident whose impact is being shown', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $worst = publicIncident(ComponentStatusEnum::major_outage, $component, ['created_at' => now()->subHour()]);
+    publicIncident(ComponentStatusEnum::performance_issues, $component, ['created_at' => now()]);
+
+    expect($component->fresh()->impacting_incident->is($worst))->toBeTrue();
+});
+
+it('keeps the baseline when an impact is less severe than it', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::major_outage]);
+
+    publicIncident(ComponentStatusEnum::performance_issues, $component);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::major_outage);
+});
+
+it('ignores impacts from incidents that are embargoed or hidden', function (array $attributes) {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    publicIncident(ComponentStatusEnum::major_outage, $component, $attributes);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::operational);
+})->with([
+    'embargoed' => [['published_at' => now()->addWeek()]],
+    'hidden' => [['visible' => ResourceVisibilityEnum::hidden]],
+    'authenticated only' => [['visible' => ResourceVisibilityEnum::authenticated]],
+]);
+
+it('ignores impacts from incidents that are resolved', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    publicIncident(ComponentStatusEnum::major_outage, $component, ['status' => IncidentStatusEnum::fixed]);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::operational);
+});
+
+it('replaces the baseline while maintenance is in progress', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::major_outage]);
+
+    $schedule = Schedule::factory()->create([
+        'scheduled_at' => now()->subHour(),
+        'completed_at' => now()->addHour(),
+    ]);
+
+    $schedule->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::under_maintenance);
+});
+
+it('still surfaces an incident raised during maintenance', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $schedule = Schedule::factory()->create([
+        'scheduled_at' => now()->subHour(),
+        'completed_at' => now()->addHour(),
+    ]);
+
+    $schedule->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
+
+    publicIncident(ComponentStatusEnum::major_outage, $component);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::major_outage);
+});
+
+it('ignores maintenance windows that have not started or have finished', function (array $window) {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $schedule = Schedule::factory()->create($window);
+
+    $schedule->components()->attach($component->id, [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
+
+    expect($component->fresh()->latest_status)->toBe(ComponentStatusEnum::operational);
+})->with([
+    'upcoming' => [['scheduled_at' => now()->addHour(), 'completed_at' => now()->addHours(2)]],
+    'completed' => [['scheduled_at' => now()->subHours(2), 'completed_at' => now()->subHour()]],
+]);
+
+it('resolves the same status whether or not the relations are eager loaded', function () {
+    $component = Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    publicIncident(ComponentStatusEnum::partial_outage, $component);
+
+    $lazy = Component::query()->find($component->id);
+    $eager = Component::query()->with(['unresolvedIncidents', 'activeMaintenance'])->find($component->id);
+
+    expect($lazy->latest_status)
+        ->toBe(ComponentStatusEnum::partial_outage)
+        ->and($eager->latest_status)
+        ->toBe(ComponentStatusEnum::partial_outage);
+});

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Actions\Incident\SyncIncidentStatus;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Models\Component;
@@ -67,7 +68,7 @@ it('can scope to unresolved incidents', function () {
         ->and(Incident::unresolved()->count())->toBe(3);
 });
 
-it('resolves the latest status from the newest update when timestamps tie', function () {
+it('syncs its status from the newest update when timestamps tie', function () {
     $incident = Incident::factory()->create(['status' => IncidentStatusEnum::investigating]);
 
     $timestamp = now()->startOfMinute();
@@ -78,7 +79,11 @@ it('resolves the latest status from the newest update when timestamps tie', func
         $incident->updates()->save($update);
     }
 
-    expect($incident->fresh()->latestStatus)->toBe(IncidentStatusEnum::watching);
+    app(SyncIncidentStatus::class)->handle($incident);
+
+    expect($incident->fresh())
+        ->status->toBe(IncidentStatusEnum::watching)
+        ->latestStatus->toBe(IncidentStatusEnum::watching);
 });
 
 it('falls back to its own status without updates', function () {

--- a/tests/Unit/StatusTest.php
+++ b/tests/Unit/StatusTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit;
 
+use Cachet\Actions\Incident\SyncIncidentStatus;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Enums\SystemStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
@@ -171,6 +173,7 @@ it('counts an incident with multiple updates once and resolves it by its latest 
 
     $incident = Incident::factory()->create([
         'status' => IncidentStatusEnum::investigating->value,
+        'visible' => ResourceVisibilityEnum::guest,
     ]);
     Update::factory()->forIncident($incident)->create([
         'status' => IncidentStatusEnum::identified->value,
@@ -178,6 +181,8 @@ it('counts an incident with multiple updates once and resolves it by its latest 
     Update::factory()->forIncident($incident)->create([
         'status' => IncidentStatusEnum::fixed->value,
     ]);
+
+    app(SyncIncidentStatus::class)->handle($incident);
 
     $incidents = (new Status)->incidents();
 


### PR DESCRIPTION
Different parts of Cachet answered the same questions differently. This makes them agree, before incident-response features get built on top of a model that contradicts itself.

## Is this incident open?

Three definitions could disagree: the `status` column, an accessor reading the newest update, and a banner query treating an incident as resolved if either said so. An incident could read as resolved on the banner while its own page said otherwise.

The column is now canonical. A `SyncIncidentStatus` action keeps it in step on create, edit and delete of updates, `latestStatus` becomes an alias for it, and the latest-update join disappears from `Status`. Update-driven status changes now apply to every status, not only `fixed`.

## Who may see this incident?

Publication and visibility were decided independently at each read surface, and several forgot one of the two. A single `viewableBy` scope now decides both, and every surface goes through it — the API, MCP, RSS, the status page, the timeline, the system status and the component overlay.

That closes: embargoed incidents appearing in the RSS feed, hidden incidents being readable by guid and flipping the public banner, an unpublished incident's updates being listable by id, and the component overlay ignoring publication entirely.

## What colour is this component?

The badge and the banner were computed by different rules — the badge accounted for incidents, the banner only read the raw column — so every component could show red under "All systems operational".

Component status now splits into a **baseline** (the column, what operators and monitoring assert) and an **effective status** (what the page shows). Incidents and maintenance contribute impacts on top of the baseline without ever writing to it, and the most severe wins rather than the most recent, so a minor incident can no longer mask a major one. A maintenance window in progress replaces the baseline, so expected downtime is not reported as an outage, while an incident raised during the window still surfaces. The banner is computed from the same effective statuses, and a single component under maintenance no longer masks a fleet-wide outage.

Resolution therefore restores nothing, because nothing was overwritten: the impact simply stops counting. The rewrite of every pivot to `operational` on resolution is gone — it destroyed the record of what an incident imposed, and only ran on one of the paths that resolve an incident.

## Why did this component change?

The `component_status_changed` webhook only fired for API and MCP edits, because the event lived inside `UpdateComponent` and four of the six writers never called it — the dashboard toggle and edit form, the monitor, and the OhDear import all wrote the column directly.

All six now route through a `ChangeComponentStatus` command, so the event fires wherever a status changes, and every change records what asserted it (manual, monitoring, import, system), who caused it, and an optional reason.

## Also

- Maintenance windows say what each component should look like while they run, and the most severe status wins across overlapping windows. The pivot column has been written since 2016 and read by nothing; the dashboard hardcoded it to `operational`, so the form now offers a status defaulting to under maintenance. No scheduled job is involved — the window is derived from the clock.
- Both component pivots gain a unique constraint on their parent and component, with a migration that collapses pre-existing duplicates to their most severe impact.
- Resolving the current user is now the caller's job: models and actions take a user rather than calling `auth()`, supplied by the controllers, MCP tools, Filament actions and views entitled to know it. Writes that belong together — a status and the record explaining it, an update and the incident status it drives — are wrapped in transactions, with events dispatched after commit.
- A null `scheduled_at` no longer fatals the schedule status accessor, and metric charts order by `order` rather than by their decimal places.

## Compatibility

- `component.status` in the API keeps its meaning as the baseline and its wire format. A sibling `latest_status` is **added** for the effective status.
- `component_status_changed` webhook payloads gain a `source` field, and `old_status` may now be null where a component had no prior status.
- Incidents created through the API or MCP without an explicit `visible` remain authenticated-only, as they always have. Because impacts are now gated on visibility, such an incident no longer changes the public status page. Pass `visible: true` for an incident that should be publicly visible.
- Resolved incidents keep their recorded impact, so `GET /incidents?include=components` now shows the status the incident imposed rather than `operational`.

## Verification

933 tests passing, Pint and PHPStan clean, migrations verified from a fresh build including the deduplication path against duplicate rows.

New coverage includes severity precedence over recency, the maintenance mask with a failing monitor, per-window maintenance statuses and overlapping windows, exclusion of embargoed, hidden and resolved impacts, parity between eager-loaded and lazy resolution, the read policy per surface, and the status-change log with its source and causer.

## Still open

Recording or clearing an *impact* emits no event — only baseline changes do — so a consumer watching webhooks sees "someone set this component" but not "an incident took it down". Related: because effective status now depends on the clock, a component's public status can change with no write at all when a window opens or an embargo lifts, and nothing fires then either. Both are worth settling before anything starts consuming these events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188UuLsNZ39q6Yw8BUBVH3b