### PR TITLE
Stickied incidents

### DIFF
--- a/resources/lang/de/incident.php
+++ b/resources/lang/de/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Angeheftet',
+            'stickied' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Benutzer',
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
+        'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
         'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [

--- a/resources/lang/de_AT/incident.php
+++ b/resources/lang/de_AT/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Angeheftet',
+            'stickied' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Benutzer',
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
+        'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
         'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [

--- a/resources/lang/de_CH/incident.php
+++ b/resources/lang/de_CH/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Angeheftet',
+            'stickied' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Benutzer',
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
+        'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
         'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [

--- a/resources/lang/en/incident.php
+++ b/resources/lang/en/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Visible',
-            'stickied' => 'Stickied',
+            'stickied' => 'Pin to Top',
             'occurred_at' => 'Occurred at',
             'published_at' => 'Published at',
             'notified_subscribers' => 'Notified subscribers',

--- a/resources/lang/es_ES/incident.php
+++ b/resources/lang/es_ES/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nombre',
             'status' => 'Estado',
             'visible' => 'Visible',
-            'stickied' => 'Fijado',
+            'stickied' => 'Fijar arriba',
             'occurred_at' => 'Ocurrido el',
             'published_at' => 'Publicado el',
             'notified_subscribers' => 'Suscriptores notificados',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Usuario',
         'user_helper' => 'El usuario que reportó el incidente.',
         'notifications_label' => '¿Notificar a los suscriptores?',
+        'pin_incident_label' => 'Fijar el incidente en la parte superior de la página de estado.',
         'stickied_label' => '¿Incidente fijado?',
         'guid_label' => 'UUID del Incidente',
         'add_component' => [

--- a/resources/lang/fr/incident.php
+++ b/resources/lang/fr/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nom',
             'status' => 'Statut',
             'visible' => 'Visible',
-            'stickied' => 'Épinglé',
+            'stickied' => 'Épingler en haut',
             'occurred_at' => 'Survenu le',
             'published_at' => 'Publié le',
             'notified_subscribers' => 'Abonnés notifiés',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Utilisateur',
         'user_helper' => 'L’utilisateur ayant signalé l’incident.',
         'notifications_label' => 'Notifier les abonnés ?',
+        'pin_incident_label' => 'Épingler l’incident en haut de la page d’état.',
         'stickied_label' => 'Incident épinglé ?',
         'guid_label' => 'UUID de l’incident',
         'add_component' => [

--- a/resources/lang/ko/incident.php
+++ b/resources/lang/ko/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => '이름',
             'status' => '상태',
             'visible' => '표시 여부',
-            'stickied' => '고정 여부',
+            'stickied' => '상단에 고정',
             'occurred_at' => '발생 시간',
             'published_at' => '게시 시간',
             'notified_subscribers' => '구독자 알림 여부',
@@ -63,6 +63,7 @@ return [
         'user_label' => '사용자',
         'user_helper' => '사고를 보고한 사용자입니다.',
         'notifications_label' => '구독자에게 알림을 보내시겠습니까?',
+        'pin_incident_label' => '상태 페이지 상단에 사고를 고정합니다.',
         'stickied_label' => '사고를 고정하시겠습니까?',
         'guid_label' => '사고 UUID',
         'add_component' => [

--- a/resources/lang/nl/incident.php
+++ b/resources/lang/nl/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Naam',
             'status' => 'Toestand',
             'visible' => 'Zichtbaar',
-            'stickied' => 'Vastgepind',
+            'stickied' => 'Bovenaan vastpinnen',
             'occurred_at' => 'Voorgekomen op',
             'published_at' => 'Gepubliceerd op',
             'notified_subscribers' => 'Geïnformeerde abonnees',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Gebruiker',
         'user_helper' => 'Gebruiker die het incident heeft gemeld.',
         'notifications_label' => 'Abonnees op de hoogte stellen?',
+        'pin_incident_label' => 'Het incident bovenaan de statuspagina vastpinnen.',
         'stickied_label' => 'Pin-incident?',
         'guid_label' => 'Incident-UUID',
         'add_component' => [

--- a/resources/lang/ph/incident.php
+++ b/resources/lang/ph/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Pangalan',
             'status' => 'Kalagayan',
             'visible' => 'Nakikita',
-            'stickied' => 'Naka-sticky',
+            'stickied' => 'I-pin sa itaas',
             'occurred_at' => 'Nangyari noong',
             'published_at' => 'Nai-publish noong',
             'notified_subscribers' => 'Naabisuhan ang mga subscriber',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Gumagamit',
         'user_helper' => 'Ang gumagamit na nag-ulat ng insidente.',
         'notifications_label' => 'Abisuhan ang mga Subscriber?',
+        'pin_incident_label' => 'I-pin ang insidente sa itaas ng status page.',
         'stickied_label' => 'Gawing Sticky ang Insidente?',
         'guid_label' => 'Incident UUID',
         'add_component' => [

--- a/resources/lang/pt_BR/incident.php
+++ b/resources/lang/pt_BR/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nome',
             'status' => 'Status',
             'visible' => 'Visível',
-            'stickied' => 'Fixado',
+            'stickied' => 'Fixar no topo',
             'occurred_at' => 'Ocorrido em',
             'published_at' => 'Publicado em',
             'notified_subscribers' => 'Inscritos notificados',
@@ -63,6 +63,7 @@ return [
         'user_label' => 'Usuário',
         'user_helper' => 'O usuário que reportou o incidente.',
         'notifications_label' => 'Notificar Inscritos?',
+        'pin_incident_label' => 'Fixar o incidente no topo da página de status.',
         'stickied_label' => 'Fixar Incidente?',
         'guid_label' => 'UUID do Incidente',
         'add_component' => [

--- a/resources/lang/zh_CN/incident.php
+++ b/resources/lang/zh_CN/incident.php
@@ -63,6 +63,7 @@ return [
         'user_label' => '用户',
         'user_helper' => '报告事件的用户。',
         'notifications_label' => '通知订阅者？',
+        'pin_incident_label' => '将事件置顶到状态页面顶部。',
         'stickied_label' => '置顶事件？',
         'guid_label' => '事件 UUID',
         'add_component' => [

--- a/resources/lang/zh_TW/incident.php
+++ b/resources/lang/zh_TW/incident.php
@@ -63,6 +63,7 @@ return [
         'user_label' => '用戶',
         'user_helper' => '報告事件的用戶。',
         'notifications_label' => '通知訂閱者？',
+        'pin_incident_label' => '將事件置頂到狀態頁面頂部。',
         'stickied_label' => '置頂事件？',
         'guid_label' => '事件 UUID',
         'add_component' => [

--- a/resources/views/components/incident-timeline.blade.php
+++ b/resources/views/components/incident-timeline.blade.php
@@ -32,6 +32,10 @@
     </div>
 
     <div class="flex w-full flex-col gap-8">
+        @if ($stickiedIncidents->isNotEmpty())
+            <x-cachet::incident :date="$from" :incidents="$stickiedIncidents" :with-date="false" />
+        @endif
+
         @forelse ($timeline as $date => $day)
             <x-cachet::incident :date="$date" :incidents="$day['incidents']" :schedules="$day['schedules']" />
         @empty

--- a/src/View/Components/IncidentTimeline.php
+++ b/src/View/Components/IncidentTimeline.php
@@ -31,6 +31,7 @@ class IncidentTimeline extends Component
         $endDate = $startDate->clone()->subDays($incidentDays);
 
         return view('cachet::components.incident-timeline', [
+            'stickiedIncidents' => $this->stickiedIncidents(),
             'timeline' => $this->timeline(
                 $startDate,
                 $endDate,
@@ -86,6 +87,7 @@ class IncidentTimeline extends Component
                 'updates' => fn ($query) => $query->orderByDesc('created_at')->orderByDesc('id'),
             ])
             ->viewableBy(auth()->check())
+            ->where('stickied', false)
             ->when($this->appSettings->recent_incidents_only, function ($query) {
                 $query->where(function ($query) {
                     $query->whereDate(
@@ -118,6 +120,24 @@ class IncidentTimeline extends Component
             ->toBase()
             ->sortByDesc(fn (Incident $incident) => $incident->timestamp)
             ->groupBy(fn (Incident $incident) => $incident->timestamp->toDateString());
+    }
+
+    /**
+     * Fetch incidents pinned to the top of the timeline.
+     *
+     * @return Collection<int, Incident>
+     */
+    private function stickiedIncidents(): Collection
+    {
+        return Incident::query()
+            ->with([
+                'components',
+                'updates' => fn ($query) => $query->orderByDesc('created_at')->orderByDesc('id'),
+            ])
+            ->viewableBy(auth()->check())
+            ->stickied()
+            ->get()
+            ->sortByDesc(fn (Incident $incident) => $incident->timestamp);
     }
 
     /**

--- a/tests/Feature/StatusPage/StatusPageTest.php
+++ b/tests/Feature/StatusPage/StatusPageTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Models\Component;
+use Cachet\Models\Incident;
 use Cachet\Models\Schedule;
 use Cachet\Settings\AppSettings;
 
@@ -52,6 +53,24 @@ it('shows completed maintenance in the timeline instead of the maintenance block
     expect($response->viewData('schedules')->pluck('id'))->not->toContain($completed->id);
 
     $response->assertSee('Completed maintenance');
+});
+
+it('shows stickied incidents at the top of the timeline', function () {
+    Incident::factory()->create([
+        'name' => 'Pinned incident',
+        'stickied' => true,
+        'occurred_at' => now()->subMonths(2),
+    ]);
+    Incident::factory()->create([
+        'name' => 'Recent incident',
+        'occurred_at' => now(),
+    ]);
+
+    $response = $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSeeInOrder(['Pinned incident', 'Recent incident']);
+
+    expect(substr_count($response->getContent(), 'Pinned incident'))->toBe(1);
 });
 
 it('does not render a dynamic favicon when the setting is disabled', function () {


### PR DESCRIPTION
## Summary

- Display stickied incidents above the regular incident timeline
- Exclude stickied incidents from their chronological entries
- Rename the admin label to “Pin to Top”

## Testing

Not run (not requested)