### PR TITLE
Configure trusted proxies

### DIFF
--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -39,6 +39,7 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
@@ -82,6 +83,18 @@ class CachetCoreServiceProvider extends ServiceProvider
     }
 
     /**
+     * Configure Laravel to respect forwarded request headers from Cachet's trusted proxies.
+     */
+    private function configureTrustedProxies(): void
+    {
+        $trustedProxies = config('cachet.trusted_proxies');
+
+        if ($trustedProxies) {
+            TrustProxies::at($trustedProxies);
+        }
+    }
+
+    /**
      * Bootstrap any application services.
      */
     public function boot(): void
@@ -89,6 +102,8 @@ class CachetCoreServiceProvider extends ServiceProvider
         if (! $this->app->configurationIsCached()) {
             $this->mergeConfigFrom(__DIR__.'/../config/cachet.php', 'cachet');
         }
+
+        $this->configureTrustedProxies();
 
         Route::middlewareGroup('cachet', config('cachet.middleware', []));
         Route::middlewareGroup('cachet:api', config('cachet.api_middleware', []));

--- a/tests/Feature/TrustedProxiesTest.php
+++ b/tests/Feature/TrustedProxiesTest.php
@@ -11,6 +11,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TrustedProxiesTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        TrustProxies::flushState();
+
+        parent::tearDown();
+    }
+
     protected function trustAllProxies(Application $app): void
     {
         $app['config']->set('cachet.trusted_proxies', '*');

--- a/tests/Feature/TrustedProxiesTest.php
+++ b/tests/Feature/TrustedProxiesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cachet\Tests\Feature;
+
+use Cachet\Tests\TestCase;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use Symfony\Component\HttpFoundation\Response;
+
+class TrustedProxiesTest extends TestCase
+{
+    protected function trustAllProxies(Application $app): void
+    {
+        $app['config']->set('cachet.trusted_proxies', '*');
+    }
+
+    #[DefineEnvironment('trustAllProxies')]
+    public function test_it_respects_the_forwarded_scheme_from_trusted_proxies(): void
+    {
+        $request = Request::create('/', server: [
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ]);
+
+        app(TrustProxies::class)->handle($request, function (Request $request): Response {
+            $this->assertTrue($request->isSecure());
+
+            return new Response;
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- configure Laravel's built-in proxy middleware from `CACHET_TRUSTED_PROXIES`
- preserve `*` so forwarded HTTPS schemes are trusted correctly
- add regression coverage for HTTPS forwarded by a trusted proxy

## Root cause

The Cachet application converted `*` to `['*']`, which Laravel treats as a literal IP instead of its all-proxies wildcard. That caused Livewire to generate HTTP update URLs behind TLS-terminating proxies.

## Validation

- `vendor/bin/pest tests/Feature/TrustedProxiesTest.php`
- `vendor/bin/pint --test`

The full Core suite was also attempted, but the environment's 128 MB PHP memory limit exhausted in unrelated tests.