### PR TITLE
Add bulk deletion API endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,13 +14,17 @@ use Cachet\Http\Controllers\Api\StatusController;
 use Cachet\Http\Controllers\Api\SubscriberController;
 use Illuminate\Support\Facades\Route;
 
-Route::apiResources([
+$bulkDeletableResources = [
     'components' => ComponentController::class,
     'component-groups' => ComponentGroupController::class,
     'incidents' => IncidentController::class,
     'incident-templates' => IncidentTemplateController::class,
     'metrics' => MetricController::class,
     'schedules' => ScheduleController::class,
+];
+
+Route::apiResources([
+    ...$bulkDeletableResources,
 ], ['except' => ['store', 'update', 'destroy']]);
 
 Route::apiResource('incidents.updates', IncidentUpdateController::class, [
@@ -39,14 +43,13 @@ Route::apiResource('metrics.points', MetricPointController::class, [
     ->parameter('points', 'metricPoint')
     ->scoped();
 
-Route::middleware(['auth:sanctum'])->group(function () {
+Route::middleware(['auth:sanctum'])->group(function () use ($bulkDeletableResources) {
+    foreach ($bulkDeletableResources as $resource => $controller) {
+        Route::delete($resource, [$controller, 'destroyMany']);
+    }
+
     Route::apiResources([
-        'components' => ComponentController::class,
-        'component-groups' => ComponentGroupController::class,
-        'incidents' => IncidentController::class,
-        'incident-templates' => IncidentTemplateController::class,
-        'metrics' => MetricController::class,
-        'schedules' => ScheduleController::class,
+        ...$bulkDeletableResources,
     ], ['except' => ['index', 'show']]);
 
     Route::apiResource('incidents.updates', IncidentUpdateController::class, [

--- a/src/Actions/BulkDeleteResources.php
+++ b/src/Actions/BulkDeleteResources.php
@@ -13,8 +13,10 @@ class BulkDeleteResources
     /**
      * Delete every requested model atomically after validating that all exist.
      *
-     * @param  class-string<Model>  $modelClass
-     * @param  Closure(Model): void  $deleteResource
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $modelClass
+     * @param  Closure(TModel): void  $deleteResource
      */
     public function handle(Request $request, string $modelClass, Closure $deleteResource): void
     {
@@ -26,7 +28,7 @@ class BulkDeleteResources
         $ids = array_values(array_unique(array_map('intval', explode(',', $validated['ids']))));
 
         DB::transaction(function () use ($ids, $modelClass, $deleteResource): void {
-            /** @var Model $model */
+            /** @var TModel $model */
             $model = new $modelClass;
             $resources = $model->newQuery()->whereKey($ids)->lockForUpdate()->get();
             $missingIds = array_values(array_diff($ids, $resources->modelKeys()));

--- a/src/Actions/BulkDeleteResources.php
+++ b/src/Actions/BulkDeleteResources.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cachet\Actions;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class BulkDeleteResources
+{
+    /**
+     * Delete every requested model atomically after validating that all exist.
+     *
+     * @param  class-string<Model>  $modelClass
+     * @param  Closure(Model): void  $deleteResource
+     */
+    public function handle(Request $request, string $modelClass, Closure $deleteResource): void
+    {
+        $validated = $request->validate([
+            'ids' => ['required', 'string', 'regex:/^[1-9][0-9]*(,[1-9][0-9]*)*$/'],
+        ]);
+
+        /** @var array<int, int> $ids */
+        $ids = array_values(array_unique(array_map('intval', explode(',', $validated['ids']))));
+
+        DB::transaction(function () use ($ids, $modelClass, $deleteResource): void {
+            /** @var Model $model */
+            $model = new $modelClass;
+            $resources = $model->newQuery()->whereKey($ids)->lockForUpdate()->get();
+            $missingIds = array_values(array_diff($ids, $resources->modelKeys()));
+
+            if ($missingIds !== []) {
+                throw (new ModelNotFoundException)->setModel($modelClass, $missingIds);
+            }
+
+            $resources->each($deleteResource);
+        });
+    }
+}

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -161,7 +161,7 @@ class ComponentController extends Controller
      * Delete Components
      */
     #[QueryParameter('ids', 'Comma-separated component IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponent $deleteComponentAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponent $deleteComponentAction): Response
     {
         $this->guard('components.delete');
 

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\Component\CreateComponent;
 use Cachet\Actions\Component\DeleteComponent;
 use Cachet\Actions\Component\UpdateComponent;
@@ -152,6 +153,19 @@ class ComponentController extends Controller
         // @todo re-calculate existing component orders?
 
         $deleteComponentAction->handle($component);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Components
+     */
+    #[QueryParameter('ids', 'Comma-separated component IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponent $deleteComponentAction)
+    {
+        $this->guard('components.delete');
+
+        $bulkDeleteResources->handle($request, Component::class, fn (Component $component) => $deleteComponentAction->handle($component));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -126,7 +126,7 @@ class ComponentGroupController extends Controller
      * Delete Component Groups
      */
     #[QueryParameter('ids', 'Comma-separated component group IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponentGroup $deleteComponentGroupAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponentGroup $deleteComponentGroupAction): Response
     {
         $this->guard('component-groups.delete');
 

--- a/src/Http/Controllers/Api/ComponentGroupController.php
+++ b/src/Http/Controllers/Api/ComponentGroupController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\ComponentGroup\CreateComponentGroup;
 use Cachet\Actions\ComponentGroup\DeleteComponentGroup;
 use Cachet\Actions\ComponentGroup\UpdateComponentGroup;
@@ -117,6 +118,19 @@ class ComponentGroupController extends Controller
     {
         $this->guard('component-groups.delete');
         $deleteComponentGroupAction->handle($componentGroup);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Component Groups
+     */
+    #[QueryParameter('ids', 'Comma-separated component group IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteComponentGroup $deleteComponentGroupAction)
+    {
+        $this->guard('component-groups.delete');
+
+        $bulkDeleteResources->handle($request, ComponentGroup::class, fn (ComponentGroup $componentGroup) => $deleteComponentGroupAction->handle($componentGroup));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -139,7 +139,7 @@ class IncidentController extends Controller
      * Delete Incidents
      */
     #[QueryParameter('ids', 'Comma-separated incident IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncident $deleteIncidentAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncident $deleteIncidentAction): Response
     {
         $this->guard('incidents.delete');
 

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\Incident\CreateIncident;
 use Cachet\Actions\Incident\DeleteIncident;
 use Cachet\Actions\Incident\UpdateIncident;
@@ -130,6 +131,19 @@ class IncidentController extends Controller
         $this->guard('incidents.delete');
 
         $deleteIncidentAction->handle($incident);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Incidents
+     */
+    #[QueryParameter('ids', 'Comma-separated incident IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncident $deleteIncidentAction)
+    {
+        $this->guard('incidents.delete');
+
+        $bulkDeleteResources->handle($request, Incident::class, fn (Incident $incident) => $deleteIncidentAction->handle($incident));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\IncidentTemplate\CreateIncidentTemplate;
 use Cachet\Actions\IncidentTemplate\DeleteIncidentTemplate;
 use Cachet\Actions\IncidentTemplate\UpdateIncidentTemplate;
@@ -77,11 +78,24 @@ class IncidentTemplateController extends Controller
     /**
      * Delete Incident Template
      */
-    public function destroy(IncidentTemplate $incidentTemplate)
+    public function destroy(IncidentTemplate $incidentTemplate, DeleteIncidentTemplate $deleteIncidentTemplateAction)
     {
         $this->guard('incident-templates.delete');
 
-        app(DeleteIncidentTemplate::class)->handle($incidentTemplate);
+        $deleteIncidentTemplateAction->handle($incidentTemplate);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Incident Templates
+     */
+    #[QueryParameter('ids', 'Comma-separated incident template IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncidentTemplate $deleteIncidentTemplateAction)
+    {
+        $this->guard('incident-templates.delete');
+
+        $bulkDeleteResources->handle($request, IncidentTemplate::class, fn (IncidentTemplate $incidentTemplate) => $deleteIncidentTemplateAction->handle($incidentTemplate));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/IncidentTemplateController.php
+++ b/src/Http/Controllers/Api/IncidentTemplateController.php
@@ -91,7 +91,7 @@ class IncidentTemplateController extends Controller
      * Delete Incident Templates
      */
     #[QueryParameter('ids', 'Comma-separated incident template IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncidentTemplate $deleteIncidentTemplateAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteIncidentTemplate $deleteIncidentTemplateAction): Response
     {
         $this->guard('incident-templates.delete');
 

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\Metric\CreateMetric;
 use Cachet\Actions\Metric\DeleteMetric;
 use Cachet\Actions\Metric\UpdateMetric;
@@ -102,6 +103,19 @@ class MetricController extends Controller
         $this->guard('metrics.delete');
 
         $deleteMetricAction->handle($metric);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Metrics
+     */
+    #[QueryParameter('ids', 'Comma-separated metric IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteMetric $deleteMetricAction)
+    {
+        $this->guard('metrics.delete');
+
+        $bulkDeleteResources->handle($request, Metric::class, fn (Metric $metric) => $deleteMetricAction->handle($metric));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/MetricController.php
+++ b/src/Http/Controllers/Api/MetricController.php
@@ -111,7 +111,7 @@ class MetricController extends Controller
      * Delete Metrics
      */
     #[QueryParameter('ids', 'Comma-separated metric IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteMetric $deleteMetricAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteMetric $deleteMetricAction): Response
     {
         $this->guard('metrics.delete');
 

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Http\Controllers\Api;
 
+use Cachet\Actions\BulkDeleteResources;
 use Cachet\Actions\Schedule\CreateSchedule;
 use Cachet\Actions\Schedule\DeleteSchedule;
 use Cachet\Actions\Schedule\UpdateSchedule;
@@ -130,6 +131,19 @@ class ScheduleController extends Controller
         $this->guard('schedules.delete');
 
         $deleteScheduleAction->handle($schedule);
+
+        return response()->noContent();
+    }
+
+    /**
+     * Delete Schedules
+     */
+    #[QueryParameter('ids', 'Comma-separated schedule IDs to delete.', required: true, type: 'string', example: '1,2,3')]
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteSchedule $deleteScheduleAction)
+    {
+        $this->guard('schedules.delete');
+
+        $bulkDeleteResources->handle($request, Schedule::class, fn (Schedule $schedule) => $deleteScheduleAction->handle($schedule));
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -139,7 +139,7 @@ class ScheduleController extends Controller
      * Delete Schedules
      */
     #[QueryParameter('ids', 'Comma-separated schedule IDs to delete.', required: true, type: 'string', example: '1,2,3')]
-    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteSchedule $deleteScheduleAction)
+    public function destroyMany(Request $request, BulkDeleteResources $bulkDeleteResources, DeleteSchedule $deleteScheduleAction): Response
     {
         $this->guard('schedules.delete');
 

--- a/tests/Feature/Api/BulkDeleteTest.php
+++ b/tests/Feature/Api/BulkDeleteTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
+use Cachet\Models\Incident;
+use Cachet\Models\IncidentTemplate;
+use Cachet\Models\Metric;
+use Cachet\Models\Schedule;
+use Laravel\Sanctum\Sanctum;
+use Workbench\App\User;
+
+use function Pest\Laravel\deleteJson;
+
+it('can bulk delete every supported resource', function (string $resource, string $ability, string $modelClass, string $table, bool $softDeletes) {
+    Sanctum::actingAs(User::factory()->create(), [$ability]);
+
+    $models = $modelClass::factory(2)->create();
+
+    $response = deleteJson('/status/api/'.$resource.'?ids='.$models->pluck('id')->join(','));
+
+    $response->assertNoContent();
+
+    foreach ($models as $model) {
+        if ($softDeletes) {
+            $this->assertSoftDeleted($table, ['id' => $model->id]);
+        } else {
+            $this->assertDatabaseMissing($table, ['id' => $model->id]);
+        }
+    }
+})->with([
+    ['components', 'components.delete', Component::class, 'components', true],
+    ['component-groups', 'component-groups.delete', ComponentGroup::class, 'component_groups', false],
+    ['incidents', 'incidents.delete', Incident::class, 'incidents', true],
+    ['incident-templates', 'incident-templates.delete', IncidentTemplate::class, 'incident_templates', false],
+    ['metrics', 'metrics.delete', Metric::class, 'metrics', false],
+    ['schedules', 'schedules.delete', Schedule::class, 'schedules', true],
+]);
+
+it('rejects collection deletion without valid IDs', function (string $query) {
+    Sanctum::actingAs(User::factory()->create(), ['components.delete']);
+
+    $response = deleteJson('/status/api/components'.$query);
+
+    $response->assertUnprocessable()->assertInvalid('ids');
+})->with([
+    '',
+    '?ids=',
+    '?ids=all',
+    '?ids=1,not-an-id',
+    '?ids=1,',
+]);
+
+it('does not delete any resources when one requested ID does not exist', function () {
+    Sanctum::actingAs(User::factory()->create(), ['components.delete']);
+
+    $component = Component::factory()->create();
+
+    $response = deleteJson('/status/api/components?ids='.$component->id.',999999');
+
+    $response->assertNotFound();
+    $this->assertDatabaseHas('components', ['id' => $component->id, 'deleted_at' => null]);
+});
+
+it('requires authentication and the matching ability for collection deletion', function () {
+    $component = Component::factory()->create();
+
+    deleteJson('/status/api/components?ids='.$component->id)->assertUnauthorized();
+
+    Sanctum::actingAs(User::factory()->create(), ['components.manage']);
+
+    deleteJson('/status/api/components?ids='.$component->id)->assertForbidden();
+    $this->assertDatabaseHas('components', ['id' => $component->id, 'deleted_at' => null]);
+});
+
+it('applies component group cleanup when bulk deleting component groups', function () {
+    Sanctum::actingAs(User::factory()->create(), ['component-groups.delete']);
+
+    $componentGroups = ComponentGroup::factory()->hasComponents(1)->count(2)->create();
+
+    deleteJson('/status/api/component-groups?ids='.$componentGroups->pluck('id')->join(','))->assertNoContent();
+
+    $this->assertDatabaseMissing('component_groups', ['id' => $componentGroups[0]->id]);
+    $this->assertDatabaseMissing('component_groups', ['id' => $componentGroups[1]->id]);
+    $this->assertDatabaseHas('components', ['component_group_id' => null]);
+});
+
+it('deletes incident updates when bulk deleting incidents', function () {
+    Sanctum::actingAs(User::factory()->create(), ['incidents.delete']);
+
+    $incidents = Incident::factory()->hasUpdates(1)->count(2)->create();
+
+    deleteJson('/status/api/incidents?ids='.$incidents->pluck('id')->join(','))->assertNoContent();
+
+    $this->assertDatabaseMissing('updates', ['updateable_id' => $incidents[0]->id]);
+    $this->assertDatabaseMissing('updates', ['updateable_id' => $incidents[1]->id]);
+});
+
+it('deletes metric points when bulk deleting metrics', function () {
+    Sanctum::actingAs(User::factory()->create(), ['metrics.delete']);
+
+    $metrics = Metric::factory()->hasMetricPoints(1)->count(2)->create();
+
+    deleteJson('/status/api/metrics?ids='.$metrics->pluck('id')->join(','))->assertNoContent();
+
+    $this->assertDatabaseMissing('metric_points', ['metric_id' => $metrics[0]->id]);
+    $this->assertDatabaseMissing('metric_points', ['metric_id' => $metrics[1]->id]);
+});


### PR DESCRIPTION
## Summary
- add collection-level bulk deletion for components, component groups, incidents, incident templates, metrics, and schedules
- validate the complete ID set before deletion and run domain deletion actions in a transaction
- preserve single-resource deletion and document collection delete parameters in generated OpenAPI

## Testing
- vendor/bin/pint --test
- focused API and architecture tests: 236 passed, 1 existing todo (578 assertions)
- full suite is blocked locally by the fixed 128 MB PHP memory limit during framework/architecture bootstrap