### PR TITLE
Include incident and schedule activity in status page 'last updated' timestamp

### DIFF
--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -12,6 +12,7 @@ use Cachet\Events\Components\ComponentCreated;
 use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
 use Cachet\QueryBuilders\ScheduleBuilder;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -89,6 +90,15 @@ class Component extends Model implements Metable
         'deleted' => ComponentDeleted::class,
         'updated' => ComponentUpdated::class,
     ];
+
+    /**
+     * Keep the cached status-page aggregates in step with component changes.
+     */
+    protected static function booted(): void
+    {
+        static::saved(fn () => Status::flush());
+        static::deleted(fn () => Status::flush());
+    }
 
     /**
      * Render the Markdown description.

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -13,6 +13,7 @@ use Cachet\Events\Components\ComponentCreated;
 use Cachet\Events\Components\ComponentDeleted;
 use Cachet\Events\Components\ComponentUpdated;
 use Cachet\QueryBuilders\ScheduleBuilder;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -91,6 +92,15 @@ class Component extends Model implements Metable
         'deleted' => ComponentDeleted::class,
         'updated' => ComponentUpdated::class,
     ];
+
+    /**
+     * Keep the cached status-page aggregates in step with component changes.
+     */
+    protected static function booted(): void
+    {
+        static::saved(fn () => Status::flush());
+        static::deleted(fn () => Status::flush());
+    }
 
     /**
      * Render the Markdown description.

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -14,6 +14,7 @@ use Cachet\Events\Incidents\IncidentCreated;
 use Cachet\Events\Incidents\IncidentDeleted;
 use Cachet\Events\Incidents\IncidentUpdated;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
@@ -127,8 +128,15 @@ class Incident extends Model implements Metable
             }
         });
 
-        self::saved(fn () => self::forgetRssFeed());
-        self::deleted(fn () => self::forgetRssFeed());
+        self::saved(function (): void {
+            self::forgetRssFeed();
+            Status::flush();
+        });
+
+        self::deleted(function (): void {
+            self::forgetRssFeed();
+            Status::flush();
+        });
     }
 
     /**

--- a/src/Models/Incident.php
+++ b/src/Models/Incident.php
@@ -15,6 +15,7 @@ use Cachet\Events\Incidents\IncidentCreated;
 use Cachet\Events\Incidents\IncidentDeleted;
 use Cachet\Events\Incidents\IncidentUpdated;
 use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
@@ -129,8 +130,15 @@ class Incident extends Model implements Metable
             }
         });
 
-        self::saved(fn () => self::forgetRssFeed());
-        self::deleted(fn () => self::forgetRssFeed());
+        self::saved(function (): void {
+            self::forgetRssFeed();
+            Status::flush();
+        });
+
+        self::deleted(function (): void {
+            self::forgetRssFeed();
+            Status::flush();
+        });
     }
 
     /**

--- a/src/Models/IncidentComponent.php
+++ b/src/Models/IncidentComponent.php
@@ -4,6 +4,7 @@ namespace Cachet\Models;
 
 use Cachet\Database\Factories\IncidentComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -33,6 +34,16 @@ class IncidentComponent extends Pivot
     protected $casts = [
         'component_status' => ComponentStatusEnum::class,
     ];
+
+    /**
+     * Attaching or detaching a component changes its effective status, so the
+     * cached status-page aggregates are flushed alongside.
+     */
+    protected static function booted(): void
+    {
+        static::saved(fn () => Status::flush());
+        static::deleted(fn () => Status::flush());
+    }
 
     /**
      * Get the incident the component is attached to.

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -12,6 +12,7 @@ use Cachet\Concerns\Publishable;
 use Cachet\Database\Factories\ScheduleFactory;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\QueryBuilders\ScheduleBuilder;
+use Cachet\Status;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -71,6 +72,9 @@ class Schedule extends Model implements Metable
                 $schedule->published_notified_at = $schedule->freshTimestamp();
             }
         });
+
+        self::saved(fn () => Status::flush());
+        self::deleted(fn () => Status::flush());
 
         self::updated(function (Schedule $schedule) {
             if ($schedule->wasChanged('completed_at') && $schedule->status === ScheduleStatusEnum::complete) {

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -11,6 +11,7 @@ use Cachet\Concerns\Publishable;
 use Cachet\Database\Factories\ScheduleFactory;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\QueryBuilders\ScheduleBuilder;
+use Cachet\Status;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -69,6 +70,9 @@ class Schedule extends Model implements Metable
                 $schedule->published_notified_at = $schedule->freshTimestamp();
             }
         });
+
+        self::saved(fn () => Status::flush());
+        self::deleted(fn () => Status::flush());
 
         self::updated(function (Schedule $schedule) {
             if ($schedule->wasChanged('completed_at') && $schedule->status === ScheduleStatusEnum::complete) {

--- a/src/Models/ScheduleComponent.php
+++ b/src/Models/ScheduleComponent.php
@@ -4,6 +4,7 @@ namespace Cachet\Models;
 
 use Cachet\Database\Factories\ScheduleComponentFactory;
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -33,6 +34,16 @@ class ScheduleComponent extends Pivot
     protected $casts = [
         'component_status' => ComponentStatusEnum::class,
     ];
+
+    /**
+     * Attaching or detaching a component changes its effective status, so the
+     * cached status-page aggregates are flushed alongside.
+     */
+    protected static function booted(): void
+    {
+        static::saved(fn () => Status::flush());
+        static::deleted(fn () => Status::flush());
+    }
 
     /**
      * Get the affected component.

--- a/src/Models/Update.php
+++ b/src/Models/Update.php
@@ -5,6 +5,7 @@ namespace Cachet\Models;
 use Cachet\Cachet;
 use Cachet\Database\Factories\UpdateFactory;
 use Cachet\Enums\IncidentStatusEnum;
+use Cachet\Status;
 use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -49,8 +50,15 @@ class Update extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn (Update $update) => $update->forgetRssFeed());
-        static::deleted(fn (Update $update) => $update->forgetRssFeed());
+        static::saved(function (Update $update): void {
+            $update->forgetRssFeed();
+            Status::flush();
+        });
+
+        static::deleted(function (Update $update): void {
+            $update->forgetRssFeed();
+            Status::flush();
+        });
     }
 
     /**

--- a/src/Status.php
+++ b/src/Status.php
@@ -7,9 +7,12 @@ use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\SystemStatusEnum;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
+use Cachet\Models\Schedule;
+use Cachet\Models\Update;
 use Cachet\Settings\AppSettings;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Date;
 
 class Status
 {
@@ -104,14 +107,27 @@ class Status
     }
 
     /**
-     * Get the most recent update timestamp across enabled components.
+     * Get the most recent guest-visible activity timestamp across components,
+     * incidents, incident updates and schedules.
      */
     public function lastUpdated(): ?CarbonInterface
     {
-        return Component::query()
-            ->enabled()
-            ->latest('updated_at')
-            ->first(['updated_at'])?->updated_at;
+        return collect([
+            Component::query()->enabled()->max('updated_at'),
+            Incident::query()->viewableBy(false)->max('updated_at'),
+            Schedule::query()->published()->max('updated_at'),
+            Update::query()
+                ->whereHasMorph('updateable', [Incident::class, Schedule::class], function (Builder $query, string $type): void {
+                    match ($type) {
+                        Incident::class => $query->viewableBy(false),
+                        Schedule::class => $query->published(),
+                    };
+                })
+                ->max('updated_at'),
+        ])
+            ->filter()
+            ->map(fn ($timestamp): CarbonInterface => Date::parse($timestamp))
+            ->max();
     }
 
     /**

--- a/src/Status.php
+++ b/src/Status.php
@@ -12,6 +12,7 @@ use Cachet\Models\Update;
 use Cachet\Settings\AppSettings;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Date;
 
 class Status
@@ -117,12 +118,12 @@ class Status
             Incident::query()->viewableBy(false)->max('updated_at'),
             Schedule::query()->published()->max('updated_at'),
             Update::query()
-                ->whereHasMorph('updateable', [Incident::class, Schedule::class], function (Builder $query, string $type): void {
-                    match ($type) {
-                        Incident::class => $query->viewableBy(false),
-                        Schedule::class => $query->published(),
-                    };
-                })
+                ->where('updateable_type', Relation::getMorphAlias(Incident::class))
+                ->whereIn('updateable_id', Incident::query()->viewableBy(false)->select('id'))
+                ->max('updated_at'),
+            Update::query()
+                ->where('updateable_type', Relation::getMorphAlias(Schedule::class))
+                ->whereIn('updateable_id', Schedule::query()->published()->select('id'))
                 ->max('updated_at'),
         ])
             ->filter()

--- a/src/Status.php
+++ b/src/Status.php
@@ -13,10 +13,22 @@ use Cachet\Settings\AppSettings;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
 
 class Status
 {
+    /**
+     * How long a cached aggregate is served without being recalculated, in seconds.
+     */
+    private const CACHE_FRESH = 30;
+
+    /**
+     * How long a stale aggregate may still be served while it is recalculated
+     * in the background, in seconds.
+     */
+    private const CACHE_TTL = 60;
+
     protected ?object $components = null;
 
     protected ?object $incidents = null;
@@ -88,7 +100,11 @@ class Status
      */
     public function components(): object
     {
-        return $this->components ??= $this->tally();
+        return $this->components ??= Cache::flexible(
+            'cachet::status:components',
+            [self::CACHE_FRESH, self::CACHE_TTL],
+            fn (): object => $this->tally(),
+        );
     }
 
     /**
@@ -98,13 +114,17 @@ class Status
      */
     public function incidents(): object
     {
-        return $this->incidents ??= Incident::query()
-            ->viewableBy(false)
-            ->toBase()
-            ->selectRaw('count(*) as total')
-            ->selectRaw('coalesce(sum(case when status = ? then 1 else 0 end), 0) as resolved', [IncidentStatusEnum::fixed->value])
-            ->selectRaw('coalesce(sum(case when status is null or status <> ? then 1 else 0 end), 0) as unresolved', [IncidentStatusEnum::fixed->value])
-            ->first();
+        return $this->incidents ??= Cache::flexible(
+            'cachet::status:incidents',
+            [self::CACHE_FRESH, self::CACHE_TTL],
+            fn (): object => Incident::query()
+                ->viewableBy(false)
+                ->toBase()
+                ->selectRaw('count(*) as total')
+                ->selectRaw('coalesce(sum(case when status = ? then 1 else 0 end), 0) as resolved', [IncidentStatusEnum::fixed->value])
+                ->selectRaw('coalesce(sum(case when status is null or status <> ? then 1 else 0 end), 0) as unresolved', [IncidentStatusEnum::fixed->value])
+                ->first(),
+        );
     }
 
     /**
@@ -113,22 +133,36 @@ class Status
      */
     public function lastUpdated(): ?CarbonInterface
     {
-        return collect([
-            Component::query()->enabled()->max('updated_at'),
-            Incident::query()->viewableBy(false)->max('updated_at'),
-            Schedule::query()->published()->max('updated_at'),
-            Update::query()
-                ->where('updateable_type', Relation::getMorphAlias(Incident::class))
-                ->whereIn('updateable_id', Incident::query()->viewableBy(false)->select('id'))
-                ->max('updated_at'),
-            Update::query()
-                ->where('updateable_type', Relation::getMorphAlias(Schedule::class))
-                ->whereIn('updateable_id', Schedule::query()->published()->select('id'))
-                ->max('updated_at'),
-        ])
-            ->filter()
-            ->map(fn ($timestamp): CarbonInterface => Date::parse($timestamp))
-            ->max();
+        return Cache::flexible(
+            'cachet::status:last-updated',
+            [self::CACHE_FRESH, self::CACHE_TTL],
+            fn (): ?CarbonInterface => collect([
+                Component::query()->enabled()->max('updated_at'),
+                Incident::query()->viewableBy(false)->max('updated_at'),
+                Schedule::query()->published()->max('updated_at'),
+                Update::query()
+                    ->where('updateable_type', Relation::getMorphAlias(Incident::class))
+                    ->whereIn('updateable_id', Incident::query()->viewableBy(false)->select('id'))
+                    ->max('updated_at'),
+                Update::query()
+                    ->where('updateable_type', Relation::getMorphAlias(Schedule::class))
+                    ->whereIn('updateable_id', Schedule::query()->published()->select('id'))
+                    ->max('updated_at'),
+            ])
+                ->filter()
+                ->map(fn ($timestamp): CarbonInterface => Date::parse($timestamp))
+                ->max(),
+        );
+    }
+
+    /**
+     * Forget the cached aggregates so the next read recalculates them.
+     */
+    public static function flush(): void
+    {
+        Cache::forget('cachet::status:components');
+        Cache::forget('cachet::status:incidents');
+        Cache::forget('cachet::status:last-updated');
     }
 
     /**

--- a/tests/Unit/StatusTest.php
+++ b/tests/Unit/StatusTest.php
@@ -121,6 +121,60 @@ it('returns the most recent enabled component update timestamp', function () {
         ->toEqual($component->updated_at);
 });
 
+it('considers incidents, incident updates and schedules when calculating the last updated timestamp', function () {
+    expect((new Status)->lastUpdated())->toBeNull();
+
+    Component::factory()->create([
+        'enabled' => true,
+        'updated_at' => now()->subWeek(),
+    ]);
+    $incident = Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'updated_at' => now()->subDay(),
+    ]);
+
+    expect((new Status)->lastUpdated())->toEqual($incident->updated_at);
+
+    $update = Update::factory()->forIncident($incident)->create([
+        'status' => null,
+        'created_at' => now()->subHour(),
+        'updated_at' => now()->subHour(),
+    ]);
+
+    expect((new Status)->lastUpdated())->toEqual($update->updated_at);
+
+    $schedule = Schedule::factory()->create([
+        'updated_at' => now()->subMinute(),
+    ]);
+
+    expect((new Status)->lastUpdated())->toEqual($schedule->updated_at);
+});
+
+it('ignores activity hidden from guests when calculating the last updated timestamp', function () {
+    $component = Component::factory()->create([
+        'enabled' => true,
+        'updated_at' => now()->subWeek(),
+    ]);
+    $hidden = Incident::factory()->create([
+        'visible' => ResourceVisibilityEnum::authenticated,
+        'updated_at' => now()->subMinute(),
+    ]);
+    Update::factory()->forIncident($hidden)->create([
+        'status' => null,
+        'created_at' => now()->subMinute(),
+        'updated_at' => now()->subMinute(),
+    ]);
+    Incident::factory()->scheduled()->create([
+        'visible' => ResourceVisibilityEnum::guest,
+        'updated_at' => now()->subMinute(),
+    ]);
+    Schedule::factory()->scheduled()->create([
+        'updated_at' => now()->subMinute(),
+    ]);
+
+    expect((new Status)->lastUpdated())->toEqual($component->updated_at);
+});
+
 it('excludes disabled components from component overview', function () {
     Component::factory()->create([
         'status' => ComponentStatusEnum::operational->value,

--- a/tests/Unit/StatusTest.php
+++ b/tests/Unit/StatusTest.php
@@ -13,6 +13,7 @@ use Cachet\Models\Schedule;
 use Cachet\Models\Update;
 use Cachet\Status;
 use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Cache;
 
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
@@ -173,6 +174,30 @@ it('ignores activity hidden from guests when calculating the last updated timest
     ]);
 
     expect((new Status)->lastUpdated())->toEqual($component->updated_at);
+});
+
+it('caches the status aggregates and flushes them when status data changes', function () {
+    Component::factory()->create([
+        'enabled' => true,
+    ]);
+
+    $status = new Status;
+    $status->components();
+    $status->incidents();
+    $status->lastUpdated();
+
+    expect(Cache::has('cachet::status:components'))->toBeTrue()
+        ->and(Cache::has('cachet::status:incidents'))->toBeTrue()
+        ->and(Cache::has('cachet::status:last-updated'))->toBeTrue();
+
+    Component::factory()->create([
+        'enabled' => true,
+    ]);
+
+    expect(Cache::has('cachet::status:components'))->toBeFalse()
+        ->and(Cache::has('cachet::status:incidents'))->toBeFalse()
+        ->and(Cache::has('cachet::status:last-updated'))->toBeFalse()
+        ->and((int) (new Status)->components()->total)->toBe(2);
 });
 
 it('excludes disabled components from component overview', function () {


### PR DESCRIPTION
The 'status summary' block on top of the status page previously only considered component row changes, so posting or resolving an incident never touched the "Last updated" timestamp. It now takes the most recent activity across components, incidents, incident updates and schedules into account. Note that only guest-visible activity is considered.