### PR TITLE
Add status page badges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": "^8.3",
         "ext-simplexml": "*",
+        "cachethq/badger": "^5.0",
         "doctrine/dbal": "^3.6",
         "filament/filament": "^5.0",
         "filament/spatie-laravel-settings-plugin": "^5.0",

--- a/src/CachetCoreServiceProvider.php
+++ b/src/CachetCoreServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Cachet;
 
 use BladeUI\Icons\Factory;
+use Cachet\Badger\BadgerServiceProvider;
 use Cachet\Commands\AssetsCommand;
 use Cachet\Commands\CheckComponentsCommand;
 use Cachet\Commands\MakeUserCommand;
@@ -64,6 +65,7 @@ class CachetCoreServiceProvider extends ServiceProvider
         $this->app->singleton(Cachet::class);
         $this->app->singleton(ViewManager::class);
         $this->app->scoped(Status::class);
+        $this->app->register(BadgerServiceProvider::class);
 
         $this->configureSettingsCache();
     }

--- a/src/Enums/ComponentStatusEnum.php
+++ b/src/Enums/ComponentStatusEnum.php
@@ -79,6 +79,18 @@ enum ComponentStatusEnum: int implements HasColor, HasIcon, HasLabel
         };
     }
 
+    public function getBadgeColor(): string
+    {
+        return match ($this) {
+            self::operational => 'brightgreen',
+            self::performance_issues => 'yellow',
+            self::partial_outage => 'orange',
+            self::major_outage => 'red',
+            self::under_maintenance => 'orange',
+            self::unknown => 'lightgray',
+        };
+    }
+
     public function getColor(): array
     {
         return match ($this) {

--- a/src/Enums/SystemStatusEnum.php
+++ b/src/Enums/SystemStatusEnum.php
@@ -34,6 +34,16 @@ enum SystemStatusEnum implements HasColor, HasIcon, HasLabel
         };
     }
 
+    public function getBadgeColor(): string
+    {
+        return match ($this) {
+            self::operational => 'brightgreen',
+            self::partial_outage => 'orange',
+            self::major_outage => 'red',
+            self::under_maintenance => 'orange',
+        };
+    }
+
     public function getIcon(): string
     {
         return match ($this) {

--- a/src/Http/BadgeResponseFactory.php
+++ b/src/Http/BadgeResponseFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cachet\Http;
+
+use Cachet\Badger\BadgeImage;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class BadgeResponseFactory
+{
+    /**
+     * Build a cacheable SVG response.
+     */
+    public function make(BadgeImage $badge): Response
+    {
+        return response((string) $badge, 200, [
+            'Cache-Control' => 'public, max-age=60, s-maxage=60',
+            'Content-Type' => 'image/svg+xml; charset=UTF-8',
+        ]);
+    }
+
+    /**
+     * Return the requested style, falling back to the default for unsupported values.
+     */
+    public function style(Request $request): string
+    {
+        $style = $request->string('style', 'flat-square')->value();
+
+        return in_array($style, ['flat-square', 'plastic-flat', 'flat', 'plastic', 'social', 'svg'], true)
+            ? $style
+            : 'flat-square';
+    }
+}

--- a/src/Http/Controllers/StatusPage/ComponentBadgeController.php
+++ b/src/Http/Controllers/StatusPage/ComponentBadgeController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cachet\Http\Controllers\StatusPage;
+
+use Cachet\Badger\Badger;
+use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Http\BadgeResponseFactory;
+use Cachet\Models\Component;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class ComponentBadgeController
+{
+    /**
+     * Render a badge for a publicly visible component.
+     */
+    public function __invoke(Request $request, Component $component, Badger $badger, BadgeResponseFactory $badgeResponseFactory): Response
+    {
+        $component->loadMissing('group');
+
+        abort_if(! $component->enabled || ($component->group?->visible !== null && $component->group->visible !== ResourceVisibilityEnum::guest), 404);
+
+        return $badgeResponseFactory->make(
+            $badger->generate(
+                $component->name,
+                $component->latest_status->getLabel(),
+                $component->latest_status->getBadgeColor(),
+                $badgeResponseFactory->style($request),
+            ),
+        );
+    }
+}

--- a/src/Http/Controllers/StatusPage/StatusBadgeController.php
+++ b/src/Http/Controllers/StatusPage/StatusBadgeController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Cachet\Http\Controllers\StatusPage;
+
+use Cachet\Badger\Badger;
+use Cachet\Http\BadgeResponseFactory;
+use Cachet\Status;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class StatusBadgeController
+{
+    /**
+     * Render a badge for the status page's current system status.
+     */
+    public function __invoke(Request $request, Status $status, Badger $badger, BadgeResponseFactory $badgeResponseFactory): Response
+    {
+        $systemStatus = $status->current();
+
+        return $badgeResponseFactory->make(
+            $badger->generate('status', $systemStatus->getLabel(), $systemStatus->getBadgeColor(), $badgeResponseFactory->style($request)),
+        );
+    }
+}

--- a/src/PendingRouteRegistration.php
+++ b/src/PendingRouteRegistration.php
@@ -6,6 +6,8 @@ use Cachet\Http\Controllers\Auth\VerifyEmailController;
 use Cachet\Http\Controllers\HealthController;
 use Cachet\Http\Controllers\RssController;
 use Cachet\Http\Controllers\Setup\SetupController;
+use Cachet\Http\Controllers\StatusPage\ComponentBadgeController;
+use Cachet\Http\Controllers\StatusPage\StatusBadgeController;
 use Cachet\Http\Controllers\StatusPage\StatusPageController;
 use Cachet\Http\Controllers\Subscribers\SubscriberController;
 use Cachet\Http\Controllers\Subscribers\UnsubscribeSubscriberController;
@@ -36,6 +38,8 @@ class PendingRouteRegistration
                 $router->get('/', [StatusPageController::class, 'index'])->name('status-page');
                 $router->get('/incidents/{incident:guid}', [StatusPageController::class, 'show'])->name('status-page.incident');
                 $router->get('/schedules/{schedule}', [StatusPageController::class, 'schedule'])->name('status-page.schedule');
+                $router->get('/badge.svg', StatusBadgeController::class)->name('status-page.badge');
+                $router->get('/components/{component}/badge.svg', ComponentBadgeController::class)->name('status-page.component.badge');
 
                 $router->get('/setup', [SetupController::class, 'index'])->name('setup.index');
                 $router->post('/setup', [SetupController::class, 'store'])->name('setup.store');

--- a/tests/Feature/StatusPage/StatusPageTest.php
+++ b/tests/Feature/StatusPage/StatusPageTest.php
@@ -14,6 +14,50 @@ it('renders the status page', function () {
         ->assertOk();
 });
 
+it('renders an SVG badge for the overall status page status', function () {
+    Component::factory()->create(['status' => ComponentStatusEnum::operational]);
+
+    $response = $this->get(route('cachet.status-page.badge'))
+        ->assertOk()
+        ->assertHeader('content-type', 'image/svg+xml; charset=UTF-8')
+        ->assertSee('<svg', escape: false)
+        ->assertSee('All systems are operational.');
+
+    expect($response->headers->get('cache-control'))
+        ->toContain('public')
+        ->toContain('max-age=60')
+        ->toContain('s-maxage=60');
+});
+
+it('renders an SVG badge for a public component', function () {
+    $component = Component::factory()->create([
+        'name' => 'Public API',
+        'status' => ComponentStatusEnum::major_outage,
+    ]);
+
+    $this->get(route('cachet.status-page.component.badge', $component))
+        ->assertOk()
+        ->assertHeader('content-type', 'image/svg+xml; charset=UTF-8')
+        ->assertSee('<svg', escape: false)
+        ->assertSee('Public API')
+        ->assertSee('Major outage');
+});
+
+it('does not render a badge for a component in a private group', function () {
+    $group = ComponentGroup::factory()->create(['visible' => 0]);
+    $component = Component::factory()->create(['component_group_id' => $group->id]);
+
+    $this->get(route('cachet.status-page.component.badge', $component))
+        ->assertNotFound();
+});
+
+it('does not render a badge for a disabled component', function () {
+    $component = Component::factory()->create(['enabled' => false]);
+
+    $this->get(route('cachet.status-page.component.badge', $component))
+        ->assertNotFound();
+});
+
 it('can hide the site name and about content without changing status page metadata', function () {
     $settings = app(AppSettings::class);
     $settings->name = 'Acme Status';

--- a/tests/Unit/StatusBadgeColorTest.php
+++ b/tests/Unit/StatusBadgeColorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\SystemStatusEnum;
+
+it('maps component statuses to badge colors', function (ComponentStatusEnum $status, string $color) {
+    expect($status->getBadgeColor())->toBe($color);
+})->with([
+    [ComponentStatusEnum::operational, 'brightgreen'],
+    [ComponentStatusEnum::performance_issues, 'yellow'],
+    [ComponentStatusEnum::partial_outage, 'orange'],
+    [ComponentStatusEnum::major_outage, 'red'],
+    [ComponentStatusEnum::unknown, 'lightgray'],
+    [ComponentStatusEnum::under_maintenance, 'orange'],
+]);
+
+it('maps system statuses to badge colors', function (SystemStatusEnum $status, string $color) {
+    expect($status->getBadgeColor())->toBe($color);
+})->with([
+    [SystemStatusEnum::operational, 'brightgreen'],
+    [SystemStatusEnum::partial_outage, 'orange'],
+    [SystemStatusEnum::major_outage, 'red'],
+    [SystemStatusEnum::under_maintenance, 'orange'],
+]);


### PR DESCRIPTION
## Summary

Adds cacheable SVG badges for the overall status page and individual public components.

- Introduces `/badge.svg` and `/components/{component}/badge.svg` beneath the configured Cachet path.
- Uses Badger 5.0 to generate SVG output, with supported style selection via `?style=`.
- Uses dedicated invokable controllers for system and component badges.
- Keeps status-to-badge-color mappings on the relevant enums, with unit coverage.
- Returns 404 for disabled components and components in non-public groups.

## Validation

- `vendor/bin/pest tests/Feature/StatusPage/StatusPageTest.php tests/Unit/StatusBadgeColorTest.php --compact` (33 passed)
- `vendor/bin/pint` for changed files
- `composer validate --no-check-publish`

The full parallel test command was also attempted earlier but an unrelated subscriber test worker exceeded its fixed 128 MB memory limit.