### PR TITLE
Hide updates of unpublished schedules from the API

### DIFF
--- a/src/Http/Controllers/Api/ScheduleUpdateController.php
+++ b/src/Http/Controllers/Api/ScheduleUpdateController.php
@@ -34,6 +34,8 @@ class ScheduleUpdateController extends Controller
     #[QueryParameter('page', 'Which page to show.', type: 'int', example: 2)]
     public function index(Request $request, Schedule $schedule)
     {
+        $this->ensureScheduleVisible($schedule);
+
         $query = Update::query()
             ->where('updateable_id', $schedule->id)
             ->where('updateable_type', Relation::getMorphAlias(Schedule::class));
@@ -65,6 +67,8 @@ class ScheduleUpdateController extends Controller
      */
     public function show(Schedule $schedule, Update $update)
     {
+        $this->ensureScheduleVisible($schedule);
+
         $updateQuery = QueryBuilder::for(Update::class)
             ->allowedIncludes([
                 AllowedInclude::relationship('schedule', 'updateable'),
@@ -74,6 +78,20 @@ class ScheduleUpdateController extends Controller
         return UpdateResource::make($updateQuery)
             ->response()
             ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Abort with a 404 when the parent schedule is not readable by the caller.
+     *
+     * An unpublished schedule must not leak its updates either, so publication
+     * is checked here on exactly the same terms as the schedule endpoints.
+     */
+    protected function ensureScheduleVisible(Schedule $schedule): void
+    {
+        abort_unless(
+            $schedule->isPublished() || $this->tokenCan('schedules.manage'),
+            Response::HTTP_NOT_FOUND,
+        );
     }
 
     /**

--- a/tests/Feature/Api/ScheduleUpdateTest.php
+++ b/tests/Feature/Api/ScheduleUpdateTest.php
@@ -229,3 +229,52 @@ it('cannot delete an schedule update from another schedule', function () {
         'updateable_id' => $scheduleUpdate->updateable_id,
     ]);
 });
+
+it('does not list updates of an unpublished schedule', function () {
+    $schedule = Schedule::factory()->hasUpdates(2)->create(['published_at' => now()->addYear()]);
+
+    $response = getJson("/status/api/schedules/{$schedule->id}/updates");
+
+    $response->assertNotFound();
+});
+
+it('does not show an update of an unpublished schedule', function () {
+    $schedule = Schedule::factory()->hasUpdates(1)->create(['published_at' => now()->addYear()]);
+    $update = $schedule->updates()->first();
+
+    $response = getJson("/status/api/schedules/{$schedule->id}/updates/{$update->id}");
+
+    $response->assertNotFound();
+});
+
+it('lists updates of an unpublished schedule to a token that can manage schedules', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $schedule = Schedule::factory()->hasUpdates(2)->create(['published_at' => now()->addYear()]);
+
+    $response = getJson("/status/api/schedules/{$schedule->id}/updates");
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+it('shows an update of an unpublished schedule to a token that can manage schedules', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $schedule = Schedule::factory()->hasUpdates(1)->create(['published_at' => now()->addYear()]);
+    $update = $schedule->updates()->first();
+
+    $response = getJson("/status/api/schedules/{$schedule->id}/updates/{$update->id}");
+
+    $response->assertOk();
+    $response->assertJsonPath('data.attributes.id', $update->id);
+});
+
+it('does not hide updates of a schedule published in the past', function () {
+    $schedule = Schedule::factory()->hasUpdates(2)->create(['published_at' => now()->subDay()]);
+
+    $response = getJson("/status/api/schedules/{$schedule->id}/updates");
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});


### PR DESCRIPTION
The schedule updates endpoints served every update regardless of whether
the parent schedule was published, so an anonymous caller could read the
bodies of an embargoed maintenance schedule's updates by guessing its id
while GET /api/schedules/{id} correctly 404'd for the same schedule.

Gate index() and show() on the parent's publication state on exactly the
same terms as ScheduleController, mirroring the equivalent gate that
IncidentUpdateController already applies to its parent incident. Tokens
holding schedules.manage keep their existing access to unpublished
schedules.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KqpH13mrPo7wJLDxkLaNYQ