### PR TITLE
Fix component select dropdowns being clipped inside modals

### DIFF
--- a/resources/css/dashboard/theme.css
+++ b/resources/css/dashboard/theme.css
@@ -227,7 +227,7 @@ a.fi-wi-stats-overview-stat:hover {
 .fi-input-wrp {
     border: 1px solid var(--cachet-border);
     background: var(--cachet-surface-solid);
-    filter: drop-shadow(0 1px 1px rgb(15 23 42 / 4%));
+    box-shadow: 0 1px 1px rgb(15 23 42 / 4%);
 }
 
 .dark .fi-input-wrp {


### PR DESCRIPTION
It seems like in #443, a `filter: drop-shadow()` was added to `.fi-input-wrp`. This created a new stacking context in CSS, which meant the select component dropdowns couldn't layer over the sibling fields properly, colliding with the elements rather.

<img width="799" height="457" alt="image" src="https://github.com/user-attachments/assets/0ed56ec1-4740-4745-a6ac-2ab5fab8a520" />

The fix uses `box-shadow` instead for the same shadow, thus avoiding the stacking context issue.