### PR TITLE
Render dashboard date time fields in the configured display timezone

### DIFF
--- a/src/CachetDashboardServiceProvider.php
+++ b/src/CachetDashboardServiceProvider.php
@@ -17,6 +17,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Colors\Color;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
@@ -111,6 +112,12 @@ class CachetDashboardServiceProvider extends PanelProvider
             ->path(Cachet::dashboardPath())
             ->bootUsing(function (): void {
                 Section::configureUsing(fn (Section $section) => $section->columnSpanFull());
+
+                FilamentTimezone::set(function (): ?string {
+                    $timezone = rescue(fn () => app(AppSettings::class)->timezone, null, report: false);
+
+                    return $timezone === '-' ? null : $timezone;
+                });
             });
     }
 }

--- a/tests/Feature/Filament/DashboardTimezoneTest.php
+++ b/tests/Feature/Filament/DashboardTimezoneTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use Cachet\Filament\Resources\Incidents\Pages\EditIncident;
+use Cachet\Models\Incident;
+use Cachet\Settings\AppSettings;
+use Filament\Facades\Filament;
+use Workbench\App\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('cachet'));
+    Filament::bootCurrentPanel();
+
+    actingAs(User::factory()->create(['is_admin' => true]));
+});
+
+it('renders dashboard date times in the configured display timezone', function () {
+    $settings = app(AppSettings::class);
+    $settings->timezone = 'Europe/Berlin';
+    $settings->save();
+
+    $incident = Incident::factory()->create(['occurred_at' => '2026-08-06 13:01:37']);
+
+    livewire(EditIncident::class, ['record' => $incident->getKey()])
+        ->assertSet('data.occurred_at', '2026-08-06 15:01:37');
+});
+
+it('stores dashboard-edited date times in the application timezone', function () {
+    $settings = app(AppSettings::class);
+    $settings->timezone = 'Europe/Berlin';
+    $settings->save();
+
+    $incident = Incident::factory()->create();
+
+    livewire(EditIncident::class, ['record' => $incident->getKey()])
+        ->fillForm(['occurred_at' => '2026-08-06 15:01:37'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('incidents', [
+        'id' => $incident->id,
+        'occurred_at' => '2026-08-06 13:01:37',
+    ]);
+});
+
+it('falls back to the application timezone when the browser default sentinel is configured', function () {
+    $settings = app(AppSettings::class);
+    $settings->timezone = '-';
+    $settings->save();
+
+    $incident = Incident::factory()->create(['occurred_at' => '2026-08-06 13:01:37']);
+
+    livewire(EditIncident::class, ['record' => $incident->getKey()])
+        ->assertSet('data.occurred_at', '2026-08-06 13:01:37');
+});


### PR DESCRIPTION
The timezone configured via the **Timezone** setting under **Manage Localization** only affected the public status page; the dashboard kept rendering and accepting date time fields in the application timezone, so the same instant appeared inconsistently and was confusing.

When the panel boots, it now reads the timezone setting and applies it as Filament's global timezone. This happens through a closure, so the setting isn't read until the database is actually available. Filament then handles the conversion in both directions: tables and infolists display dates in that timezone, and DateTimePicker values are converted back to the app timezone before saving, so nothing changes about how dates are stored.

Note that since the "-" (browser default) sentinel cannot be resolved server-side, the dashboard falls back to the application timezone in that case.

Closes #262 