### PR TITLE
Fix the Vite watch loop and stale assets during composer dev

### DIFF
--- a/resources/css/cachet.css
+++ b/resources/css/cachet.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source not '../../public/build';
 @import '../../vendor/filament/support/resources/css/index.css';
 
 @plugin '@tailwindcss/forms';

--- a/resources/css/dashboard/theme.css
+++ b/resources/css/dashboard/theme.css
@@ -1,4 +1,5 @@
 @import '../../../vendor/filament/filament/resources/css/theme.css';
+@source not '../../../public/build';
 
 @source '../../../resources/views/filament';
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,28 @@
+import { cpSync, existsSync, rmSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import laravel from 'laravel-vite-plugin'
 import tailwindcss from "@tailwindcss/vite"
+
+/**
+ * Mirror the compiled assets into the Testbench skeleton after each build.
+ */
+function syncTestbenchAssets() {
+  const source = 'public/build'
+  const target = 'vendor/orchestra/testbench-core/laravel/public/vendor/cachethq/cachet/build'
+
+  return {
+    name: 'cachet-sync-testbench-assets',
+    apply: 'build',
+    closeBundle() {
+      if (!existsSync(`${target}/..`)) {
+        return
+      }
+
+      rmSync(target, { recursive: true, force: true })
+      cpSync(source, target, { recursive: true })
+    },
+  }
+}
 
 export default defineConfig({
   plugins: [
@@ -10,9 +32,8 @@ export default defineConfig({
         'resources/css/dashboard/theme.css',
         'resources/js/cachet.js',
       ],
-      // publicDirectory: 'vendor/orchestra/testbench-core/laravel/public/vendor/cachethq',
-      // buildDirectory: 'cachet',
     }),
     tailwindcss(),
+    syncTestbenchAssets(),
   ],
 })


### PR DESCRIPTION
This PR seeks to fix two issues that made `composer dev` a bit annoying for frontend dev.

- Tailwind v4 auto scans every non-gitignored file for class names. Since public/build is committed in this repo, each build's output was picked up as a change and kept retriggering the next build, leaving `vite build --watch` rebuilding in a loop. Marking public/build with `@source not` in both CSS entry points so the generated assets are never treated as input.

- `workbench:build` publishes `public/` into the Testbench skeleton once at startup, so the running server kept serving the old manifest and assets even after every rebuild. The only way to see CSS/JS changes was a restart. This commit adds a Vite plugin that mirrors `public/build` into the published location after each build whenever it exists, leaving `npm run build` unaffected.