### PR TITLE
Make status page timestamps timezone-aware

### DIFF
--- a/resources/views/components/timestamp.blade.php
+++ b/resources/views/components/timestamp.blade.php
@@ -4,7 +4,7 @@
       @focusin="tooltipOpen = true"
       @focusout="tooltipOpen = false"
       class="relative inline-flex">
-    <time x-ref="anchor" datetime="{{ $timestamp->toW3cString() }}" x-text="timestamp.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short'@if($appSettings->timezone !== '-'), timeZone: '{{ $appSettings->timezone }}'@endif })"></time>
+    <time x-ref="anchor" datetime="{{ $timestamp->toW3cString() }}" x-text="timestamp.toLocaleString(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', timeZoneName: 'short'@if($appSettings->timezone !== '-'), timeZone: '{{ $appSettings->timezone }}'@endif })"></time>
 
     <div x-show="tooltipOpen"
          x-cloak
@@ -12,5 +12,6 @@
          x-anchor.top.offset.8="$refs.anchor"
          class="pointer-events-none z-10 w-max max-w-sm rounded-md bg-zinc-900 px-3 py-2 text-xs font-medium text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
         {{ $timestamp->diffForHumans() }}
+        <span class="block">{{ $timestamp->avoidMutation()->utc()->format('Y-m-d H:i') }} UTC</span>
     </div>
 </span>

--- a/src/Filament/Pages/Settings/ManageLocalization.php
+++ b/src/Filament/Pages/Settings/ManageLocalization.php
@@ -41,7 +41,11 @@ class ManageLocalization extends SettingsPage
                     Select::make('timezone')
                         ->label(__('cachet::settings.manage_localization.timezone_label'))
                         ->helperText(__('cachet::settings.manage_localization.timezone_helper'))
-                        ->options(fn () => collect(timezone_identifiers_list())
+                        ->options(fn () => collect([
+                            __('cachet::settings.manage_cachet.timezone_other') => [
+                                '-' => __('cachet::settings.manage_cachet.browser_default'),
+                            ],
+                        ])->merge(collect(timezone_identifiers_list())
                             ->mapToGroups(
                                 fn ($timezone) => [
                                     Str::of($timezone)
@@ -49,7 +53,7 @@ class ManageLocalization extends SettingsPage
                                         ->toString() => [$timezone => $timezone],
                                 ]
                             )
-                            ->map(fn ($group) => $group->collapse()))
+                            ->map(fn ($group) => $group->collapse())))
                         ->required()
                         ->searchable()
                         ->suffixIcon('heroicon-o-globe-alt'),

--- a/tests/Feature/Filament/Settings/ManageLocalizationTest.php
+++ b/tests/Feature/Filament/Settings/ManageLocalizationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Filament\Settings;
+
+use Cachet\Filament\Pages\Settings\ManageLocalization;
+use Cachet\Settings\AppSettings;
+use Filament\Facades\Filament;
+use Workbench\App\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('cachet'));
+
+    actingAs(User::factory()->create(['is_admin' => true]));
+});
+
+it('renders the manage localization page', function () {
+    $this->get(ManageLocalization::getUrl())->assertOk();
+});
+
+it('saves a named timezone', function () {
+    expect(app(AppSettings::class)->timezone)->toBe('UTC');
+
+    livewire(ManageLocalization::class)
+        ->fillForm(['timezone' => 'Europe/Berlin'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(app(AppSettings::class)->refresh()->timezone)->toBe('Europe/Berlin');
+});
+
+it('saves the browser default timezone sentinel', function () {
+    livewire(ManageLocalization::class)
+        ->fillForm(['timezone' => '-'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(app(AppSettings::class)->refresh()->timezone)->toBe('-');
+});

--- a/tests/Feature/StatusPage/StatusPageTest.php
+++ b/tests/Feature/StatusPage/StatusPageTest.php
@@ -264,3 +264,47 @@ it('does not render raw html in component descriptions', function () {
         ->assertSee('<strong>primary</strong>', escape: false)
         ->assertDontSee('<script>alert(1)</script>', escape: false);
 });
+
+it('renders timestamps with the configured display timezone and timezone name', function () {
+    $occurredAt = now()->subDay()->startOfMinute();
+
+    Incident::factory()->create([
+        'name' => 'Timezone incident',
+        'occurred_at' => $occurredAt,
+    ]);
+
+    $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSee("timeZone: 'UTC'", escape: false)
+        ->assertSee("timeZoneName: 'short'", escape: false)
+        ->assertSee('datetime="'.$occurredAt->toW3cString().'"', escape: false);
+});
+
+it('omits the explicit timezone when the browser default sentinel is set', function () {
+    $settings = app(AppSettings::class);
+    $settings->timezone = '-';
+    $settings->save();
+
+    Incident::factory()->create([
+        'name' => 'Timezone incident',
+        'occurred_at' => now()->subDay()->startOfMinute(),
+    ]);
+
+    $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSee("timeZoneName: 'short'", escape: false)
+        ->assertDontSee("timeZone: '", escape: false);
+});
+
+it('shows the UTC instant in the timestamp tooltip', function () {
+    $occurredAt = now()->subDay()->startOfMinute();
+
+    Incident::factory()->create([
+        'name' => 'Timezone incident',
+        'occurred_at' => $occurredAt,
+    ]);
+
+    $this->get(route('cachet.status-page'))
+        ->assertOk()
+        ->assertSee($occurredAt->format('Y-m-d H:i').' UTC');
+});


### PR DESCRIPTION
Timestamps on the status page next to incidents and schedules carried no timezone indication; the only hint was the footer note, which was disabled by default and was easy to miss.

Every timestamp is now displayed with the timezone appended next to it, and the hover tooltip shows the exact UTC instant along with the pre-existing relative/human time.

<img width="398" height="185" alt="image" src="https://github.com/user-attachments/assets/b233ccbf-828c-4ca8-9264-45f249372791" />

Additionally, the **Timezone** setting under **Manage Localization** in the dashboard now exposes a "Browser default" option. It seems like it was already half-built, so it was just a matter of reusing/extending it.

<img width="320" height="310" alt="image" src="https://github.com/user-attachments/assets/ad2101f0-fbb0-4ac6-afd8-a2a9b779f555" />

The default configured timezone remains UTC btw, so existing installs are unaffected.

Closes #399 