### PR TITLE
Use pinned incident terminology

### DIFF
--- a/resources/lang/de/incident.php
+++ b/resources/lang/de/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Oben anheften',
+            'pinned' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
         'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
-        'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [
             'action_label' => 'Komponente hinzufügen',

--- a/resources/lang/de_AT/incident.php
+++ b/resources/lang/de_AT/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Oben anheften',
+            'pinned' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
         'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
-        'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [
             'action_label' => 'Komponente hinzufügen',

--- a/resources/lang/de_CH/incident.php
+++ b/resources/lang/de_CH/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Sichtbar',
-            'stickied' => 'Oben anheften',
+            'pinned' => 'Oben anheften',
             'occurred_at' => 'Aufgetreten am',
             'published_at' => 'Veröffentlicht am',
             'notified_subscribers' => 'Benachrichtigte Abonnenten',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'Benutzer, welcher den Vorfall gemeldet hat.',
         'notifications_label' => 'Abonnenten benachrichtigen?',
         'pin_incident_label' => 'Vorfall oben auf der Statusseite anheften.',
-        'stickied_label' => 'Vorfall anheften?',
         'guid_label' => 'Vorfall-UUID',
         'add_component' => [
             'action_label' => 'Komponente hinzufügen',

--- a/resources/lang/en/incident.php
+++ b/resources/lang/en/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Name',
             'status' => 'Status',
             'visible' => 'Visible',
-            'stickied' => 'Pin to Top',
+            'pinned' => 'Pin to Top',
             'occurred_at' => 'Occurred at',
             'published_at' => 'Published at',
             'notified_subscribers' => 'Notified subscribers',

--- a/resources/lang/es_ES/incident.php
+++ b/resources/lang/es_ES/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nombre',
             'status' => 'Estado',
             'visible' => 'Visible',
-            'stickied' => 'Fijar arriba',
+            'pinned' => 'Fijar arriba',
             'occurred_at' => 'Ocurrido el',
             'published_at' => 'Publicado el',
             'notified_subscribers' => 'Suscriptores notificados',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'El usuario que reportó el incidente.',
         'notifications_label' => '¿Notificar a los suscriptores?',
         'pin_incident_label' => 'Fijar el incidente en la parte superior de la página de estado.',
-        'stickied_label' => '¿Incidente fijado?',
         'guid_label' => 'UUID del Incidente',
         'add_component' => [
             'action_label' => 'Añadir Componente',

--- a/resources/lang/fr/incident.php
+++ b/resources/lang/fr/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nom',
             'status' => 'Statut',
             'visible' => 'Visible',
-            'stickied' => 'Épingler en haut',
+            'pinned' => 'Épingler en haut',
             'occurred_at' => 'Survenu le',
             'published_at' => 'Publié le',
             'notified_subscribers' => 'Abonnés notifiés',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'L’utilisateur ayant signalé l’incident.',
         'notifications_label' => 'Notifier les abonnés ?',
         'pin_incident_label' => 'Épingler l’incident en haut de la page d’état.',
-        'stickied_label' => 'Incident épinglé ?',
         'guid_label' => 'UUID de l’incident',
         'add_component' => [
             'action_label' => 'Ajouter un composant',

--- a/resources/lang/ko/incident.php
+++ b/resources/lang/ko/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => '이름',
             'status' => '상태',
             'visible' => '표시 여부',
-            'stickied' => '상단에 고정',
+            'pinned' => '상단에 고정',
             'occurred_at' => '발생 시간',
             'published_at' => '게시 시간',
             'notified_subscribers' => '구독자 알림 여부',
@@ -64,7 +64,6 @@ return [
         'user_helper' => '사고를 보고한 사용자입니다.',
         'notifications_label' => '구독자에게 알림을 보내시겠습니까?',
         'pin_incident_label' => '상태 페이지 상단에 사고를 고정합니다.',
-        'stickied_label' => '사고를 고정하시겠습니까?',
         'guid_label' => '사고 UUID',
         'add_component' => [
             'action_label' => '구성 요소 추가',

--- a/resources/lang/nl/incident.php
+++ b/resources/lang/nl/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Naam',
             'status' => 'Toestand',
             'visible' => 'Zichtbaar',
-            'stickied' => 'Bovenaan vastpinnen',
+            'pinned' => 'Bovenaan vastpinnen',
             'occurred_at' => 'Voorgekomen op',
             'published_at' => 'Gepubliceerd op',
             'notified_subscribers' => 'Geïnformeerde abonnees',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'Gebruiker die het incident heeft gemeld.',
         'notifications_label' => 'Abonnees op de hoogte stellen?',
         'pin_incident_label' => 'Het incident bovenaan de statuspagina vastpinnen.',
-        'stickied_label' => 'Pin-incident?',
         'guid_label' => 'Incident-UUID',
         'add_component' => [
             'action_label' => 'Component toevoegen',

--- a/resources/lang/ph/incident.php
+++ b/resources/lang/ph/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Pangalan',
             'status' => 'Kalagayan',
             'visible' => 'Nakikita',
-            'stickied' => 'I-pin sa itaas',
+            'pinned' => 'I-pin sa itaas',
             'occurred_at' => 'Nangyari noong',
             'published_at' => 'Nai-publish noong',
             'notified_subscribers' => 'Naabisuhan ang mga subscriber',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'Ang gumagamit na nag-ulat ng insidente.',
         'notifications_label' => 'Abisuhan ang mga Subscriber?',
         'pin_incident_label' => 'I-pin ang insidente sa itaas ng status page.',
-        'stickied_label' => 'Gawing Sticky ang Insidente?',
         'guid_label' => 'Incident UUID',
         'add_component' => [
             'action_label' => 'Magdagdag ng Komponent',

--- a/resources/lang/pt_BR/incident.php
+++ b/resources/lang/pt_BR/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => 'Nome',
             'status' => 'Status',
             'visible' => 'Visível',
-            'stickied' => 'Fixar no topo',
+            'pinned' => 'Fixar no topo',
             'occurred_at' => 'Ocorrido em',
             'published_at' => 'Publicado em',
             'notified_subscribers' => 'Inscritos notificados',
@@ -64,7 +64,6 @@ return [
         'user_helper' => 'O usuário que reportou o incidente.',
         'notifications_label' => 'Notificar Inscritos?',
         'pin_incident_label' => 'Fixar o incidente no topo da página de status.',
-        'stickied_label' => 'Fixar Incidente?',
         'guid_label' => 'UUID do Incidente',
         'add_component' => [
             'action_label' => 'Adicionar Componente',

--- a/resources/lang/zh_CN/incident.php
+++ b/resources/lang/zh_CN/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => '名称',
             'status' => '状态',
             'visible' => '可见',
-            'stickied' => '置顶',
+            'pinned' => '置顶',
             'occurred_at' => '发生时间',
             'published_at' => '发布时间',
             'notified_subscribers' => '已通知的订阅者',
@@ -64,7 +64,6 @@ return [
         'user_helper' => '报告事件的用户。',
         'notifications_label' => '通知订阅者？',
         'pin_incident_label' => '将事件置顶到状态页面顶部。',
-        'stickied_label' => '置顶事件？',
         'guid_label' => '事件 UUID',
         'add_component' => [
             'action_label' => '添加组件',

--- a/resources/lang/zh_TW/incident.php
+++ b/resources/lang/zh_TW/incident.php
@@ -30,7 +30,7 @@ return [
             'name' => '名稱',
             'status' => '狀態',
             'visible' => '可見',
-            'stickied' => '置頂',
+            'pinned' => '置頂',
             'occurred_at' => '發生時間',
             'published_at' => '發布時間',
             'notified_subscribers' => '已通知的訂閱者',
@@ -64,7 +64,6 @@ return [
         'user_helper' => '報告事件的用戶。',
         'notifications_label' => '通知訂閱者？',
         'pin_incident_label' => '將事件置頂到狀態頁面頂部。',
-        'stickied_label' => '置頂事件？',
         'guid_label' => '事件 UUID',
         'add_component' => [
             'action_label' => '添加組件',

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -177,7 +177,7 @@ class IncidentResource extends Resource
                     ->sortable()
                     ->badge(),
                 IconColumn::make('stickied')
-                    ->label(__('cachet::incident.list.headers.stickied'))
+                    ->label(__('cachet::incident.list.headers.pinned'))
                     ->toggleable(isToggledHiddenByDefault: true)
                     ->boolean(),
                 TextColumn::make('occurred_at')

--- a/src/Mcp/Tools/Incidents/CreateIncident.php
+++ b/src/Mcp/Tools/Incidents/CreateIncident.php
@@ -38,7 +38,7 @@ class CreateIncident extends Tool
             'template' => $schema->string()->description('The slug of an incident template to render the message from.'),
             'template_vars' => $schema->object()->description('Variables passed to the incident template.'),
             'visible' => $schema->boolean()->default(false)->description('Whether the incident is visible to guests.'),
-            'stickied' => $schema->boolean()->default(false)->description('Whether the incident is stickied to the top of the status page.'),
+            'stickied' => $schema->boolean()->default(false)->description('Whether the incident is pinned to the top of the status page.'),
             'notifications' => $schema->boolean()->default(false)->description('Whether to notify verified subscribers.'),
             'occurred_at' => $schema->string()->description('When the incident occurred, as an ISO-8601 datetime. Defaults to now.'),
             'published_at' => $schema->string()->description('When to publish the incident, as an ISO-8601 datetime. While set in the future the incident is hidden from the status page and public API. Defaults to published immediately.'),

--- a/src/Mcp/Tools/Incidents/UpdateIncident.php
+++ b/src/Mcp/Tools/Incidents/UpdateIncident.php
@@ -38,7 +38,7 @@ class UpdateIncident extends Tool
                 ->enum(array_column(IncidentStatusEnum::cases(), 'value'))
                 ->description('The status: 0 unknown, 1 investigating, 2 identified, 3 watching, 4 fixed.'),
             'visible' => $schema->boolean()->description('Whether the incident is visible to guests.'),
-            'stickied' => $schema->boolean()->description('Whether the incident is stickied to the top of the status page.'),
+            'stickied' => $schema->boolean()->description('Whether the incident is pinned to the top of the status page.'),
             'notifications' => $schema->boolean()->description('Whether to notify verified subscribers.'),
             'occurred_at' => $schema->string()->description('When the incident occurred, as an ISO-8601 datetime.'),
             'published_at' => $schema->string()->description('When to publish the incident, as an ISO-8601 datetime. While set in the future the incident is hidden from the status page and public API.'),


### PR DESCRIPTION
## Summary

Uses “pinned” consistently in human-facing incident copy while preserving the existing `stickied` storage and API field.

## Changes

- renames the admin table translation key to `pinned`
- removes unused legacy `stickied_label` translations
- updates MCP field descriptions to describe pinned behavior

## Validation

- `composer test:lint`
- PHP syntax checks for every edited file
- `composer test:unit` could not start because the local `pest` executable is unavailable