### PR TITLE
Fix 500 error when picking Mauve, Olive, Mist or Taupe as the accent colour

### DIFF
--- a/src/Data/Cachet/ThemeData.php
+++ b/src/Data/Cachet/ThemeData.php
@@ -11,7 +11,9 @@ use Spatie\LaravelData\Attributes\Validation\Required;
 
 final class ThemeData extends BaseData
 {
-    public const GRAYS = ['slate', 'gray', 'zinc', 'neutral', 'stone'];
+    public const GRAYS = ['slate', 'gray', 'zinc', 'neutral', 'stone', 'mauve', 'olive', 'mist', 'taupe'];
+
+    private const DEFAULT_PAIRING = 'zinc';
 
     private const THEME_PAIRINGS = [
         'cachet' => 'zinc',
@@ -308,7 +310,7 @@ final class ThemeData extends BaseData
     protected function generate(): void
     {
         $accent = $this->themeSettings->accent;
-        if ($accent === 'cachet') {
+        if (! isset(self::THEMES[$accent])) {
             $primaryColor = FilamentColor::getColors()['cachet'];
 
             $theme = [
@@ -328,9 +330,9 @@ final class ThemeData extends BaseData
         }
 
         if ($this->themeSettings->accent_pairing) {
-            $pairing = self::THEME_PAIRINGS[$accent];
+            $pairing = self::matchPairing($accent);
         } else {
-            $pairing = $this->themeSettings->accent_content;
+            $pairing = $this->themeSettings->accent_content ?? self::matchPairing($accent);
         }
 
         $this->styles = $this->compileCss($theme, $pairing);
@@ -341,8 +343,7 @@ final class ThemeData extends BaseData
      */
     protected function compileCss(array $theme, string $pairing): string
     {
-        $pairingKey = ucwords($pairing);
-        $pairingColor = constant("Filament\Support\Colors\Color::{$pairingKey}");
+        $pairingColor = Color::all()[$pairing] ?? Color::all()[self::DEFAULT_PAIRING];
 
         $this->lightColors = [
             'accent' => $theme['light']['accent'],
@@ -381,10 +382,11 @@ final class ThemeData extends BaseData
     }
 
     /**
-     * Match the pairing for the given accent.
+     * Match the pairing for the given accent, falling back to a neutral gray
+     * for accents Cachet has no explicit pairing for.
      */
-    public static function matchPairing(string $accent): string
+    public static function matchPairing(?string $accent): string
     {
-        return self::THEME_PAIRINGS[$accent];
+        return self::THEME_PAIRINGS[$accent] ?? self::DEFAULT_PAIRING;
     }
 }

--- a/tests/Unit/Data/ThemeDataTest.php
+++ b/tests/Unit/Data/ThemeDataTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Data;
+
+use Cachet\Data\Cachet\ThemeData;
+use Cachet\Settings\ThemeSettings;
+use Filament\Support\Colors\Color;
+
+/**
+ * The accent select is built from Filament's palette minus the grays, so any
+ * color Filament adds becomes selectable without Cachet knowing about it.
+ */
+function selectableAccents(): array
+{
+    return collect(Color::all())
+        ->except(ThemeData::GRAYS)
+        ->keys()
+        ->push('cachet')
+        ->all();
+}
+
+it('compiles styles for every selectable accent', function () {
+    foreach (selectableAccents() as $accent) {
+        $settings = app(ThemeSettings::class)->fill([
+            'accent' => $accent,
+            'accent_content' => null,
+            'accent_pairing' => true,
+        ]);
+
+        expect((new ThemeData($settings))->styles)
+            ->toContain('--accent:', '--accent-background:');
+    }
+});
+
+it('pairs every selectable accent with a gray', function () {
+    foreach (selectableAccents() as $accent) {
+        expect(ThemeData::matchPairing($accent))->toBeIn(ThemeData::GRAYS);
+    }
+});
+
+it('compiles styles for every selectable accent content', function () {
+    foreach (ThemeData::GRAYS as $gray) {
+        $settings = app(ThemeSettings::class)->fill([
+            'accent' => 'cachet',
+            'accent_content' => $gray,
+            'accent_pairing' => false,
+        ]);
+
+        expect((new ThemeData($settings))->styles)->toContain('--accent-background:');
+    }
+});
+
+it('falls back to the cachet accent when the stored accent is unknown', function () {
+    $settings = app(ThemeSettings::class)->fill([
+        'accent' => 'not-a-real-color',
+        'accent_content' => null,
+        'accent_pairing' => true,
+    ]);
+
+    expect((new ThemeData($settings))->styles)->toContain('--accent:');
+});


### PR DESCRIPTION
Selecting Mauve, Olive, Mist or Taupe (introduced to Filament's `Color::all()` via [Tailwind v4.2](https://superhighway.dev/tailwind-v4-2-new-palettes)) as the status page accent colour via Manage Theme, currently throws a 500. ThemeData's `THEMES` and `GRAYS` (and `THEME_PAIRINGS`) lists were hardcoded and weren't updated with the new shades, so they showed up as in the Accent dropdown with no definitions to back them. Choosing any of these broke every consumer of ThemeData.

### Changes

- Added mauve, olive, mist and taupe to `ThemeData::GRAYS`, since they seemed like a right fit in the base colour set, and not accents.
- Made the lookups non-fatal, so an already-persisted value can't leave a setup with a permanently broken status page:
  - an unknown accent falls back to the Cachet palette.
  - `matchPairing()` accepts `?string` and falls back to zinc.
  - a null `accent_content` falls back to the matched pairing.
 - Replaced `constant("Filament\Support\Colors\Color::{$pairingKey}")` in `compileCss()` with a keyed `Color::all()` lookup, for the same reason as above; i.e. not to throw an invalid pairing.

### Tests

Added 'tests/Unit/Data/ThemeDataTest.php' that steps through every option the accent and accent-content dropdowns actually offer (derived from Color::all() rather than hardcoded) and asserts each one compiles.