### PR TITLE
Fix upcoming schedule status filter

### DIFF
--- a/src/Enums/ScheduleStatusEnum.php
+++ b/src/Enums/ScheduleStatusEnum.php
@@ -25,13 +25,12 @@ enum ScheduleStatusEnum: int implements HasColor, HasIcon, HasLabel
     }
 
     /**
-     * Get the statuses that are in upcoming.
+     * Get the statuses that are upcoming.
      */
     public static function upcoming(): array
     {
         return [
             self::upcoming->value,
-            self::in_progress->value,
         ];
     }
 

--- a/tests/Unit/ScheduleStatusEnumTest.php
+++ b/tests/Unit/ScheduleStatusEnumTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Cachet\Enums\ScheduleStatusEnum;
+
+it('returns only the upcoming status from upcoming', function () {
+    expect(ScheduleStatusEnum::upcoming())->toBe([
+        ScheduleStatusEnum::upcoming->value,
+    ]);
+});


### PR DESCRIPTION
## Summary

- make `ScheduleStatusEnum::upcoming()` return only the upcoming status value
- add a regression test covering the enum helper

## Root cause

The `upcoming()` helper duplicated the values returned by `incomplete()`, so in-progress schedules were incorrectly included where only upcoming schedules were requested.

## Impact

Consumers can now distinguish upcoming schedules from all incomplete schedules.

Fixes #340

## Validation

- `vendor/bin/pest tests/Unit/ScheduleStatusEnumTest.php`
- `composer test:lint`