### PR TITLE
RSS Feed Improvements

### DIFF
--- a/resources/views/rss.blade.php
+++ b/resources/views/rss.blade.php
@@ -12,12 +12,24 @@
         <pubDate>{{ now()->toRssString() }}</pubDate>
 
         @foreach($incidents as $incident)
+        @php
+            $latestUpdate = $incident->updates->last();
+            $publishedAt = $latestUpdate?->updated_at ?? $incident->created_at;
+            $feedVersion = sha1($incident->guid.$incident->updated_at?->format('Y-m-d H:i:s.u').$incident->updates->map(
+                fn ($update) => $update->id.$update->updated_at?->format('Y-m-d H:i:s.u')
+            )->join(''));
+        @endphp
         <item>
-            <title>{{ $incident->name }}</title>
+            <title>[{{ $incident->status?->getLabel() }}] {{ $incident->name }}</title>
             <link>{{ route('cachet.status-page.incident', $incident) }}</link>
-            <description><![CDATA[{!! str_replace(']]>', ']]]]><![CDATA[>', $incident->message) !!}]]></description>
-            <guid>{{ $incident->guid }}</guid>
-            <pubDate>{{ $incident->created_at->toRssString() }}</pubDate>
+            <description><![CDATA[
+{{ $incident->created_at->toRssString() }}: {!! str_replace(']]>', ']]]]><![CDATA[>', $incident->formattedMessage()) !!}
+@foreach($incident->updates as $update)
+[{{ $update->status?->getLabel() }}] {{ $update->updated_at->toRssString() }}: {!! str_replace(']]>', ']]]]><![CDATA[>', $update->formattedMessage()) !!}
+@endforeach
+]]></description>
+            <guid isPermaLink="false">{{ $feedVersion }}</guid>
+            <pubDate>{{ $publishedAt->toRssString() }}</pubDate>
         </item>
         @endforeach
     </channel>

--- a/src/Http/Controllers/RssController.php
+++ b/src/Http/Controllers/RssController.php
@@ -4,6 +4,7 @@ namespace Cachet\Http\Controllers;
 
 use Cachet\Models\Incident;
 use Cachet\Settings\AppSettings;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -23,7 +24,7 @@ class RssController
     /**
      * Returns the RSS feed of all incidents.
      */
-    public function __invoke(AppSettings $appSettings): Response
+    public function __invoke(Request $request, AppSettings $appSettings): Response
     {
         $feed = Cache::remember('cachet::rss-feed', self::CACHE_TTL, function () use ($appSettings) {
             return view('cachet::rss', [
@@ -31,7 +32,7 @@ class RssController
                 'statusAbout' => $appSettings->about,
                 'incidents' => Incident::query()
                     ->viewableBy(false)
-                    ->with('updates')
+                    ->with(['updates' => fn ($query) => $query->orderBy('created_at')->orderBy('id')])
                     ->when($appSettings->recent_incidents_only, function ($query) use ($appSettings) {
                         $query->where(function ($query) use ($appSettings) {
                             $query->whereDate(
@@ -53,6 +54,17 @@ class RssController
             ])->render();
         });
 
-        return response($feed)->header('Content-Type', 'application/rss+xml');
+        $lastModified = Cache::remember('cachet::rss-feed-last-modified', self::CACHE_TTL, fn () => now());
+
+        $response = response($feed)
+            ->header('Content-Type', 'application/rss+xml; charset=UTF-8')
+            ->setEtag(hash('sha256', $feed))
+            ->setLastModified($lastModified)
+            ->setPublic()
+            ->setMaxAge(self::CACHE_TTL);
+
+        $response->isNotModified($request);
+
+        return $response;
     }
 }

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 /**
@@ -125,6 +126,9 @@ class Incident extends Model implements Metable
                 $model->published_notified_at = $model->freshTimestamp();
             }
         });
+
+        self::saved(fn () => self::forgetRssFeed());
+        self::deleted(fn () => self::forgetRssFeed());
     }
 
     /**
@@ -265,6 +269,15 @@ class Incident extends Model implements Metable
     protected function latestStatus(): Attribute
     {
         return Attribute::make(get: fn (): ?IncidentStatusEnum => $this->status);
+    }
+
+    /**
+     * Clear the cached RSS feed and its HTTP validators.
+     */
+    private static function forgetRssFeed(): void
+    {
+        Cache::forget('cachet::rss-feed');
+        Cache::forget('cachet::rss-feed-last-modified');
     }
 
     /**

--- a/src/Models/Update.php
+++ b/src/Models/Update.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * @template TUser of Authenticatable
@@ -46,6 +47,12 @@ class Update extends Model
         'user_id',
     ];
 
+    protected static function booted(): void
+    {
+        static::saved(fn (Update $update) => $update->forgetRssFeed());
+        static::deleted(fn (Update $update) => $update->forgetRssFeed());
+    }
+
     /**
      * Get the resource that the update belongs to.
      */
@@ -68,6 +75,17 @@ class Update extends Model
     public function formattedMessage(): string
     {
         return Cachet::markdown($this->message);
+    }
+
+    /**
+     * Clear the RSS feed when an incident update changes its content.
+     */
+    private function forgetRssFeed(): void
+    {
+        if ($this->updateable instanceof Incident) {
+            Cache::forget('cachet::rss-feed');
+            Cache::forget('cachet::rss-feed-last-modified');
+        }
     }
 
     /**

--- a/tests/Feature/RssTest.php
+++ b/tests/Feature/RssTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Cachet\Models\Incident;
+use Cachet\Models\Update;
+use Illuminate\Support\Carbon;
 
 it('can get the rss feed', function () {
     $incident = Incident::factory()->create();
@@ -10,9 +12,55 @@ it('can get the rss feed', function () {
         ->assertSee($incident->name);
 });
 
+it('returns cache validators for the rss feed', function () {
+    Incident::factory()->create();
+
+    $response = $this->get('/status/rss')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/rss+xml; charset=UTF-8')
+        ->assertHeader('Cache-Control', 'max-age=60, public')
+        ->assertHeader('ETag')
+        ->assertHeader('Last-Modified');
+
+    $this->withHeaders(['If-None-Match' => $response->headers->get('ETag')])
+        ->get('/status/rss')
+        ->assertNotModified();
+});
+
+it('updates an incident item when an incident update is added', function () {
+    $incident = Incident::factory()->create([
+        'message' => 'We are **investigating** the issue.',
+    ]);
+
+    $initialFeed = simplexml_load_string($this->get('/status/rss')->assertOk()->getContent());
+    $initialGuid = (string) $initialFeed->channel->item[0]->guid;
+
+    $updatedAt = Carbon::now()->addMinute();
+
+    Update::factory()->forIncident($incident)->create([
+        'message' => 'We [identified](https://example.com) the affected service.',
+        'created_at' => $updatedAt,
+        'updated_at' => $updatedAt,
+    ]);
+
+    $updatedFeed = simplexml_load_string($this->get('/status/rss')->assertOk()->getContent());
+    $item = $updatedFeed->channel->item[0];
+
+    expect((string) $item->description)
+        ->toContain('<strong>investigating</strong>')
+        ->toContain('<a href="https://example.com">identified</a> the affected service.')
+        ->and((string) $item->guid)->not->toBe($initialGuid)
+        ->and((string) $item->guid['isPermaLink'])->toBe('false')
+        ->and((string) $item->pubDate)->toBe($updatedAt->toRssString());
+});
+
 it('produces valid xml when an incident message contains a cdata terminator', function () {
-    Incident::factory()->create([
+    $incident = Incident::factory()->create([
         'message' => 'Something broke: ]]><script>alert(1)</script>',
+    ]);
+
+    Update::factory()->forIncident($incident)->create([
+        'message' => 'Still broken: ]]><script>alert(2)</script>',
     ]);
 
     $response = $this->get('/status/rss')->assertOk();
@@ -21,5 +69,6 @@ it('produces valid xml when an incident message contains a cdata terminator', fu
 
     expect($xml)->not->toBeFalse()
         ->and((string) $xml->channel->item[0]->description)
-        ->toContain(']]><script>alert(1)</script>');
+        ->toContain(']]&gt;alert(1)')
+        ->toContain(']]&gt;alert(2)');
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/cachethq/core/issues/282

- Include incident statuses, formatted messages, and ordered updates in RSS items
- Refresh item identifiers and publication dates when incidents or updates change
- Add ETag, Last-Modified, and public cache headers with conditional response support
- Invalidate cached RSS content when incidents or incident updates are saved or deleted
- Preserve valid XML when messages contain CDATA terminators

## Testing

- Added feature coverage for cache validators and conditional requests
- Added coverage for update-driven feed changes and formatted content
- Added coverage for CDATA-safe XML output