### PR TITLE
Expand architecture and core behavior tests

### DIFF
--- a/tests/Architecture/CommandsTest.php
+++ b/tests/Architecture/CommandsTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Console\Command;
 
 test('commands test')
-    ->expect('Cachet\Console\Commands')
+    ->expect('Cachet\Commands')
     ->toBeClasses()
     ->toExtend(Command::class)
     ->toHaveSuffix('Command');

--- a/tests/Architecture/FiltersTest.php
+++ b/tests/Architecture/FiltersTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Spatie\QueryBuilder\Filters\Filter;
+
+test('filters test')
+    ->expect('Cachet\Filters')
+    ->toBeClasses()
+    ->toImplement(Filter::class)
+    ->toHaveSuffix('Filter');

--- a/tests/Architecture/McpTest.php
+++ b/tests/Architecture/McpTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Laravel\Mcp\Server\Tool;
+
+test('mcp tools test')
+    ->expect('Cachet\Mcp\Tools')
+    ->toBeClasses()
+    ->toExtend(Tool::class);

--- a/tests/Architecture/NotificationsTest.php
+++ b/tests/Architecture/NotificationsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Cachet\Notifications\VerifySubscriberEmail;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+test('notifications test')
+    ->expect('Cachet\Notifications')
+    ->toBeClasses()
+    ->toExtend(Notification::class)
+    ->toImplement(ShouldQueue::class)
+    ->toHaveSuffix('Notification')
+    ->ignoring(VerifySubscriberEmail::class);

--- a/tests/Architecture/QueryBuildersTest.php
+++ b/tests/Architecture/QueryBuildersTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Database\Eloquent\Builder;
+
+test('query builders test')
+    ->expect('Cachet\QueryBuilders')
+    ->toBeClasses()
+    ->toExtend(Builder::class)
+    ->toHaveSuffix('Builder');

--- a/tests/Architecture/RenderersTest.php
+++ b/tests/Architecture/RenderersTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Cachet\Renderers\BladeRenderer;
+use Cachet\Renderers\Renderer;
+use Cachet\Renderers\TwigRenderer;
+
+test('renderers test')
+    ->expect([
+        BladeRenderer::class,
+        TwigRenderer::class,
+    ])
+    ->toBeClasses()
+    ->toImplement(Renderer::class)
+    ->toHaveSuffix('Renderer');

--- a/tests/Architecture/SettingsTest.php
+++ b/tests/Architecture/SettingsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Spatie\LaravelSettings\Settings;
+
+test('settings test')
+    ->expect('Cachet\Settings')
+    ->toBeClasses()
+    ->toExtend(Settings::class)
+    ->toHaveSuffix('Settings');

--- a/tests/Unit/Actions/Webhook/DispatchWebhooksTest.php
+++ b/tests/Unit/Actions/Webhook/DispatchWebhooksTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Cachet\Actions\Webhook\DispatchWebhooks;
+use Cachet\Enums\WebhookEventEnum;
+use Cachet\Events\Components\ComponentCreated;
+use Cachet\Models\Component;
+use Cachet\Models\WebhookSubscription;
+use Illuminate\Support\Facades\Queue;
+use Spatie\WebhookServer\CallWebhookJob;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+it('dispatches matching webhook subscriptions with the event payload', function () {
+    $component = Component::factory()->create();
+
+    $matching = WebhookSubscription::factory()
+        ->selectedEvents([WebhookEventEnum::component_created])
+        ->create();
+
+    WebhookSubscription::factory()
+        ->selectedEvents([WebhookEventEnum::component_updated])
+        ->create();
+
+    app(DispatchWebhooks::class)->handle(new ComponentCreated($component));
+
+    Queue::assertPushed(CallWebhookJob::class, function (CallWebhookJob $job) use ($component, $matching): bool {
+        return $job->webhookUrl === $matching->url
+            && $job->payload === [
+                'event' => WebhookEventEnum::component_created->value,
+                'body' => $component->toArray(),
+            ]
+            && $job->meta === [
+                'subscription_id' => $matching->id,
+                'event' => WebhookEventEnum::component_created->value,
+            ];
+    });
+
+    Queue::assertPushed(CallWebhookJob::class, 1);
+});
+
+it('dispatches subscriptions configured for all events', function () {
+    WebhookSubscription::factory()->allEvents()->create();
+
+    Component::factory()->create();
+
+    Queue::assertPushed(CallWebhookJob::class, 1);
+});
+
+it('does not dispatch when no subscriptions match the event', function () {
+    WebhookSubscription::factory()
+        ->selectedEvents([WebhookEventEnum::component_updated])
+        ->create();
+
+    app(DispatchWebhooks::class)->handle(new ComponentCreated(Component::factory()->create()));
+
+    Queue::assertNothingPushed();
+});

--- a/tests/Unit/Data/FlexibleDateTimeCastTest.php
+++ b/tests/Unit/Data/FlexibleDateTimeCastTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Cachet\Data\Casts\FlexibleDateTimeCast;
+use Carbon\Carbon;
+use Spatie\LaravelData\Casts\Uncastable;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\DataProperty;
+
+it('casts supported date values to carbon', function (mixed $value, string $expected) {
+    $result = (new FlexibleDateTimeCast)->cast(
+        mock(DataProperty::class),
+        $value,
+        [],
+        mock(CreationContext::class),
+    );
+
+    expect($result)
+        ->toBeInstanceOf(Carbon::class)
+        ->and($result->toIso8601String())->toBe($expected);
+})->with([
+    'date time' => [new DateTimeImmutable('2026-08-10T12:30:00+00:00'), '2026-08-10T12:30:00+00:00'],
+    'ISO 8601 string' => ['2026-08-10T13:30:00+01:00', '2026-08-10T12:30:00+00:00'],
+    'timestamp' => [1786365000, '2026-08-10T12:30:00+00:00'],
+]);
+
+it('returns uncastable for unsupported or invalid values', function (mixed $value) {
+    $result = (new FlexibleDateTimeCast)->cast(
+        mock(DataProperty::class),
+        $value,
+        [],
+        mock(CreationContext::class),
+    );
+
+    expect($result)->toBeInstanceOf(Uncastable::class);
+})->with([
+    'null' => null,
+    'boolean' => true,
+    'array' => [[]],
+    'object' => [new stdClass],
+    'invalid string' => 'not a date',
+]);

--- a/tests/Unit/Models/HasMetaTest.php
+++ b/tests/Unit/Models/HasMetaTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Cachet\Models\Component;
+
+it('synchronizes metadata while preserving value types', function () {
+    $component = Component::factory()->create();
+
+    $component->syncMeta([
+        'region' => 'eu-west',
+        'priority' => 3,
+        'enabled' => true,
+        'options' => ['replicas' => 2],
+    ]);
+
+    expect($component->metaValues())->toBe([
+        'region' => 'eu-west',
+        'priority' => 3,
+        'enabled' => true,
+        'options' => ['replicas' => 2],
+    ]);
+});
+
+it('updates supplied metadata and removes omitted keys', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west', 'stale' => true]);
+
+    $component->load('meta');
+    $component->syncMeta(['region' => 'us-east']);
+
+    expect($component->relationLoaded('meta'))->toBeFalse()
+        ->and($component->metaValues())->toBe(['region' => 'us-east']);
+});
+
+it('retains metadata when its owner is soft deleted', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west']);
+    $metaId = $component->meta()->sole()->id;
+
+    $component->delete();
+
+    $this->assertDatabaseHas('meta', ['id' => $metaId]);
+});
+
+it('deletes metadata when its owner is force deleted', function () {
+    $component = Component::factory()->create();
+    $component->syncMeta(['region' => 'eu-west']);
+    $metaId = $component->meta()->sole()->id;
+
+    $component->forceDelete();
+
+    $this->assertDatabaseMissing('meta', ['id' => $metaId]);
+});


### PR DESCRIPTION
## Summary

- fix `CommandsTest` so it targets the real `Cachet\Commands` namespace
- add Pest architecture coverage for filters, MCP tools, notifications, query builders, renderers, and settings
- add behavioral coverage for webhook dispatch, flexible date casting, and model metadata lifecycle

## Testing

- `php84 -d memory_limit=512M vendor/bin/pest tests/Architecture tests/Unit/Actions/Webhook/DispatchWebhooksTest.php tests/Unit/Data/FlexibleDateTimeCastTest.php tests/Unit/Models/HasMetaTest.php --compact` (38 passed, 78 assertions)
- `php84 vendor/bin/pint --test tests/Architecture tests/Unit/Actions/Webhook/DispatchWebhooksTest.php tests/Unit/Data/FlexibleDateTimeCastTest.php tests/Unit/Models/HasMetaTest.php`
- Full suite attempted: 986 passed and 2 todo; 49 rendering tests fail because the Testbench fixture cannot find its published Vite manifest.