### PR TITLE
Localize and group components in incident attach modal

### DIFF
--- a/resources/lang/en/component.php
+++ b/resources/lang/en/component.php
@@ -19,6 +19,11 @@ return [
             'heading' => 'Components',
             'description' => 'Components represent the various parts of your system that can affect the status of your status page.',
         ],
+        'ungrouped' => 'Ungrouped components',
+    ],
+    'attach' => [
+        'heading' => 'Attach components',
+        'placeholder' => 'Select components',
     ],
     'last_updated' => 'Last updated :timestamp',
     'view_details' => 'View details',

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -89,11 +89,11 @@ class IncidentResource extends Resource
                         ->addActionLabel(__('cachet::incident.form.add_component.action_label'))
                         ->schema([
                             Select::make('component_id')
+                                ->label(__('cachet::incident.form.add_component.component_label'))
                                 ->preload()
                                 ->required()
                                 ->options(fn (): array => static::getComponentOptions())
-                                ->disableOptionsWhenSelectedInSiblingRepeaterItems()
-                                ->label(__('cachet::incident.form.add_component.component_label')),
+                                ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
                             ToggleButtons::make('component_status')
                                 ->label(__('cachet::incident.form.add_component.status_label'))
                                 ->inline()
@@ -138,9 +138,9 @@ class IncidentResource extends Resource
      *
      * @return array<string, array<int, string>>
      */
-    protected static function getComponentOptions(): array
+    public static function getComponentOptions(?Incident $excludeAttachedTo = null): array
     {
-        return Component::query()
+        $query = Component::query()
             ->with('group')
             ->leftJoin('component_groups', 'components.component_group_id', '=', 'component_groups.id')
             ->orderByRaw('component_groups.id is null')
@@ -148,7 +148,13 @@ class IncidentResource extends Resource
             ->orderBy('component_groups.name')
             ->orderBy('components.order')
             ->orderBy('components.name')
-            ->select('components.*')
+            ->select('components.*');
+
+        if ($excludeAttachedTo instanceof Incident) {
+            $query->whereNotIn('components.id', $excludeAttachedTo->components()->pluck('components.id'));
+        }
+
+        return $query
             ->get()
             ->groupBy(function (Component $component): string {
                 $group = $component->group;

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -161,7 +161,7 @@ class IncidentResource extends Resource
 
                 return $group instanceof ComponentGroup
                     ? $group->name
-                    : __('Ungrouped components');
+                    : __('cachet::component.list.ungrouped');
             })
             ->map(fn ($components): array => $components->pluck('name', 'id')->all())
             ->all();

--- a/src/Filament/Resources/Incidents/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Incidents/RelationManagers/ComponentsRelationManager.php
@@ -3,6 +3,8 @@
 namespace Cachet\Filament\Resources\Incidents\RelationManagers;
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Models\Incident;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
@@ -23,7 +25,7 @@ class ComponentsRelationManager extends RelationManager
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string
     {
-        return __('Components');
+        return trans_choice('cachet::component.resource_label', 2);
     }
 
     public function form(Schema $schema): Schema
@@ -31,9 +33,9 @@ class ComponentsRelationManager extends RelationManager
         return $schema
             ->components([
                 TextInput::make('name')
-                    ->label(__('Name')),
+                    ->label(__('cachet::component.form.name_label')),
                 ToggleButtons::make('component_status')
-                    ->label(__('Status'))
+                    ->label(__('cachet::component.form.status_label'))
                     ->inline()
                     ->options(ComponentStatusEnum::class)
                     ->required(),
@@ -44,13 +46,13 @@ class ComponentsRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('name')
-            ->modelLabel(__('Component'))
-            ->pluralModelLabel(__('Components'))
+            ->modelLabel(trans_choice('cachet::component.resource_label', 1))
+            ->pluralModelLabel(trans_choice('cachet::component.resource_label', 2))
             ->columns([
                 TextColumn::make('name')
-                    ->label(__('Name')),
+                    ->label(__('cachet::component.list.headers.name')),
                 TextColumn::make('component_status')
-                    ->label(__('Status'))
+                    ->label(__('cachet::component.list.headers.status'))
                     ->badge()
                     ->sortable(),
             ])
@@ -59,19 +61,25 @@ class ComponentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->form(fn (AttachAction $action): array => [
-                        $action->getRecordSelect(),
+                    ->modalHeading(__('cachet::component.attach.heading'))
+                    ->form(fn (): array => [
+                        Select::make('recordId')
+                            ->label(trans_choice('cachet::component.resource_label', 2))
+                            ->placeholder(__('cachet::component.attach.placeholder'))
+                            ->options(function (): array {
+                                $owner = $this->getOwnerRecord();
+                                return IncidentResource::getComponentOptions($owner instanceof Incident ? $owner : null);
+                            })
+                            ->searchable()
+                            ->multiple()
+                            ->required(),
                         ToggleButtons::make('component_status')
-                            ->label(__('Status'))
+                            ->label(__('cachet::component.form.status_label'))
                             ->inline()
                             ->columnSpanFull()
                             ->options(ComponentStatusEnum::class)
                             ->required(),
                     ])
-                    ->preloadRecordSelect()
-                    ->recordSelect(
-                        fn (Select $select) => $select->placeholder(__('Select a component')),
-                    )
                     ->multiple(),
             ])
             ->recordActions([

--- a/tests/Feature/Filament/Resources/IncidentResourceTest.php
+++ b/tests/Feature/Filament/Resources/IncidentResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Filament\Resources;
 
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Filament\Resources\Incidents\Pages\CreateIncident;
@@ -88,4 +89,15 @@ it('groups component selections by component group when creating an incident', f
         ->assertSeeInOrder(['First Group', 'Second Group', 'Ungrouped components'])
         ->assertSee('Webservice')
         ->assertSee('Ungrouped Service');
+});
+
+it('excludes already attached components from the attach action options', function () {
+    $incident = Incident::factory()->create();
+    $attached = Component::factory()->create(['name' => 'Already Attached']);
+
+    $incident->components()->attach($attached->id, ['component_status' => ComponentStatusEnum::operational->value]);
+
+    $options = \Cachet\Filament\Resources\Incidents\IncidentResource::getComponentOptions($incident);
+
+    expect(collect($options)->flatten()->all())->not->toContain('Already Attached');
 });


### PR DESCRIPTION
## What

- Localize all hardcoded strings in `ComponentsRelationManager` using existing `cachet::component.*` translation keys
- Replace Filament native recordSelect with custom Select that groups options by component group
- Exclude already-attached components from the attach dropdown

## Why

- Modals displayed hardcoded English strings even for non-English locales
- Attach modal dropdown showed a flat list, inconsistent with create flow that already grouped by component group
- Attaching a component that's already linked was confusing UX

## Changes

- Wire existing `getComponentOptions()` into the relation manager attach modal — previously used Filament native select which ignored grouping
- `getComponentOptions(?Incident $excludeAttachedTo = null)` now accepts an optional incident to filter out already-attached components
- New translation keys: `cachet::component.list.ungrouped`, `cachet::component.attach.heading`, `cachet::component.attach.placeholder`
- Added "Components" label to the components dropdown

## Screenshots
<img width="960" height="501" alt="image" src="https://github.com/user-attachments/assets/af0eca6d-10f7-49ac-a361-1254aaf5a6a4" />

Closes #432 
