### PR TITLE
Restrict component links to http and https URLs

### DIFF
--- a/resources/views/components/component.blade.php
+++ b/resources/views/components/component.blade.php
@@ -7,8 +7,8 @@
                 'font-semibold text-zinc-900 dark:text-zinc-100' => ! ($nested ?? false),
                 'text-zinc-600 dark:text-zinc-300' => $nested ?? false,
             ])>
-                @if($component->link)
-                    <a href="{{ $component->link }}" target="_blank" rel="nofollow noopener" class="before:absolute before:inset-0 before:content-['']">{{ $component->name }}</a>
+                @if($component->formattedLink())
+                    <a href="{{ $component->formattedLink() }}" target="_blank" rel="nofollow noopener" class="before:absolute before:inset-0 before:content-['']">{{ $component->name }}</a>
                 @else
                     {{ $component->name }}
                 @endif

--- a/src/Data/Requests/Component/CreateComponentRequestData.php
+++ b/src/Data/Requests/Component/CreateComponentRequestData.php
@@ -27,7 +27,7 @@ final class CreateComponentRequestData extends BaseData
             'name' => ['string', 'required', 'max:255'],
             'description' => ['string'],
             'status' => [Rule::enum(ComponentStatusEnum::class)],
-            'link' => ['string'],
+            'link' => ['string', 'url:http,https'],
             'order' => ['int', 'min:0'],
             'enabled' => ['boolean'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],

--- a/src/Data/Requests/Component/UpdateComponentRequestData.php
+++ b/src/Data/Requests/Component/UpdateComponentRequestData.php
@@ -27,7 +27,7 @@ final class UpdateComponentRequestData extends BaseData
             'name' => ['string', 'max:255'],
             'description' => ['string'],
             'status' => [Rule::enum(ComponentStatusEnum::class)],
-            'link' => ['string'],
+            'link' => ['string', 'url:http,https'],
             'order' => ['int', 'min:0'],
             'component_group_id' => ['int', 'min:0', Rule::exists('component_groups', 'id')],
             'enabled' => ['boolean'],

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection as SupportCollection;
+use Illuminate\Support\Str;
 
 /**
  * @property int $id
@@ -95,6 +96,17 @@ class Component extends Model implements Metable
     public function formattedDescription(): string
     {
         return Cachet::markdown($this->description, inline: true);
+    }
+
+    /**
+     * Get the link to render on the status page, which is only ever an http
+     * or https URL.
+     */
+    public function formattedLink(): ?string
+    {
+        return Str::isUrl((string) $this->link, ['http', 'https'])
+            ? $this->link
+            : null;
     }
 
     /**

--- a/tests/Feature/Api/ComponentTest.php
+++ b/tests/Feature/Api/ComponentTest.php
@@ -252,6 +252,29 @@ it('can get a component with group', function () {
     $response->assertJsonFragment(['id' => $component->id]);
 });
 
+it('cannot create a component with a javascript link', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
+    $response = postJson('/status/api/components', [
+        'name' => 'Test',
+        'link' => 'javascript:alert(1)',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrorFor('link');
+});
+
+it('can create a component with an http link', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
+    $response = postJson('/status/api/components', [
+        'name' => 'Test',
+        'link' => 'https://status.example.com/api',
+    ]);
+
+    $response->assertCreated();
+});
+
 it('cannot create a component when not authenticated', function () {
     $response = postJson('/status/api/components', [
         'name' => 'Test',

--- a/tests/Feature/StatusPage/StatusPageTest.php
+++ b/tests/Feature/StatusPage/StatusPageTest.php
@@ -93,6 +93,29 @@ it('falls back to the default favicon when operational and dynamic favicons are 
         ->assertDontSee('image/svg+xml');
 });
 
+it('does not link a component to a javascript url', function () {
+    Component::factory()->create([
+        'name' => 'Scriptable API',
+        'link' => 'javascript:alert(1)',
+    ]);
+
+    $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSee('Scriptable API')
+        ->assertDontSee('javascript:alert(1)', escape: false);
+});
+
+it('links a component to an http url', function () {
+    Component::factory()->create([
+        'name' => 'Linked API',
+        'link' => 'https://status.example.com/api',
+    ]);
+
+    $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSee('href="https://status.example.com/api"', escape: false);
+});
+
 it('does not render raw html in component descriptions', function () {
     Component::factory()->create([
         'description' => 'The **primary** API <script>alert(1)</script>',


### PR DESCRIPTION
### What

A component `link` is written into the status page anchor as it was stored (`resources/views/components/component.blade.php:11`), and the API accepts any string for it (`'link' => ['string']`, `src/Data/Requests/Component/CreateComponentRequestData.php:30` and the update equivalent). A value such as `javascript:alert(1)` therefore ends up in `href`, where Blade escaping does not help, because the value is a syntactically valid attribute; only the scheme is the problem.

### Why

The Filament form already restricts the field with `->url()` (`src/Filament/Resources/Components/ComponentResource.php:60`), so the same expectation is missing on the API and MCP paths that share the request data. Those paths are authorised by the `components.manage` token ability, so any holder of a component-managing token can store the value, and every visitor of the status page then receives the anchor.

### How

- `link` is validated as `url:http,https` on create and update, which matches what the form has always allowed and is stricter than a bare `url` rule (Laravel's default protocol list covers about 250 schemes).
- `Component::formattedLink()` returns the link only when it is an http or https URL, and the status page anchor uses that accessor. Values stored before this change stay in the database and render as plain component names instead of links, which is the same shape as `formattedDescription()` for the Markdown fix in `23adbb88`.
- Left unchanged on purpose: the API resource keeps exposing the raw `link` attribute, since an API consumer is not an HTML context, and the column is not rewritten by a migration.

### Behaviour change

A component whose link is not an http or https URL loses its anchor on the status page, and updating such a component through the API now fails validation until the link is corrected or cleared.

### Testing

PHP 8.3.30 in a container, dependencies from `composer update`, assets from `npm ci` and `npm run build`, workbench prepared with `composer build`.

- `composer test:unit`: 954 passed, 2 todos, 0 failed.
- `composer test:lint` (Pint): PASS.
- `vendor/bin/phpstan analyse`: no errors.
- New tests: `tests/Feature/Api/ComponentTest.php` covers the rejected `javascript:` link and an accepted https link; `tests/Feature/StatusPage/StatusPageTest.php` covers a stored `javascript:` link rendering without an anchor and an https link still rendering one. The two negative cases fail on `main` at `78b41c4`, the two positive ones pass on both sides.

### References

GHSA-8jf8-9272-94v7 (reported privately, in triage)
