### PR TITLE
Fix legacy incident component attachment

### DIFF
--- a/src/Actions/Incident/CreateIncident.php
+++ b/src/Actions/Incident/CreateIncident.php
@@ -36,13 +36,18 @@ class CreateIncident
                 ['guid' => Str::uuid()],
                 $data->except('components', 'meta')->toArray()
             )), function (Incident $incident) use ($data) {
-                if ($data->components) {
-                    $components = collect($data->components)
-                        ->mapWithKeys(fn (IncidentComponentRequestData $component) => [
-                            $component->id => ['component_status' => $component->status],
-                        ])
-                        ->all();
+                $components = collect($data->components)
+                    ->mapWithKeys(fn (IncidentComponentRequestData $component) => [
+                        $component->id => ['component_status' => $component->status],
+                    ]);
 
+                if ($data->componentId !== null) {
+                    $components->put($data->componentId, [
+                        'component_status' => $data->componentStatus,
+                    ]);
+                }
+
+                if ($components->isNotEmpty()) {
                     $incident->components()->sync($components);
                 }
 

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -358,6 +358,32 @@ it('can create an incident with components', function () {
     expect($response->json('data.relationships.components.data'))->toHaveCount(2);
 });
 
+it('can create an incident with a legacy component payload', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
+
+    $component = Component::factory()->create();
+
+    $response = postJson('/status/api/incidents?include=components', [
+        'name' => 'Incident With Legacy Component',
+        'message' => 'Something went wrong.',
+        'status' => IncidentStatusEnum::investigating->value,
+        'component_id' => $component->id,
+        'component_status' => ComponentStatusEnum::major_outage->value,
+    ]);
+
+    $response->assertCreated();
+
+    $incident = Incident::where('name', 'Incident With Legacy Component')->firstOrFail();
+
+    $this->assertDatabaseHas('incident_components', [
+        'incident_id' => $incident->id,
+        'component_id' => $component->id,
+        'component_status' => ComponentStatusEnum::major_outage->value,
+    ]);
+
+    expect($response->json('data.relationships.components.data'))->toHaveCount(1);
+});
+
 it('cannot create an incident with a template that does not exist', function () {
     Sanctum::actingAs(User::factory()->create(), ['incidents.manage']);
 


### PR DESCRIPTION
## Summary

- attach the legacy `component_id` / `component_status` payload to the incident's component pivot
- retain support for the existing multi-component request payload
- add an API regression test covering the legacy request

## Root cause

The create action validated the legacy fields but only synchronized components supplied through the `components` array, leaving the legacy component unattached.

Closes cachethq/cachet#4611

## Validation

- `vendor/bin/pest tests/Feature/Api/IncidentTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse --memory-limit=1G`