### PR TITLE
Add affected components to demo schedules

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -58,7 +58,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         /** @phpstan-ignore-next-line  argument.type */
-        tap(Schedule::create([
+        $documentationMaintenance = tap(Schedule::create([
             'name' => 'Documentation Maintenance',
             'message' => 'We will be conducting maintenance on our documentation servers. You may experience degraded performance during this time.',
             'scheduled_at' => now()->addHours(24),
@@ -79,7 +79,7 @@ EOF
         });
 
         /** @phpstan-ignore-next-line  argument.type */
-        tap(Schedule::create([
+        $databaseUpgrade = tap(Schedule::create([
             'name' => 'Database Server Upgrade',
             'message' => 'We upgraded our primary database servers to improve performance and reliability.',
             'scheduled_at' => now()->subHours(26),
@@ -136,6 +136,14 @@ EOF
             'link' => 'https://artisan.page',
             'status' => ComponentStatusEnum::operational,
             'checked' => true,
+        ]);
+
+        $documentationMaintenance->components()->attach($documentation, [
+            'component_status' => ComponentStatusEnum::performance_issues,
+        ]);
+
+        $databaseUpgrade->components()->attach($website, [
+            'component_status' => ComponentStatusEnum::partial_outage,
         ]);
 
         $metric = Metric::create([

--- a/tests/Unit/Database/DatabaseSeederTest.php
+++ b/tests/Unit/Database/DatabaseSeederTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Cachet\Database\Seeders\DatabaseSeeder;
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Models\Schedule;
+
+it('assigns affected components to the demo maintenance schedules', function () {
+    $this->seed(DatabaseSeeder::class);
+
+    $documentationMaintenance = Schedule::query()
+        ->where('name', 'Documentation Maintenance')
+        ->firstOrFail();
+    $databaseUpgrade = Schedule::query()
+        ->where('name', 'Database Server Upgrade')
+        ->firstOrFail();
+
+    expect($documentationMaintenance->components)
+        ->toHaveCount(1)
+        ->first()->name->toBe('Cachet Documentation')
+        ->and($documentationMaintenance->components->first()->pivot->component_status)
+        ->toBe(ComponentStatusEnum::performance_issues)
+        ->and($databaseUpgrade->components)
+        ->toHaveCount(1)
+        ->first()->name->toBe('Cachet Website')
+        ->and($databaseUpgrade->components->first()->pivot->component_status)
+        ->toBe(ComponentStatusEnum::partial_outage);
+});


### PR DESCRIPTION
## Summary

- Associate the documentation maintenance demo schedule with Cachet Documentation.
- Associate the database upgrade demo schedule with Cachet Website.
- Cover the seeded component links and their maintenance statuses with a regression test.

## Why

The demo seeder created maintenance schedules without attaching their affected components, despite the existing schedule-component relationship and UI support.

## Validation

- `vendor/bin/pest tests/Unit/Database/DatabaseSeederTest.php`
- `vendor/bin/pint --test database/seeders/DatabaseSeeder.php tests/Unit/Database/DatabaseSeederTest.php`