### PR TITLE
Fix PostgreSQL enum column padding

### DIFF
--- a/database/migrations/2023_09_18_105838_add_engine_column_to_incident_templates_table.php
+++ b/database/migrations/2023_09_18_105838_add_engine_column_to_incident_templates_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -12,7 +13,11 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('incident_templates', function (Blueprint $table) {
-            $table->char('engine')->default('twig')->after('template');
+            if (DB::getDriverName() === 'pgsql') {
+                $table->string('engine')->default('twig')->after('template');
+            } else {
+                $table->char('engine')->default('twig')->after('template');
+            }
         });
     }
 };

--- a/database/migrations/2025_01_21_121458_add_ordering_cols_to_component_groups_table.php
+++ b/database/migrations/2025_01_21_121458_add_ordering_cols_to_component_groups_table.php
@@ -15,7 +15,11 @@ return new class extends Migration
     {
         Schema::table('component_groups', function (Blueprint $table) {
             $table->string('order_column')->nullable()->after('order');
-            $table->char('order_direction', 4)->nullable()->after('order_column');
+            if (DB::getDriverName() === 'pgsql') {
+                $table->string('order_direction', 4)->nullable()->after('order_column');
+            } else {
+                $table->char('order_direction', 4)->nullable()->after('order_column');
+            }
         });
 
         DB::table('component_groups')->update(['order_column' => ResourceOrderColumnEnum::Manual->value]);

--- a/database/migrations/2026_08_09_000001_change_enum_char_columns_to_varchar_on_postgres.php
+++ b/database/migrations/2026_08_09_000001_change_enum_char_columns_to_varchar_on_postgres.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        Schema::table('component_groups', function (Blueprint $table) {
+            $table->string('order_direction', 4)->nullable()->change();
+        });
+
+        Schema::table('incident_templates', function (Blueprint $table) {
+            $table->string('engine')->default('twig')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        Schema::table('component_groups', function (Blueprint $table) {
+            $table->char('order_direction', 4)->nullable()->change();
+        });
+
+        Schema::table('incident_templates', function (Blueprint $table) {
+            $table->char('engine')->default('twig')->change();
+        });
+    }
+};

--- a/tests/Feature/Api/ComponentGroupTest.php
+++ b/tests/Feature/Api/ComponentGroupTest.php
@@ -367,6 +367,20 @@ it('exposes the order column and direction in the resource', function () {
     ]);
 });
 
+it('exposes an ascending order direction in the resource', function () {
+    $componentGroup = ComponentGroup::factory()
+        ->orderedBy(ResourceOrderColumnEnum::Name, ResourceOrderDirectionEnum::Asc)
+        ->create();
+
+    $response = getJson('/status/api/component-groups/'.$componentGroup->id);
+
+    $response->assertOk();
+    $response->assertJsonFragment([
+        'order_column' => ResourceOrderColumnEnum::Name->value,
+        'order_direction' => ResourceOrderDirectionEnum::Asc->value,
+    ]);
+});
+
 it('can create a component group with a manual order column', function () {
     Sanctum::actingAs(User::factory()->create(), ['component-groups.manage']);
 


### PR DESCRIPTION
## Summary

Fixes PostgreSQL space padding on enum-backed `CHAR` columns while preserving `CHAR` for MySQL and SQLite.

- Use `VARCHAR` for the affected PostgreSQL columns in fresh installs.
- Convert existing PostgreSQL columns with an upgrade migration.
- Cover the padded `asc` enum value in the component-group API resource.

Closes #423

## Validation

- `vendor/bin/pint --dirty`
- `vendor/bin/pest tests/Feature/Api/ComponentGroupTest.php tests/Feature/StatusPage/ComponentGroupOrderingTest.php` (47 passed)

`composer test:unit` was attempted but could not complete due to the existing 128 MB memory limit in an unrelated migration worker.