### PR TITLE
Sandbox incident template rendering

### DIFF
--- a/config/cachet.php
+++ b/config/cachet.php
@@ -269,16 +269,17 @@ return [
 
     /*
      |--------------------------------------------------------------------------
-     | Cachet Incident Templates
+     | Cachet Template Renderers
      |--------------------------------------------------------------------------
      |
-     | Twig template bodies are rendered inside a sandbox. Blade template
-     | bodies are compiled to PHP and run with the permissions of the
-     | application, so they are only rendered when enabled here.
+     | Configure which renderers a template body may be rendered with. Twig
+     | bodies are rendered inside a sandbox. Blade bodies are compiled to
+     | PHP and run with the permissions of the application, so the Blade
+     | renderer is only used when an installation enables it here.
      |
      */
-    'incident_templates' => [
-        'allow_blade' => env('CACHET_ALLOW_BLADE_TEMPLATES', false),
+    'renderers' => [
+        'blade' => env('CACHET_BLADE_RENDERER', false),
     ],
 
     /*

--- a/config/cachet.php
+++ b/config/cachet.php
@@ -269,6 +269,20 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Cachet Incident Templates
+     |--------------------------------------------------------------------------
+     |
+     | Twig template bodies are rendered inside a sandbox. Blade template
+     | bodies are compiled to PHP and run with the permissions of the
+     | application, so they are only rendered when enabled here.
+     |
+     */
+    'incident_templates' => [
+        'allow_blade' => env('CACHET_ALLOW_BLADE_TEMPLATES', false),
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
      | Cachet Blog Feed
      |--------------------------------------------------------------------------
      |

--- a/src/Data/Requests/IncidentTemplate/CreateIncidentTemplateRequestData.php
+++ b/src/Data/Requests/IncidentTemplate/CreateIncidentTemplateRequestData.php
@@ -27,7 +27,7 @@ final class CreateIncidentTemplateRequestData extends BaseData
             'name' => ['required', 'string', 'max:255'],
             'slug' => ['string'],
             'template' => ['required', 'string'],
-            'engine' => [Rule::enum(IncidentTemplateEngineEnum::class)],
+            'engine' => [Rule::enum(IncidentTemplateEngineEnum::class)->only(IncidentTemplateEngineEnum::available())],
         ];
     }
 

--- a/src/Data/Requests/IncidentTemplate/UpdateIncidentTemplateRequestData.php
+++ b/src/Data/Requests/IncidentTemplate/UpdateIncidentTemplateRequestData.php
@@ -23,7 +23,7 @@ final class UpdateIncidentTemplateRequestData extends BaseData
             'name' => ['string', 'max:255'],
             'slug' => ['string'],
             'template' => ['string'],
-            'engine' => [Rule::enum(IncidentTemplateEngineEnum::class)],
+            'engine' => [Rule::enum(IncidentTemplateEngineEnum::class)->only(IncidentTemplateEngineEnum::available())],
         ];
     }
 

--- a/src/Enums/IncidentTemplateEngineEnum.php
+++ b/src/Enums/IncidentTemplateEngineEnum.php
@@ -12,6 +12,29 @@ enum IncidentTemplateEngineEnum: string implements HasColor, HasIcon, HasLabel
     case blade = 'blade';
     case twig = 'twig';
 
+    /**
+     * The engines that may be selected for a template.
+     *
+     * Blade template bodies compile to PHP, so they are only available when an
+     * installation opts in through cachet.incident_templates.allow_blade.
+     *
+     * @return list<self>
+     */
+    public static function available(): array
+    {
+        return config('cachet.incident_templates.allow_blade')
+            ? self::cases()
+            : [self::twig];
+    }
+
+    /**
+     * Determine if the engine may be selected for a template.
+     */
+    public function isAvailable(): bool
+    {
+        return in_array($this, self::available(), strict: true);
+    }
+
     public function getColor(): array
     {
         return match ($this) {

--- a/src/Enums/IncidentTemplateEngineEnum.php
+++ b/src/Enums/IncidentTemplateEngineEnum.php
@@ -13,26 +13,30 @@ enum IncidentTemplateEngineEnum: string implements HasColor, HasIcon, HasLabel
     case twig = 'twig';
 
     /**
-     * The engines that may be selected for a template.
-     *
-     * Blade template bodies compile to PHP, so they are only available when an
-     * installation opts in through cachet.incident_templates.allow_blade.
+     * The engines whose renderer is available to a template.
      *
      * @return list<self>
      */
     public static function available(): array
     {
-        return config('cachet.incident_templates.allow_blade')
-            ? self::cases()
-            : [self::twig];
+        return array_values(array_filter(
+            self::cases(),
+            fn (self $engine): bool => $engine->isAvailable(),
+        ));
     }
 
     /**
      * Determine if the engine may be selected for a template.
+     *
+     * Blade template bodies compile to PHP, so the Blade renderer is only
+     * available when an installation enables cachet.renderers.blade.
      */
     public function isAvailable(): bool
     {
-        return in_array($this, self::available(), strict: true);
+        return match ($this) {
+            self::blade => (bool) config('cachet.renderers.blade'),
+            self::twig => true,
+        };
     }
 
     public function getColor(): array

--- a/src/Filament/Resources/IncidentTemplates/IncidentTemplateResource.php
+++ b/src/Filament/Resources/IncidentTemplates/IncidentTemplateResource.php
@@ -57,6 +57,7 @@ class IncidentTemplateResource extends Resource
                     Select::make('engine')
                         ->label(__('cachet::incident_template.form.engine_label'))
                         ->options(IncidentTemplateEngineEnum::class)
+                        ->disableOptionWhen(fn (string $value): bool => ! IncidentTemplateEngineEnum::from($value)->isAvailable())
                         ->default(IncidentTemplateEngineEnum::twig)
                         ->live()
                         ->required(),

--- a/src/Renderers/BladeRenderer.php
+++ b/src/Renderers/BladeRenderer.php
@@ -2,15 +2,27 @@
 
 namespace Cachet\Renderers;
 
+use Cachet\Enums\IncidentTemplateEngineEnum;
 use Illuminate\Support\Facades\Blade;
+use RuntimeException;
 
 class BladeRenderer implements Renderer
 {
     /**
      * Render the template using Laravel Blade.
+     *
+     * Blade compiles echo tags and directives to PHP, so a template body is
+     * executable code. Rendering is therefore limited to installations that
+     * opt in through the cachet.incident_templates.allow_blade config value.
+     *
+     * @throws RuntimeException
      */
     public function render(string $template, array $variables = []): string
     {
+        if (! IncidentTemplateEngineEnum::blade->isAvailable()) {
+            throw new RuntimeException('Blade incident templates are disabled. Set CACHET_ALLOW_BLADE_TEMPLATES=true to render them.');
+        }
+
         return Blade::render($template, $variables, deleteCachedView: true);
     }
 }

--- a/src/Renderers/BladeRenderer.php
+++ b/src/Renderers/BladeRenderer.php
@@ -2,7 +2,6 @@
 
 namespace Cachet\Renderers;
 
-use Cachet\Enums\IncidentTemplateEngineEnum;
 use Illuminate\Support\Facades\Blade;
 use RuntimeException;
 
@@ -13,14 +12,14 @@ class BladeRenderer implements Renderer
      *
      * Blade compiles echo tags and directives to PHP, so a template body is
      * executable code. Rendering is therefore limited to installations that
-     * opt in through the cachet.incident_templates.allow_blade config value.
+     * enable the Blade renderer through the cachet.renderers.blade config value.
      *
      * @throws RuntimeException
      */
     public function render(string $template, array $variables = []): string
     {
-        if (! IncidentTemplateEngineEnum::blade->isAvailable()) {
-            throw new RuntimeException('Blade incident templates are disabled. Set CACHET_ALLOW_BLADE_TEMPLATES=true to render them.');
+        if (! config('cachet.renderers.blade')) {
+            throw new RuntimeException('The Blade renderer is disabled. Set CACHET_BLADE_RENDERER=true to render Blade templates.');
         }
 
         return Blade::render($template, $variables, deleteCachedView: true);

--- a/src/Renderers/TwigRenderer.php
+++ b/src/Renderers/TwigRenderer.php
@@ -3,15 +3,42 @@
 namespace Cachet\Renderers;
 
 use Twig\Environment;
+use Twig\Extension\SandboxExtension;
 use Twig\Loader\ArrayLoader;
+use Twig\Sandbox\SecurityPolicy;
 
 class TwigRenderer implements Renderer
 {
+    /**
+     * The Twig tags an incident template may use.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_TAGS = ['apply', 'for', 'if', 'set', 'verbatim', 'with'];
+
+    /**
+     * The Twig filters an incident template may use. Filters that take a callable
+     * (map, filter, reduce, sort) are omitted, because a template can pass the
+     * name of any PHP function to them.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_FILTERS = [
+        'abs', 'capitalize', 'date', 'default', 'e', 'escape', 'first', 'format', 'join', 'keys',
+        'last', 'length', 'lower', 'nl2br', 'number_format', 'raw', 'replace', 'reverse', 'round',
+        'slice', 'split', 'striptags', 'title', 'trim', 'upper', 'url_encode',
+    ];
+
     public function __construct() {}
 
     public function render(string $template, array $variables = []): string
     {
         $env = new Environment(new ArrayLoader([]));
+
+        $env->addExtension(new SandboxExtension(
+            new SecurityPolicy(self::ALLOWED_TAGS, self::ALLOWED_FILTERS),
+            sandboxed: true,
+        ));
 
         $template = $env->createTemplate($template);
 

--- a/tests/Feature/Api/IncidentTemplateTest.php
+++ b/tests/Feature/Api/IncidentTemplateTest.php
@@ -91,8 +91,8 @@ it('can create an incident template', function () {
     ]);
 });
 
-it('cannot create an incident template with the blade engine when blade is not allowed', function () {
-    config()->set('cachet.incident_templates.allow_blade', false);
+it('cannot create an incident template with the blade engine when the blade renderer is disabled', function () {
+    config()->set('cachet.renderers.blade', false);
 
     Sanctum::actingAs(User::factory()->create(), ['incident-templates.manage']);
 
@@ -107,8 +107,8 @@ it('cannot create an incident template with the blade engine when blade is not a
     $response->assertJsonValidationErrorFor('engine');
 });
 
-it('can create an incident template with the blade engine when blade is allowed', function () {
-    config()->set('cachet.incident_templates.allow_blade', true);
+it('can create an incident template with the blade engine when the blade renderer is enabled', function () {
+    config()->set('cachet.renderers.blade', true);
 
     Sanctum::actingAs(User::factory()->create(), ['incident-templates.manage']);
 

--- a/tests/Feature/Api/IncidentTemplateTest.php
+++ b/tests/Feature/Api/IncidentTemplateTest.php
@@ -91,6 +91,37 @@ it('can create an incident template', function () {
     ]);
 });
 
+it('cannot create an incident template with the blade engine when blade is not allowed', function () {
+    config()->set('cachet.incident_templates.allow_blade', false);
+
+    Sanctum::actingAs(User::factory()->create(), ['incident-templates.manage']);
+
+    $response = postJson('/status/api/incident-templates', [
+        'name' => 'New Template',
+        'slug' => 'new-template',
+        'template' => 'Hello {{ $name }}',
+        'engine' => 'blade',
+    ]);
+
+    $response->assertUnprocessable();
+    $response->assertJsonValidationErrorFor('engine');
+});
+
+it('can create an incident template with the blade engine when blade is allowed', function () {
+    config()->set('cachet.incident_templates.allow_blade', true);
+
+    Sanctum::actingAs(User::factory()->create(), ['incident-templates.manage']);
+
+    $response = postJson('/status/api/incident-templates', [
+        'name' => 'New Template',
+        'slug' => 'new-template',
+        'template' => 'Hello {{ $name }}',
+        'engine' => 'blade',
+    ]);
+
+    $response->assertCreated();
+});
+
 it('cannot update an incident template when not authenticated', function () {
     $incidentTemplate = IncidentTemplate::factory()->create();
 

--- a/tests/Unit/Actions/Incident/CreateIncidentTest.php
+++ b/tests/Unit/Actions/Incident/CreateIncidentTest.php
@@ -71,6 +71,8 @@ it('can create an incident with a twig template', function () {
 });
 
 it('can create an incident with a blade template', function () {
+    config()->set('cachet.incident_templates.allow_blade', true);
+
     $template = IncidentTemplate::factory()->blade()->create([
         'slug' => 'my-template',
         'template' => 'This is a template: {{ $incident[\'name\'] }} foo: {{ $foo }}',

--- a/tests/Unit/Actions/Incident/CreateIncidentTest.php
+++ b/tests/Unit/Actions/Incident/CreateIncidentTest.php
@@ -71,7 +71,7 @@ it('can create an incident with a twig template', function () {
 });
 
 it('can create an incident with a blade template', function () {
-    config()->set('cachet.incident_templates.allow_blade', true);
+    config()->set('cachet.renderers.blade', true);
 
     $template = IncidentTemplate::factory()->blade()->create([
         'slug' => 'my-template',

--- a/tests/Unit/Models/IncidentTemplateTest.php
+++ b/tests/Unit/Models/IncidentTemplateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cachet\Models\IncidentTemplate;
+use Twig\Sandbox\SecurityError;
 
 it('can fetch data', function () {
     $template = IncidentTemplate::factory()->create([
@@ -28,6 +29,8 @@ it('can render a twig template', function () {
 });
 
 it('can render a blade template', function () {
+    config()->set('cachet.incident_templates.allow_blade', true);
+
     $template = IncidentTemplate::factory()->blade()->create([
         'template' => 'Hello, {{ $name }}!',
     ]);
@@ -39,3 +42,26 @@ it('can render a blade template', function () {
     expect($output)
         ->toBe('Hello, James Brooks!');
 });
+
+it('does not render a blade template when blade is not allowed', function () {
+    config()->set('cachet.incident_templates.allow_blade', false);
+
+    $template = IncidentTemplate::factory()->blade()->create([
+        'template' => 'Hello, {{ $name }}!',
+    ]);
+
+    expect(fn () => $template->render(['name' => 'James Brooks']))
+        ->toThrow(RuntimeException::class);
+});
+
+it('does not let a twig template call php functions', function (string $body) {
+    $template = IncidentTemplate::factory()->twig()->create([
+        'template' => $body,
+    ]);
+
+    expect(fn () => $template->render(['name' => 'James Brooks']))
+        ->toThrow(SecurityError::class);
+})->with([
+    'callable filter' => ["{{ ['cachet']|map('strtoupper')|join }}"],
+    'template include' => ["{% include 'another-template' %}"],
+]);

--- a/tests/Unit/Models/IncidentTemplateTest.php
+++ b/tests/Unit/Models/IncidentTemplateTest.php
@@ -29,7 +29,7 @@ it('can render a twig template', function () {
 });
 
 it('can render a blade template', function () {
-    config()->set('cachet.incident_templates.allow_blade', true);
+    config()->set('cachet.renderers.blade', true);
 
     $template = IncidentTemplate::factory()->blade()->create([
         'template' => 'Hello, {{ $name }}!',
@@ -43,8 +43,8 @@ it('can render a blade template', function () {
         ->toBe('Hello, James Brooks!');
 });
 
-it('does not render a blade template when blade is not allowed', function () {
-    config()->set('cachet.incident_templates.allow_blade', false);
+it('does not render a blade template when the blade renderer is disabled', function () {
+    config()->set('cachet.renderers.blade', false);
 
     $template = IncidentTemplate::factory()->blade()->create([
         'template' => 'Hello, {{ $name }}!',


### PR DESCRIPTION
### What

`IncidentTemplate::render()` hands the stored template body to a bare Twig `Environment` (`src/Renderers/TwigRenderer.php:16`) and to `Blade::render()` (`src/Renderers/BladeRenderer.php:14`). Both compile and execute that body, so whoever authors a template decides which PHP runs when an incident is created from it (`src/Actions/Incident/CreateIncident.php:77`).

### Why

A template body reaches those renderers through `POST /api/incident-templates` and the MCP `create_incident_template` tool, where it is validated as `['required', 'string']` (`src/Data/Requests/IncidentTemplate/CreateIncidentTemplateRequestData.php:24`), and both paths are authorised by the `incident-templates.manage` token ability alone (`src/Http/Controllers/Api/IncidentTemplateController.php:48`). Twig ships a sandbox for exactly this situation and it was not switched on. Blade has no equivalent: an echo tag holds an arbitrary PHP expression, so a Blade body cannot be made safe by filtering directives.

### How

- `TwigRenderer` registers `SandboxExtension` with a `SecurityPolicy` that allows the tags and filters a status update needs. Filters that take a callable (`map`, `filter`, `reduce`, `sort`) are left out, because a template can pass them the name of any PHP function. Methods, properties and functions are all denied, which also closes template introspection through `_self`.
- Blade rendering becomes opt in through the new `cachet.renderers.blade` option (`CACHET_BLADE_RENDERER`, default `false`). While it is off, `engine: blade` fails validation on create and update, the option is disabled in the Filament form, and `BladeRenderer` refuses to render. Availability sits on `IncidentTemplateEngineEnum`: `isAvailable()` reads the config for its own renderer and `available()` derives the list from that. Twig is always available, so an installation carrying an older published `config/cachet.php` keeps rendering Twig and still gets no Blade.
- Left unchanged on purpose: `src/Filament/Resources/IncidentTemplates/IncidentTemplateResource.php:49` also calls `Blade::render()`, but on hardcoded translation strings rather than on stored input. The scope of `incident-templates.manage` is untouched as well; who may author a template is a separate question from what a template may do.

### Behaviour change

An installation that already stores Blade templates needs `CACHET_BLADE_RENDERER=true`, otherwise creating an incident from such a template fails. Twig templates that use the callable filters, `include` or method calls stop rendering; interpolation, `if`, `for` and the allowed filters keep working.

### Testing

PHP 8.3.30 in a container, dependencies from `composer update`, assets from `npm ci` and `npm run build`, workbench prepared with `composer build`.

- `composer test:unit`: 955 passed, 2 todos, 0 failed.
- `composer test:lint` (Pint): PASS, 807 files.
- `vendor/bin/phpstan analyse`: no errors.
- Psalm taint analysis, as the `Psalm (security)` workflow runs it: no errors found.
- New tests: `tests/Unit/Models/IncidentTemplateTest.php` gains one case for a Blade template while the renderer is disabled and two datasets for a Twig template that reaches for PHP functions; `tests/Feature/Api/IncidentTemplateTest.php` gains the rejected and the accepted `engine: blade` request. All four fail on `main` at `78b41c4` and pass with this change.
- Two existing tests that render Blade templates now enable the renderer first.

### References

GHSA-34gh-p78x-w96h (reported privately, in triage)