### PR TITLE
Fix status overview dark mode styles

### DIFF
--- a/resources/css/cachet.css
+++ b/resources/css/cachet.css
@@ -148,25 +148,29 @@
     }
   }
 
-  .dark .status-header {
-    background: rgb(24 24 27 / 66%);
-  }
+  @media (prefers-color-scheme: dark) {
+    .status-header {
+      border-color: rgb(255 255 255 / 14%);
+      background: rgb(24 24 27 / 66%);
+    }
 
-  .dark .status-overview {
-    border-color: rgb(255 255 255 / 14%);
-    background: rgb(24 24 27 / 76%);
-  }
+    .status-overview {
+      border-color: rgb(255 255 255 / 14%);
+      background: rgb(24 24 27 / 76%);
+      box-shadow: 0 12px 28px -24px rgb(0 0 0 / 60%);
+    }
 
-  .dark .status-overview__masthead,
-  .dark .status-summary {
-    border-color: rgb(255 255 255 / 14%);
-  }
+    .status-overview__masthead,
+    .status-summary {
+      border-color: rgb(255 255 255 / 14%);
+    }
 
-  .dark .status-summary {
-    background: linear-gradient(
-      115deg,
-      color-mix(in srgb, var(--color-400) 20%, rgb(24 24 27)),
-      color-mix(in srgb, var(--color-400) 34%, rgb(24 24 27))
-    );
+    .status-summary {
+      background: linear-gradient(
+        115deg,
+        color-mix(in srgb, var(--color-400) 20%, rgb(24 24 27)),
+        color-mix(in srgb, var(--color-400) 34%, rgb(24 24 27))
+      );
+    }
   }
 }


### PR DESCRIPTION
Fix the dark mode styles from #420. It never got applied because it was scoped to a .dark class the status page doesn't use (no manual toggle based mode). Re-scoped them to `prefers-color-scheme`, so the overview card, status summary and header now render correctly instead of showing white-on-white text.