### PR TITLE
Group components during incident creation

### DIFF
--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -13,6 +13,7 @@ use Cachet\Filament\Resources\Incidents\Pages\EditIncident;
 use Cachet\Filament\Resources\Incidents\Pages\ListIncidents;
 use Cachet\Filament\Resources\Incidents\RelationManagers\ComponentsRelationManager;
 use Cachet\Filament\Resources\Updates\RelationManagers\UpdatesRelationManager;
+use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Settings\MailSettings;
 use Cachet\Status;
@@ -89,7 +90,7 @@ class IncidentResource extends Resource
                             Select::make('component_id')
                                 ->preload()
                                 ->required()
-                                ->relationship('component', 'name')
+                                ->options(fn (): array => static::getComponentOptions())
                                 ->disableOptionsWhenSelectedInSiblingRepeaterItems()
                                 ->label(__('cachet::incident.form.add_component.component_label')),
                             ToggleButtons::make('component_status')
@@ -129,6 +130,28 @@ class IncidentResource extends Resource
                     ->columnSpan(1),
             ])
             ->columns(4);
+    }
+
+    /**
+     * Get components grouped by their component group for incident selection.
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected static function getComponentOptions(): array
+    {
+        return Component::query()
+            ->with('group')
+            ->leftJoin('component_groups', 'components.component_group_id', '=', 'component_groups.id')
+            ->orderByRaw('component_groups.id is null')
+            ->orderBy('component_groups.order')
+            ->orderBy('component_groups.name')
+            ->orderBy('components.order')
+            ->orderBy('components.name')
+            ->select('components.*')
+            ->get()
+            ->groupBy(fn (Component $component): string => $component->group?->name ?? __('Ungrouped components'))
+            ->map(fn ($components): array => $components->pluck('name', 'id')->all())
+            ->all();
     }
 
     public static function table(Table $table): Table

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -14,6 +14,7 @@ use Cachet\Filament\Resources\Incidents\Pages\ListIncidents;
 use Cachet\Filament\Resources\Incidents\RelationManagers\ComponentsRelationManager;
 use Cachet\Filament\Resources\Updates\RelationManagers\UpdatesRelationManager;
 use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Settings\MailSettings;
 use Cachet\Status;
@@ -149,7 +150,13 @@ class IncidentResource extends Resource
             ->orderBy('components.name')
             ->select('components.*')
             ->get()
-            ->groupBy(fn (Component $component): string => $component->group?->name ?? __('Ungrouped components'))
+            ->groupBy(function (Component $component): string {
+                $group = $component->group;
+
+                return $group instanceof ComponentGroup
+                    ? $group->name
+                    : __('Ungrouped components');
+            })
             ->map(fn ($components): array => $components->pluck('name', 'id')->all())
             ->all();
     }

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -111,6 +111,8 @@ class Component extends Model implements Metable
 
     /**
      * Get the group the component belongs to.
+     *
+     * @return BelongsTo<ComponentGroup, $this>
      */
     public function group(): BelongsTo
     {

--- a/tests/Feature/Filament/Resources/IncidentResourceTest.php
+++ b/tests/Feature/Filament/Resources/IncidentResourceTest.php
@@ -6,6 +6,8 @@ use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Filament\Resources\Incidents\Pages\CreateIncident;
 use Cachet\Filament\Resources\Incidents\Pages\EditIncident;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\NewIncidentNotification;
@@ -69,4 +71,21 @@ it('notifies subscribers when creating an incident from the dashboard', function
         ->assertHasNoFormErrors();
 
     Notification::assertSentTo($subscriber, NewIncidentNotification::class);
+});
+
+it('groups component selections by component group when creating an incident', function () {
+    $firstGroup = ComponentGroup::factory()->create(['name' => 'First Group', 'order' => 1]);
+    $secondGroup = ComponentGroup::factory()->create(['name' => 'Second Group', 'order' => 2]);
+
+    Component::factory()->for($firstGroup, 'group')->create(['name' => 'Webservice']);
+    Component::factory()->for($secondGroup, 'group')->create(['name' => 'Webservice']);
+    Component::factory()->create(['name' => 'Ungrouped Service']);
+
+    livewire(CreateIncident::class)
+        ->fillForm([
+            'incidentComponents' => [['component_id' => null]],
+        ])
+        ->assertSeeInOrder(['First Group', 'Second Group', 'Ungrouped components'])
+        ->assertSee('Webservice')
+        ->assertSee('Ungrouped Service');
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/cachethq/core/issues/251

- Group incident component options by component group in the create/edit form
- Preserve predictable ordering for groups and components, including ungrouped components
- Add feature coverage for grouped and ungrouped selections

## Testing

- Added a Filament feature test covering component grouping and ordering