### PR TITLE
Adopt package development skills

### DIFF
--- a/.agents/skills/laravel-best-practices/SKILL.md
+++ b/.agents/skills/laravel-best-practices/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: laravel-best-practices
+description: "Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Laravel Best Practices
+
+Best practices for Laravel, organized as an index of rule files. Each rule file teaches what to do and why. For exact API syntax, verify with `search-docs`.
+
+Core is a Laravel package. Read [`rules/package-development.md`](rules/package-development.md) before applying any application-oriented guidance.
+
+## Consistency First
+
+Before applying any rule, check what the application already does. Laravel offers multiple valid approaches, and the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
+
+Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it. Don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
+
+## How to Apply
+
+1. Check the changed files, nearby code, project configuration, and relevant tests for established patterns. Deviate only for a correctness or security defect, and call the deviation out.
+2. Map every affected concern to the rule index below. Read each mapped rule file before editing. Skip unrelated rule files.
+3. Make the smallest coherent change. Keep the application's architecture and naming instead of introducing a second pattern for the same job.
+4. Verify version-sensitive Laravel APIs for the installed version with `search-docs`, or inspect the installed framework when it is unavailable.
+5. Run the narrowest relevant tests first, then the project's formatting and static-analysis checks when the change warrants them.
+6. Re-read the diff against every mapped rule before finishing.
+
+## Rule Index
+
+Cross-cutting changes often need more than one rule file.
+
+| Concern | Read |
+| --- | --- |
+| Query count, eager loading, indexes, large datasets | [`rules/db-performance.md`](rules/db-performance.md) |
+| Subqueries, aggregates, complex ordering and query plans | [`rules/advanced-queries.md`](rules/advanced-queries.md) |
+| Models, relationships, scopes, casts | [`rules/eloquent.md`](rules/eloquent.md) |
+| Authentication, authorization, input safety, secrets, uploads | [`rules/security.md`](rules/security.md) |
+| Form Requests and validation rules | [`rules/validation.md`](rules/validation.md) |
+| Controllers, route binding, resources, middleware | [`rules/routing.md`](rules/routing.md) |
+| Schema changes, columns, foreign keys, indexes | [`rules/migrations.md`](rules/migrations.md) |
+| Jobs, retries, uniqueness, batches, Horizon | [`rules/queue-jobs.md`](rules/queue-jobs.md) |
+| Cache lifetime, invalidation, locks, memoization | [`rules/caching.md`](rules/caching.md) |
+| Outbound requests, retries, timeouts, fakes | [`rules/http-client.md`](rules/http-client.md) |
+| Exceptions, reporting, rendering, log context | [`rules/error-handling.md`](rules/error-handling.md) |
+| Events and notifications | [`rules/events-notifications.md`](rules/events-notifications.md) |
+| Mailables and mail assertions | [`rules/mail.md`](rules/mail.md) |
+| Scheduled tasks and overlap protection | [`rules/scheduling.md`](rules/scheduling.md) |
+| Collections, lazy iteration, bulk operations | [`rules/collections.md`](rules/collections.md) |
+| Blade components, attributes, composers | [`rules/blade-views.md`](rules/blade-views.md) |
+| Environment values and application configuration | [`rules/config.md`](rules/config.md) |
+| Package layout, host boundaries, compatibility, publishing | [`rules/package-development.md`](rules/package-development.md) |
+| Tests: coverage, factories, fakes, and assertions | the `testing-best-practices` skill |
+| Naming, helpers, file boundaries, PHP style | [`rules/style.md`](rules/style.md) |
+| Actions, services, dependencies, application structure | [`rules/architecture.md`](rules/architecture.md) |
+
+## Decision Rules
+
+- Prefer framework features and existing application abstractions over new helpers or dependencies.
+- Avoid speculative abstractions. Extract code when it creates a clear domain boundary, removes meaningful duplication, or makes behavior independently testable.
+- Keep database access out of Blade views and prevent hidden N+1 queries across controllers, resources, jobs, and serialization.

--- a/.agents/skills/laravel-best-practices/rules/advanced-queries.md
+++ b/.agents/skills/laravel-best-practices/rules/advanced-queries.md
@@ -1,0 +1,106 @@
+# Advanced Query Patterns
+
+## Use `addSelect()` Subqueries for Single Values from Has-Many
+
+Instead of eager-loading an entire has-many relationship for a single value (like the latest timestamp), use a correlated subquery via `addSelect()`. This pulls the value directly in the main SQL query — zero extra queries.
+
+```php
+public function scopeWithLastLoginAt($query): void
+{
+    $query->addSelect([
+        'last_login_at' => Login::select('created_at')
+            ->whereColumn('user_id', 'users.id')
+            ->latest()
+            ->take(1),
+    ])->withCasts(['last_login_at' => 'datetime']);
+}
+```
+
+## Create Dynamic Relationships via Subquery FK
+
+Extend the `addSelect()` pattern to fetch a foreign key via subquery, then define a `belongsTo` relationship on that virtual attribute. This provides a fully-hydrated related model without loading the entire collection.
+
+```php
+public function lastLogin(): BelongsTo
+{
+    return $this->belongsTo(Login::class);
+}
+
+public function scopeWithLastLogin($query): void
+{
+    $query->addSelect([
+        'last_login_id' => Login::select('id')
+            ->whereColumn('user_id', 'users.id')
+            ->latest()
+            ->take(1),
+    ])->with('lastLogin');
+}
+```
+
+## Use Conditional Aggregates Instead of Multiple Count Queries
+
+Replace N separate `count()` queries with a single query using `CASE WHEN` inside `selectRaw()`. Use `toBase()` to skip model hydration when you only need scalar values.
+
+```php
+$statuses = Feature::toBase()
+    ->selectRaw("count(case when status = 'Requested' then 1 end) as requested")
+    ->selectRaw("count(case when status = 'Planned' then 1 end) as planned")
+    ->selectRaw("count(case when status = 'Completed' then 1 end) as completed")
+    ->first();
+```
+
+## Use `setRelation()` to Prevent Circular N+1
+
+When a parent model is eager-loaded with its children, and the view also needs `$child->parent`, use `setRelation()` to inject the already-loaded parent rather than letting Eloquent fire N additional queries.
+
+```php
+$feature->load('comments.user');
+$feature->comments->each->setRelation('feature', $feature);
+```
+
+## Prefer `whereIn` + Subquery Over `whereHas`
+
+`whereHas()` emits a correlated `EXISTS` subquery that re-executes per row. Using `whereIn()` with a `select('id')` subquery lets the database use an index lookup instead, without loading data into PHP memory.
+
+Incorrect (correlated EXISTS re-executes per row):
+
+```php
+$query->whereHas('company', fn ($q) => $q->where('name', 'like', $term));
+```
+
+Correct (index-friendly subquery, no PHP memory overhead):
+
+```php
+$query->whereIn('company_id', Company::where('name', 'like', $term)->select('id'));
+```
+
+## Sometimes Two Simple Queries Beat One Complex Query
+
+Running a small, targeted secondary query and passing its results via `whereIn` is often faster than a single complex correlated subquery or join. The additional round-trip is worthwhile when the secondary query is highly selective and uses its own index.
+
+## Use Compound Indexes Matching `orderBy` Column Order
+
+When ordering by multiple columns, create a single compound index in the same column order as the `ORDER BY` clause. Individual single-column indexes cannot combine for multi-column sorts — the database will filesort without a compound index.
+
+```php
+// Migration
+$table->index(['last_name', 'first_name']);
+
+// Query — column order must match the index
+User::query()->orderBy('last_name')->orderBy('first_name')->paginate();
+```
+
+## Use Correlated Subqueries for Has-Many Ordering
+
+When sorting by a value from a has-many relationship, avoid joins (they duplicate rows). Use a correlated subquery inside `orderBy()` instead, paired with an `addSelect` scope for eager loading.
+
+```php
+public function scopeOrderByLastLogin($query): void
+{
+    $query->orderByDesc(Login::select('created_at')
+        ->whereColumn('user_id', 'users.id')
+        ->latest()
+        ->take(1)
+    );
+}
+```

--- a/.agents/skills/laravel-best-practices/rules/architecture.md
+++ b/.agents/skills/laravel-best-practices/rules/architecture.md
@@ -1,0 +1,206 @@
+# Architecture Best Practices
+
+## Single-Purpose Action Classes
+
+Extract discrete business operations into invokable Action classes.
+
+```php
+class CreateOrderAction
+{
+    public function __construct(private InventoryService $inventory) {}
+
+    public function handle(array $data): Order
+    {
+        $order = Order::create($data);
+        $this->inventory->reserve($order);
+
+        return $order;
+    }
+}
+```
+
+## Use Dependency Injection
+
+Always use constructor injection. Avoid `app()` or `resolve()` inside classes.
+
+Incorrect:
+```php
+class OrderController extends Controller
+{
+    public function store(StoreOrderRequest $request)
+    {
+        $service = app(OrderService::class);
+
+        return $service->create($request->validated());
+    }
+}
+```
+
+Correct:
+```php
+class OrderController extends Controller
+{
+    public function __construct(private OrderService $service) {}
+
+    public function store(StoreOrderRequest $request)
+    {
+        return $this->service->create($request->validated());
+    }
+}
+```
+
+## Code to Interfaces
+
+Depend on contracts at system boundaries (payment gateways, notification channels, external APIs) for testability and swappability.
+
+Incorrect (concrete dependency):
+```php
+class OrderService
+{
+    public function __construct(private StripeGateway $gateway) {}
+}
+```
+
+Correct (interface dependency):
+```php
+interface PaymentGateway
+{
+    public function charge(int $amount, string $customerId): PaymentResult;
+}
+
+class OrderService
+{
+    public function __construct(private PaymentGateway $gateway) {}
+}
+```
+
+Bind in a service provider:
+
+```php
+$this->app->bind(PaymentGateway::class, StripeGateway::class);
+```
+
+## Default Sort by Descending
+
+When no explicit order is specified, sort by `id` or `created_at` descending. Without an explicit `ORDER BY`, row order is undefined.
+
+Incorrect:
+```php
+$posts = Post::paginate();
+```
+
+Correct:
+```php
+$posts = Post::latest()->paginate();
+```
+
+## Use Atomic Locks for Race Conditions
+
+Prevent race conditions with `Cache::lock()` or `lockForUpdate()`.
+
+```php
+Cache::lock('order-processing-'.$order->id, 10)->block(5, function () use ($order) {
+    $order->process();
+});
+
+// Or at query level, inside a transaction
+DB::transaction(function () use ($id) {
+    $product = Product::where('id', $id)->lockForUpdate()->first();
+
+    // Read and update the product while the lock is held...
+});
+```
+
+## Use `mb_*` String Functions
+
+When no Laravel helper exists, prefer `mb_strlen`, `mb_strtolower`, etc. for UTF-8 safety. Standard PHP string functions count bytes, not characters.
+
+Incorrect:
+```php
+strlen('José');          // 5 (bytes, not characters)
+strtolower('MÜNCHEN');  // 'mÜnchen' — fails on multibyte
+```
+
+Correct:
+```php
+mb_strlen('José');             // 4 (characters)
+mb_strtolower('MÜNCHEN');     // 'münchen'
+
+// Prefer Laravel's Str helpers when available
+Str::length('José');          // 4
+Str::lower('MÜNCHEN');        // 'münchen'
+```
+
+## Use `defer()` for Post-Response Work
+
+For lightweight tasks that don't need to survive a crash (logging, analytics, cleanup), use `defer()` instead of dispatching a job. The callback runs after the HTTP response is sent — no queue overhead.
+
+Incorrect (job overhead for trivial work):
+```php
+dispatch(new LogPageView($page));
+```
+
+Correct (runs after response, same process):
+```php
+defer(fn () => PageView::create(['page_id' => $page->id, 'user_id' => auth()->id()]));
+```
+
+Use jobs when the work must survive process crashes or needs retry logic. Use `defer()` for fire-and-forget work.
+
+## Use `Context` for Request-Scoped Data
+
+The `Context` facade passes data through the entire request lifecycle — middleware, controllers, jobs, logs — without passing arguments manually.
+
+```php
+// In middleware
+Context::add('tenant_id', $request->header('X-Tenant-ID'));
+
+// Anywhere later — controllers, jobs, log context
+$tenantId = Context::get('tenant_id');
+```
+
+Context data automatically propagates to queued jobs and is included in log entries. Use `Context::addHidden()` for sensitive data that should be available in queued jobs but excluded from log context. If data must not leave the current process, do not store it in `Context`.
+
+## Use `Concurrency::run()` for Parallel Execution
+
+Run independent operations in parallel using child processes — no async libraries needed.
+
+```php
+use Illuminate\Support\Facades\Concurrency;
+
+[$users, $orders] = Concurrency::run([
+    fn () => User::count(),
+    fn () => Order::where('status', 'pending')->count(),
+]);
+```
+
+Each closure runs in a separate process with full Laravel access. Use for independent database queries, API calls, or computations that would otherwise run sequentially.
+
+## Convention Over Configuration
+
+Follow Laravel conventions. Don't override defaults unnecessarily.
+
+Incorrect:
+```php
+class Customer extends Model
+{
+    protected $table = 'Customer';
+    protected $primaryKey = 'customer_id';
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_customer', 'customer_id', 'role_id');
+    }
+}
+```
+
+Correct:
+```php
+class Customer extends Model
+{
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class);
+    }
+}
+```

--- a/.agents/skills/laravel-best-practices/rules/blade-views.md
+++ b/.agents/skills/laravel-best-practices/rules/blade-views.md
@@ -1,0 +1,36 @@
+# Blade & Views Best Practices
+
+## Use `$attributes->merge()` in Component Templates
+
+Hardcoding classes prevents consumers from adding their own. `merge()` combines class attributes cleanly.
+
+```blade
+<div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }}>
+    {{ $message }}
+</div>
+```
+
+## Use `@pushOnce` for Per-Component Scripts
+
+If a component renders inside a `@foreach`, `@push` inserts the script N times. `@pushOnce` guarantees it's included exactly once.
+
+## Prefer Blade Components Over `@include`
+
+`@include` shares all parent variables implicitly (hidden coupling). Components have explicit props, attribute bags, and slots.
+
+## Use View Composers for Shared View Data
+
+If every controller rendering a sidebar must pass `$categories`, that's duplicated code. A View Composer centralizes it.
+
+## Use Blade Fragments for Partial Re-Renders (htmx/Turbo)
+
+A single view can return either the full page or just a fragment, keeping routing clean.
+
+```php
+return view('dashboard', compact('users'))
+    ->fragmentIf($request->hasHeader('HX-Request'), 'user-list');
+```
+
+## Use `@aware` for Deeply Nested Component Props
+
+Avoids re-passing parent props through every level of nested components.

--- a/.agents/skills/laravel-best-practices/rules/caching.md
+++ b/.agents/skills/laravel-best-practices/rules/caching.md
@@ -1,0 +1,70 @@
+# Caching Best Practices
+
+## Use `Cache::remember()` Instead of Manual Get/Put
+
+Cleaner cache-aside pattern that removes boilerplate. use `Cache::lock()` for race conditions.
+
+Incorrect:
+```php
+$val = Cache::get('stats');
+if (! $val) {
+    $val = $this->computeStats();
+    Cache::put('stats', $val, 60);
+}
+```
+
+Correct:
+```php
+$val = Cache::remember('stats', 60, fn () => $this->computeStats());
+```
+
+## Use `Cache::flexible()` for Stale-While-Revalidate
+
+On high-traffic keys, one user always gets a slow response when the cache expires. `flexible()` serves slightly stale data while refreshing in the background.
+
+Incorrect: `Cache::remember('users', 300, fn () => User::all());`
+
+Correct: `Cache::flexible('users', [300, 600], fn () => User::all());` — fresh for 5 min, stale-but-served up to 10 min, refreshes via deferred function.
+
+## Use `Cache::memo()` to Avoid Redundant Hits Within a Request
+
+If the same cache key is read multiple times per request (e.g., a service called from multiple places), `memo()` stores the resolved value in memory.
+
+`Cache::memo()->get('settings');` — 5 calls = 1 Redis round-trip instead of 5.
+
+## Use Cache Tags to Invalidate Related Groups
+
+Without tags, invalidating a group of entries requires tracking every key. Tags let you flush atomically. Not supported by the `file`, `dynamodb`, `database` or `storage` drivers.
+
+```php
+Cache::tags(['user-1'])->flush();
+```
+
+## Use `Cache::add()` for Atomic Conditional Writes
+
+`add()` only writes if the key does not exist — atomic, no race condition between checking and writing.
+
+Incorrect: `if (! Cache::has('lock')) { Cache::put('lock', true, 10); }`
+
+Correct: `Cache::add('lock', true, 10);`
+
+## Use `once()` for Per-Request Memoization
+
+`once()` memoizes a function's return value for the lifetime of the object (or request for closures). Unlike `Cache::memo()`, it doesn't hit the cache store at all — pure in-memory.
+
+```php
+public function roles(): Collection
+{
+    return once(fn () => $this->loadRoles());
+}
+```
+
+Multiple calls return the cached result without re-executing. Use `once()` for expensive computations called multiple times per request. Use `Cache::memo()` when you also want cross-request caching.
+
+## Configure Failover Cache Stores in Production
+
+If Redis goes down, the app falls back to a secondary store automatically.
+
+```php
+'failover' => ['driver' => 'failover', 'stores' => ['redis', 'database']],
+```

--- a/.agents/skills/laravel-best-practices/rules/collections.md
+++ b/.agents/skills/laravel-best-practices/rules/collections.md
@@ -1,0 +1,44 @@
+# Collection Best Practices
+
+## Use Higher-Order Messages for Simple Operations
+
+Incorrect:
+```php
+$users->each(function (User $user) {
+    $user->markAsVip();
+});
+```
+
+Correct: `$users->each->markAsVip();`
+
+Works with `each`, `map`, `sum`, `filter`, `reject`, `contains`, etc.
+
+## Choose `cursor()` vs. `lazy()` Correctly
+
+- `cursor()` — one model in memory, but cannot eager-load relationships (N+1 risk).
+- `lazy()` — chunked pagination returning a flat LazyCollection, supports eager loading.
+
+Incorrect: `User::with('roles')->cursor()` — eager loading silently ignored.
+
+Correct: `User::with('roles')->lazy()` for relationship access; `User::cursor()` for attribute-only work.
+
+## Use `lazyById()` When Updating Records While Iterating
+
+`lazy()` uses offset pagination — updating records during iteration can skip or double-process. `lazyById()` uses `id > last_id`, safe against mutation.
+
+## Use `toQuery()` for Bulk Operations on Collections
+
+Avoids manual `whereIn` construction.
+
+Incorrect: `User::whereIn('id', $users->pluck('id'))->update([...]);`
+
+Correct: `$users->toQuery()->update([...]);`
+
+## Use `#[CollectedBy]` for Custom Collection Classes
+
+More declarative than overriding `newCollection()`.
+
+```php
+#[CollectedBy(UserCollection::class)]
+class User extends Model {}
+```

--- a/.agents/skills/laravel-best-practices/rules/config.md
+++ b/.agents/skills/laravel-best-practices/rules/config.md
@@ -1,0 +1,65 @@
+# Configuration Best Practices
+
+## `env()` Only in Config Files
+
+Direct `env()` calls may return `null` when config is cached.
+
+Incorrect:
+```php
+$key = env('API_KEY');
+```
+
+Correct:
+```php
+// config/services.php
+'key' => env('API_KEY'),
+
+// Application code
+$key = config('services.key');
+```
+
+## Leave Host Secrets to the Consumer
+
+Never store production secrets in plain `.env` files in version control.
+
+Incorrect:
+```bash
+# .env committed to repo or shared in Slack
+STRIPE_SECRET=sk_live_abc123
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI
+```
+
+Core supplies namespaced configuration defaults and must not encrypt, decrypt, publish, or otherwise manage a consumer application's environment file. Consumers should inject secrets through their deployment platform and reference them from published configuration only when necessary.
+
+## Use `App::environment()` for Environment Checks
+
+Incorrect:
+```php
+if (env('APP_ENV') === 'production') {
+```
+
+Correct:
+```php
+if (app()->isProduction()) {
+// or
+if (App::environment('production')) {
+```
+
+## Use Constants and Language Files
+
+Use class constants instead of hardcoded magic strings for model states, types, and statuses.
+
+```php
+// Incorrect
+return $this->type === 'normal';
+
+// Correct
+return $this->type === self::TYPE_NORMAL;
+```
+
+If the application already uses language files for localization, use `__()` for user-facing strings too. Do not introduce language files purely for English-only apps — simple string literals are fine there.
+
+```php
+// Only when lang files already exist in the project
+return back()->with('message', __('app.article_added'));
+```

--- a/.agents/skills/laravel-best-practices/rules/db-performance.md
+++ b/.agents/skills/laravel-best-practices/rules/db-performance.md
@@ -1,0 +1,183 @@
+# Database Performance Best Practices
+
+## Always Eager Load Relationships
+
+Lazy loading causes N+1 query problems — one query per loop iteration. Always use `with()` to load relationships upfront.
+
+Incorrect (N+1 — executes 1 + N queries):
+```php
+$posts = Post::all();
+foreach ($posts as $post) {
+    echo $post->author->name;
+}
+```
+
+Correct (2 queries total):
+```php
+$posts = Post::with('author')->get();
+foreach ($posts as $post) {
+    echo $post->author->name;
+}
+```
+
+Constrain eager loads to select only needed columns (always include the foreign key):
+
+```php
+$users = User::with(['posts' => function ($query) {
+    $query->select('id', 'user_id', 'title')
+          ->where('published', true)
+          ->latest()
+          ->limit(10);
+}])->get();
+```
+
+## Detect Lazy Loading Without Changing the Host
+
+Do not enable `Model::preventLazyLoading()` from a package service provider because that changes the consumer application's global policy. Detect N+1 queries through focused tests and explicit eager loading. A host application may enable strict lazy-loading behavior independently.
+
+## Select Only Needed Columns
+
+Avoid `SELECT *` — especially when tables have large text or JSON columns.
+
+Incorrect:
+```php
+$posts = Post::with('author')->get();
+```
+
+Correct:
+```php
+$posts = Post::select('id', 'title', 'user_id', 'created_at')
+    ->with(['author:id,name,avatar'])
+    ->get();
+```
+
+When selecting columns on eager-loaded relationships, always include the foreign key column or the relationship won't match.
+
+## Chunk Large Datasets
+
+Never load thousands of records at once. Use chunking for batch processing.
+
+Incorrect:
+```php
+$users = User::all();
+foreach ($users as $user) {
+    $user->notify(new WeeklyDigest);
+}
+```
+
+Correct:
+```php
+User::where('subscribed', true)->chunk(200, function ($users) {
+    foreach ($users as $user) {
+        $user->notify(new WeeklyDigest);
+    }
+});
+```
+
+Use `chunkById()` when modifying records during iteration — standard `chunk()` uses OFFSET which shifts when rows change:
+
+```php
+User::where('active', false)->chunkById(200, function ($users) {
+    $users->each->delete();
+});
+```
+
+## Add Database Indexes
+
+Index columns that appear in `WHERE`, `ORDER BY`, `JOIN`, and `GROUP BY` clauses.
+
+Incorrect:
+```php
+Schema::create('orders', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('user_id')->constrained();
+    $table->string('status');
+    $table->timestamps();
+});
+```
+
+Correct:
+```php
+Schema::create('orders', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('user_id')->index()->constrained();
+    $table->string('status')->index();
+    $table->timestamps();
+    $table->index(['status', 'created_at']);
+});
+```
+
+Add composite indexes for common query patterns (e.g., `WHERE status = ? ORDER BY created_at`).
+
+## Use `withCount()` for Counting Relations
+
+Never load entire collections just to count them.
+
+Incorrect:
+```php
+$posts = Post::all();
+foreach ($posts as $post) {
+    echo $post->comments->count();
+}
+```
+
+Correct:
+```php
+$posts = Post::withCount('comments')->get();
+foreach ($posts as $post) {
+    echo $post->comments_count;
+}
+```
+
+Conditional counting:
+
+```php
+$posts = Post::withCount([
+    'comments',
+    'comments as approved_comments_count' => function ($query) {
+        $query->where('approved', true);
+    },
+])->get();
+```
+
+## Use `cursor()` for Memory-Efficient Iteration
+
+For read-only iteration over large result sets, `cursor()` loads one record at a time via a PHP generator.
+
+Incorrect:
+```php
+$users = User::where('active', true)->get();
+```
+
+Correct:
+```php
+foreach (User::where('active', true)->cursor() as $user) {
+    ProcessUser::dispatch($user->id);
+}
+```
+
+Use `cursor()` for read-only iteration. Use `chunk()` / `chunkById()` when modifying records.
+
+## No Queries in Blade Templates
+
+Never execute queries in Blade templates. Pass data from controllers.
+
+Incorrect:
+```blade
+@foreach (User::all() as $user)
+    {{ $user->profile->name }}
+@endforeach
+```
+
+Correct:
+```php
+// Controller
+$users = User::with('profile')->get();
+return view('users.index', compact('users'));
+```
+
+```blade
+@foreach ($users as $user)
+    {{ $user->profile->name }}
+@endforeach
+```

--- a/.agents/skills/laravel-best-practices/rules/eloquent.md
+++ b/.agents/skills/laravel-best-practices/rules/eloquent.md
@@ -1,0 +1,150 @@
+# Eloquent Best Practices
+
+## Use Correct Relationship Types
+
+Use `hasMany`, `belongsTo`, `morphMany`, etc. with proper return type hints.
+
+```php
+public function comments(): HasMany
+{
+    return $this->hasMany(Comment::class);
+}
+
+public function author(): BelongsTo
+{
+    return $this->belongsTo(User::class, 'user_id');
+}
+```
+
+## Use Local Scopes for Reusable Queries
+
+Extract reusable query constraints into local scopes to avoid duplication.
+
+Incorrect:
+```php
+$active = User::where('verified', true)->whereNotNull('activated_at')->get();
+$articles = Article::whereHas('user', function ($q) {
+    $q->where('verified', true)->whereNotNull('activated_at');
+})->get();
+```
+
+Correct:
+```php
+#[Scope]
+protected function active(Builder $query): Builder
+{
+    return $query->where('verified', true)->whereNotNull('activated_at');
+}
+
+// Usage
+$active = User::active()->get();
+$articles = Article::whereHas('user', fn ($q) => $q->active())->get();
+```
+
+## Apply Global Scopes Sparingly
+
+Global scopes silently modify every query on the model, making debugging difficult. Prefer local scopes and reserve global scopes for truly universal constraints like soft deletes or multi-tenancy.
+
+Incorrect (global scope for a conditional filter):
+```php
+class PublishedScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('published', true);
+    }
+}
+// Now admin panels, reports, and background jobs all silently skip drafts
+```
+
+Correct (local scope you opt into):
+```php
+#[Scope]
+protected function published(Builder $query): Builder
+{
+    return $query->where('published', true);
+}
+
+Post::published()->paginate(); // Explicit
+Post::paginate(); // Admin sees all
+```
+
+## Define Attribute Casts
+
+Use the `casts()` method (or `$casts` property following project convention) for automatic type conversion.
+
+```php
+protected function casts(): array
+{
+    return [
+        'is_active' => 'boolean',
+        'metadata' => 'array',
+        'total' => 'decimal:2',
+    ];
+}
+```
+
+## Cast Date Columns Properly
+
+Always cast date columns. Use Carbon instances in templates instead of formatting strings manually.
+
+Incorrect:
+```blade
+{{ Carbon::createFromFormat('Y-d-m H-i', $order->ordered_at)->toDateString() }}
+```
+
+Correct:
+```php
+protected function casts(): array
+{
+    return [
+        'ordered_at' => 'datetime',
+    ];
+}
+```
+
+```blade
+{{ $order->ordered_at->toDateString() }}
+{{ $order->ordered_at->format('m-d') }}
+```
+
+## Use `whereBelongsTo()` for Relationship Queries
+
+Cleaner than manually specifying foreign keys.
+
+Incorrect:
+```php
+Post::where('user_id', $user->id)->get();
+```
+
+Correct:
+```php
+Post::whereBelongsTo($user)->get();
+Post::whereBelongsTo($user, 'author')->get();
+```
+
+## Avoid Hardcoded Table Names in Queries
+
+Never use string literals for table names in raw queries, joins, or subqueries. Hardcoded table names make it impossible to find all places a model is used and break refactoring (e.g., renaming a table requires hunting through every raw string).
+
+Incorrect:
+```php
+DB::table('users')->where('active', true)->get();
+
+$query->join('companies', 'companies.id', '=', 'users.company_id');
+
+DB::select('SELECT * FROM orders WHERE status = ?', ['pending']);
+```
+
+Correct — reference the model's table:
+```php
+DB::table((new User)->getTable())->where('active', true)->get();
+
+// Even better — use Eloquent or the query builder instead of raw SQL
+User::where('active', true)->get();
+Order::where('status', 'pending')->get();
+```
+
+Prefer Eloquent queries and relationships over `DB::table()` whenever possible — they already reference the model's table. When `DB::table()` or raw joins are unavoidable, always use `(new Model)->getTable()` to keep the reference traceable.
+
+**Exception — migrations:** In migrations, hardcoded table names via `DB::table('settings')` are acceptable and preferred. Models change over time but migrations are frozen snapshots — referencing a model that is later renamed or deleted would break the migration.

--- a/.agents/skills/laravel-best-practices/rules/error-handling.md
+++ b/.agents/skills/laravel-best-practices/rules/error-handling.md
@@ -1,0 +1,47 @@
+# Error Handling Best Practices
+
+## Exception Reporting and Rendering
+
+Keep package-owned exception behavior on the exception class so Core does not need to modify a consumer application's exception configuration.
+
+**Co-location on the exception class** — keeps behavior alongside the exception definition, easier to find:
+
+```php
+class InvalidOrderException extends Exception
+{
+    public function report(): void { /* custom reporting */ }
+
+    public function render(Request $request): Response
+    {
+        return response()->view('errors.invalid-order', status: 422);
+    }
+}
+```
+
+Do not edit or require changes to the host application's `bootstrap/app.php` for package behavior.
+
+## Use `ShouldntReport` for Exceptions That Should Never Log
+
+More discoverable than listing classes in `dontReport()`.
+
+```php
+class PodcastProcessingException extends Exception implements ShouldntReport {}
+```
+
+## Force JSON Error Rendering for API Routes
+
+Core cannot configure the host application's global exception renderer. Package API and MCP endpoints should return explicit responses where needed and tests should send the correct JSON accept headers.
+
+## Add Context to Exception Classes
+
+Attach structured data to exceptions at the source via a `context()` method — Laravel includes it automatically in the log entry.
+
+```php
+class InvalidOrderException extends Exception
+{
+    public function context(): array
+    {
+        return ['order_id' => $this->orderId];
+    }
+}
+```

--- a/.agents/skills/laravel-best-practices/rules/events-notifications.md
+++ b/.agents/skills/laravel-best-practices/rules/events-notifications.md
@@ -1,0 +1,52 @@
+# Events & Notifications Best Practices
+
+## Register Package Listeners Explicitly
+
+Do not assume the host application's event discovery scans package source. Register Cachet listeners through a package service provider and preserve compatibility with cached events.
+
+## Leave Deployment Caching to the Consumer
+
+Core must work when a consumer caches events and configuration, but the package does not own the consumer's deployment commands. Never run `optimize` or `event:cache` as part of package installation.
+
+## Use `ShouldDispatchAfterCommit` Inside Transactions
+
+Without it, a queued listener may process before the DB transaction commits, reading data that doesn't exist yet.
+
+```php
+class OrderShipped implements ShouldDispatchAfterCommit {}
+```
+
+## Always Queue Notifications
+
+Notifications often hit external APIs (email, SMS, Slack). Without `ShouldQueue`, they block the HTTP response.
+
+```php
+class InvoicePaid extends Notification implements ShouldQueue
+{
+    use Queueable;
+}
+```
+
+## Use `afterCommit()` on Notifications in Transactions
+
+Same race condition as events — call `afterCommit()` to delay dispatch until the transaction commits.
+
+```php
+$user->notify((new InvoicePaid($invoice))->afterCommit());
+```
+
+## Route Notification Channels to Dedicated Queues
+
+Mail and database notifications have different priorities. Use `viaQueues()` to route them to separate queues.
+
+## Use On-Demand Notifications for Non-User Recipients
+
+Avoid creating dummy models to send notifications to arbitrary addresses.
+
+```php
+Notification::route('mail', 'admin@example.com')->notify(new SystemAlert());
+```
+
+## Implement `HasLocalePreference` on Notifiable Models
+
+Laravel automatically uses the user's preferred locale for all notifications and mailables — no per-call `locale()` needed.

--- a/.agents/skills/laravel-best-practices/rules/http-client.md
+++ b/.agents/skills/laravel-best-practices/rules/http-client.md
@@ -1,0 +1,160 @@
+# HTTP Client Best Practices
+
+## Always Set Explicit Timeouts
+
+The default timeout is 30 seconds — too long for most API calls. Always set explicit `timeout` and `connectTimeout` to fail fast.
+
+Incorrect:
+```php
+$response = Http::get('https://api.example.com/users');
+```
+
+Correct:
+```php
+$response = Http::timeout(5)
+    ->connectTimeout(3)
+    ->get('https://api.example.com/users');
+```
+
+For service-specific clients, define timeouts in a macro:
+
+```php
+Http::macro('github', function () {
+    return Http::baseUrl('https://api.github.com')
+        ->timeout(10)
+        ->connectTimeout(3)
+        ->withToken(config('services.github.token'));
+});
+
+$response = Http::github()->get('/repos/laravel/framework');
+```
+
+## Use Retry with Backoff for External APIs
+
+External APIs have transient failures. Use `retry()` with increasing delays.
+
+Incorrect:
+```php
+$response = Http::post('https://api.example.com/v1/charges', $data);
+
+if ($response->failed()) {
+    throw new PaymentFailedException('Charge failed');
+}
+```
+
+Correct:
+```php
+$response = Http::retry([100, 500, 1000])
+    ->timeout(10)
+    ->post('https://api.example.com/v1/charges', $data);
+```
+
+Only retry on specific errors:
+
+```php
+$response = Http::retry(3, 100, function (Throwable $exception, PendingRequest $request) {
+    return $exception instanceof ConnectionException
+        || ($exception instanceof RequestException && $exception->response->serverError());
+})->post('https://api.example.com/data');
+```
+
+## Handle Errors Explicitly
+
+The HTTP Client does not throw on 4xx/5xx by default. Always check status or use `throw()`.
+
+Incorrect:
+```php
+$response = Http::get('https://api.example.com/users/1');
+$user = $response->json(); // Could be an error body
+```
+
+Correct:
+```php
+$response = Http::timeout(5)
+    ->get('https://api.example.com/users/1')
+    ->throw();
+
+$user = $response->json();
+```
+
+For graceful degradation:
+
+```php
+$response = Http::get('https://api.example.com/users/1');
+
+if ($response->successful()) {
+    return $response->json();
+}
+
+if ($response->notFound()) {
+    return null;
+}
+
+$response->throw();
+```
+
+## Use Request Pooling for Concurrent Requests
+
+When making multiple independent API calls, use `Http::pool()` instead of sequential calls.
+
+Incorrect:
+```php
+$users = Http::get('https://api.example.com/users')->json();
+$posts = Http::get('https://api.example.com/posts')->json();
+$comments = Http::get('https://api.example.com/comments')->json();
+```
+
+Correct:
+```php
+use Illuminate\Http\Client\Pool;
+
+$responses = Http::pool(fn (Pool $pool) => [
+    $pool->as('users')->get('https://api.example.com/users'),
+    $pool->as('posts')->get('https://api.example.com/posts'),
+    $pool->as('comments')->get('https://api.example.com/comments'),
+]);
+
+$users = $responses['users']->json();
+$posts = $responses['posts']->json();
+```
+
+## Fake HTTP Calls in Tests
+
+Never make real HTTP requests in tests. Use `Http::fake()` and `preventStrayRequests()`.
+
+Incorrect:
+```php
+it('syncs user from API', function () {
+    $service = new UserSyncService;
+    $service->sync(1); // Hits the real API
+});
+```
+
+Correct:
+```php
+it('syncs user from API', function () {
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'api.example.com/users/1' => Http::response([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+        ]),
+    ]);
+
+    $service = new UserSyncService;
+    $service->sync(1);
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'https://api.example.com/users/1';
+    });
+});
+```
+
+Test failure scenarios too:
+
+```php
+Http::fake([
+    'api.example.com/*' => Http::failedConnection(),
+]);
+```

--- a/.agents/skills/laravel-best-practices/rules/mail.md
+++ b/.agents/skills/laravel-best-practices/rules/mail.md
@@ -1,0 +1,27 @@
+# Mail Best Practices
+
+## Implement `ShouldQueue` on the Mailable Class
+
+Makes queueing the default regardless of how the mailable is dispatched. No need to remember `Mail::queue()` at every call site — `Mail::send()` also queues it.
+
+## Use `afterCommit()` on Mailables Inside Transactions
+
+A queued mailable dispatched inside a transaction may process before the commit. Use `$this->afterCommit()` in the constructor.
+
+## Use `assertQueued()` Not `assertSent()` for Queued Mailables
+
+`Mail::assertSent()` only catches synchronous mail. Queued mailables fail `assertSent` with a "Did you mean to use assertQueued()?" hint.
+
+Incorrect: `Mail::assertSent(OrderShipped::class);` when mailable implements `ShouldQueue`.
+
+Correct: `Mail::assertQueued(OrderShipped::class);`
+
+## Use Markdown Mailables for Transactional Emails
+
+Markdown mailables auto-generate both HTML and plain-text versions, use responsive components, and allow global style customization. Generate with `--markdown` flag.
+
+## Separate Content Tests from Sending Tests
+
+Content tests: instantiate the mailable directly, call `assertSeeInHtml()`.
+Sending tests: use `Mail::fake()` and `assertSent()`/`assertQueued()`.
+Don't mix them — it conflates concerns and makes tests brittle.

--- a/.agents/skills/laravel-best-practices/rules/migrations.md
+++ b/.agents/skills/laravel-best-practices/rules/migrations.md
@@ -1,0 +1,121 @@
+# Migration Best Practices
+
+## Generate Package Migrations with Testbench
+
+Use Testbench with an explicit real package path for consistent naming and timestamps. Never leave the generated migration in Testbench's host skeleton.
+
+Incorrect (manually created file):
+```php
+// database/migrations/posts_migration.php  ← wrong naming, no timestamp
+```
+
+Correct (Artisan-generated):
+```bash
+vendor/bin/testbench make:migration create_posts_table --path="$(pwd)/database/migrations" --realpath
+vendor/bin/testbench make:migration add_slug_to_posts_table --path="$(pwd)/database/migrations" --realpath
+```
+
+## Use `constrained()` for Foreign Keys
+
+Automatic naming and referential integrity.
+
+```php
+$table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+// Non-standard names
+$table->foreignId('author_id')->constrained('users');
+```
+
+## Never Modify Deployed Migrations
+
+Once a migration has run in production, treat it as immutable. Create a new migration to change the table.
+
+Incorrect (editing a deployed migration):
+```php
+// 2024_01_01_create_posts_table.php — already in production
+$table->string('slug')->unique(); // ← added after deployment
+```
+
+Correct (new migration to alter):
+```php
+// 2024_03_15_add_slug_to_posts_table.php
+Schema::table('posts', function (Blueprint $table) {
+    $table->string('slug')->unique()->after('title');
+});
+```
+
+## Add Indexes in the Migration
+
+Add indexes when creating the table, not as an afterthought. Columns used in `WHERE`, `ORDER BY`, and `JOIN` clauses need indexes.
+
+Incorrect:
+```php
+Schema::create('orders', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('user_id')->constrained();
+    $table->string('status');
+    $table->timestamps();
+});
+```
+
+Correct:
+```php
+Schema::create('orders', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('user_id')->index()->constrained();
+    $table->string('status')->index();
+    $table->timestamp('shipped_at')->nullable()->index();
+    $table->timestamps();
+});
+```
+
+## Mirror Defaults in Model `$attributes`
+
+When a column has a database default, mirror it in the model so new instances have correct values before saving.
+
+```php
+// Migration
+$table->string('status')->default('pending');
+
+// Model
+protected $attributes = [
+    'status' => 'pending',
+];
+```
+
+## Write Reversible `down()` Methods by Default
+
+Implement `down()` for schema changes that can be safely reversed so `migrate:rollback` works in CI and failed deployments.
+
+```php
+public function down(): void
+{
+    Schema::table('posts', function (Blueprint $table) {
+        $table->dropColumn('slug');
+    });
+}
+```
+
+For intentionally irreversible migrations (e.g., destructive data backfills), leave a clear comment and require a forward fix migration instead of pretending rollback is supported.
+
+## Keep Migrations Focused
+
+One concern per migration. Never mix DDL (schema changes) and DML (data manipulation).
+
+Incorrect (partial failure creates unrecoverable state):
+```php
+public function up(): void
+{
+    Schema::create('settings', function (Blueprint $table) { ... });
+    DB::table('settings')->insert(['key' => 'version', 'value' => '1.0']);
+}
+```
+
+Correct (separate migrations):
+```php
+// Migration 1: create_settings_table
+Schema::create('settings', function (Blueprint $table) { ... });
+
+// Migration 2: seed_default_settings
+DB::table('settings')->insert(['key' => 'version', 'value' => '1.0']);
+```

--- a/.agents/skills/laravel-best-practices/rules/package-development.md
+++ b/.agents/skills/laravel-best-practices/rules/package-development.md
@@ -1,0 +1,45 @@
+# Package Development
+
+Cachet Core is a Laravel package, not the complete host application. Preserve the boundary between package-owned code and the consumer application.
+
+## Package Layout
+
+Map application-oriented examples to the existing package structure:
+
+| Concern | Package path |
+| --- | --- |
+| PHP source | `src/` under the `Cachet\\` namespace |
+| Controllers and middleware | `src/Http/` |
+| Models | `src/Models/` |
+| Filament resources, pages, and widgets | `src/Filament/` |
+| MCP servers and tools | `src/Mcp/` |
+| Configuration | `config/` |
+| Routes | `routes/` or package service-provider registration |
+| Migrations and factories | `database/` |
+| Views, translations, CSS, and JavaScript | `resources/` |
+
+Do not create an `app/` tree or put domain implementation in `workbench/`.
+
+## Host Integration
+
+- Register framework integration through `CachetCoreServiceProvider` or `CachetDashboardServiceProvider`.
+- Load package routes, migrations, views, and translations through Laravel's package APIs.
+- Never edit or assume control of the host application's bootstrap files, route files, exception handler, scheduler, or default configuration.
+- Keep consumer overrides working through namespaced views, configuration, publishing tags, middleware groups, and documented extension points.
+
+## Compatibility
+
+- Support every Laravel version allowed by `composer.json`.
+- Prefer APIs shared by those versions. Add a version-specific branch only when the behavior is required and covered by tests.
+- Treat route names, configuration keys, migration history, publish tags, view namespaces, and public PHP methods as compatibility contracts.
+- Package migrations must upgrade existing Cachet installations safely and must not assume ownership of unrelated application tables.
+
+## Commands and Tests
+
+Run Artisan with `vendor/bin/testbench`. Generator output may land in Testbench's application skeleton; use it only as a reference and place final code in the matching package directory.
+
+Use Orchestra Testbench feature tests for Laravel integration. The `workbench/` directory is a host fixture and should change only when a realistic host application needs new setup.
+
+## Assets
+
+Edit source assets under `resources/`, run `npm run build`, and publish distributable output from `public/`. Testbench's mirrored public assets are disposable build output.

--- a/.agents/skills/laravel-best-practices/rules/queue-jobs.md
+++ b/.agents/skills/laravel-best-practices/rules/queue-jobs.md
@@ -1,0 +1,144 @@
+# Queue & Job Best Practices
+
+## Set `retry_after` Greater Than `timeout`
+
+If `retry_after` is shorter than the job's `timeout`, the queue worker re-dispatches the job while it's still running, causing duplicate execution.
+
+Incorrect (`retry_after` ≤ `timeout`):
+```php
+class ProcessReport implements ShouldQueue
+{
+    public $timeout = 120;
+}
+
+// config/queue.php — retry_after: 90 ← job retried while still running!
+```
+
+Correct (`retry_after` > `timeout`):
+```php
+class ProcessReport implements ShouldQueue
+{
+    public $timeout = 120;
+}
+
+// config/queue.php — retry_after: 180 ← safely longer than any job timeout
+```
+
+## Use Exponential Backoff
+
+Use progressively longer delays between retries to avoid hammering failing services.
+
+Incorrect (fixed retry interval):
+```php
+class SyncWithStripe implements ShouldQueue
+{
+    public $tries = 3;
+    // Default: retries immediately, overwhelming the API
+}
+```
+
+Correct (exponential backoff):
+```php
+class SyncWithStripe implements ShouldQueue
+{
+    public $tries = 3;
+    public $backoff = [1, 5, 10];
+}
+```
+
+## Implement `ShouldBeUnique`
+
+Prevent duplicate job processing.
+
+```php
+class GenerateInvoice implements ShouldQueue, ShouldBeUnique
+{
+    public function uniqueId(): string
+    {
+        return $this->order->id;
+    }
+
+    public $uniqueFor = 3600;
+}
+```
+
+## Always Implement `failed()`
+
+Handle errors explicitly — don't rely on silent failure.
+
+```php
+public function failed(?Throwable $exception): void
+{
+    $this->podcast->update(['status' => 'failed']);
+    Log::error('Processing failed', ['id' => $this->podcast->id, 'error' => $exception->getMessage()]);
+}
+```
+
+## Rate Limit External API Calls in Jobs
+
+Use `RateLimited` middleware to throttle jobs calling third-party APIs.
+
+```php
+public function middleware(): array
+{
+    return [new RateLimited('external-api')];
+}
+```
+
+## Batch Related Jobs
+
+Use `Bus::batch()` when jobs should succeed or fail together.
+
+```php
+Bus::batch([
+    new ImportCsvChunk($chunk1),
+    new ImportCsvChunk($chunk2),
+])
+->then(fn (Batch $batch) => Notification::send($user, new ImportComplete))
+->catch(fn (Batch $batch, Throwable $e) => Log::error('Batch failed'))
+->dispatch();
+```
+
+## `retryUntil()` Needs `$tries = 0`
+
+When using time-based retry limits, set `$tries = 0` to avoid premature failure.
+
+```php
+public $tries = 0;
+
+public function retryUntil(): \DateTimeInterface
+{
+    return now()->addHours(4);
+}
+```
+
+## Use `ShouldBeUniqueUntilProcessing` for Early Lock Release
+
+`ShouldBeUnique` holds the lock until the job completes. `ShouldBeUniqueUntilProcessing` releases it when processing starts, allowing new instances to queue.
+
+```php
+class UpdateSearchIndex implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    // Lock releases when processing begins, not when it finishes
+}
+```
+
+## Use Horizon for Complex Queue Scenarios
+
+Use Laravel Horizon when you need monitoring, auto-scaling, failure tracking, or multiple queues with different priorities.
+
+```php
+// config/horizon.php
+'environments' => [
+    'production' => [
+        'supervisor-1' => [
+            'connection' => 'redis',
+            'queue' => ['high', 'default', 'low'],
+            'balance' => 'auto',
+            'minProcesses' => 1,
+            'maxProcesses' => 10,
+            'tries' => 3,
+        ],
+    ],
+],
+```

--- a/.agents/skills/laravel-best-practices/rules/routing.md
+++ b/.agents/skills/laravel-best-practices/rules/routing.md
@@ -1,0 +1,100 @@
+# Routing & Controllers Best Practices
+
+## Use Implicit Route Model Binding
+
+Let Laravel resolve models automatically from route parameters.
+
+Incorrect:
+```php
+public function show(int $id)
+{
+    $post = Post::findOrFail($id);
+}
+```
+
+Correct:
+```php
+public function show(Post $post)
+{
+    return view('posts.show', ['post' => $post]);
+}
+```
+
+## Use Scoped Bindings for Nested Resources
+
+Enforce parent-child relationships automatically.
+
+```php
+Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
+    // $post is automatically scoped to $user
+})->scopeBindings();
+```
+
+## Use Resource Controllers
+
+Use `Route::resource()` or `apiResource()` for RESTful endpoints.
+
+```php
+Route::resource('posts', PostController::class);
+Route::apiResource('posts', Api\PostController::class);
+```
+
+Core's API and MCP prefixes, names, middleware, domain, and rate limits are applied by `CachetCoreServiceProvider`. Do not assume Laravel's application `routes/api.php` defaults or register a duplicate route group.
+
+## Keep Controllers Thin
+
+Aim for under 10 lines per method. Extract business logic to action or service classes.
+
+Incorrect:
+```php
+public function store(Request $request)
+{
+    $validated = $request->validate([...]);
+    if ($request->hasFile('image')) {
+        $request->file('image')->move(public_path('images'));
+    }
+    $post = Post::create($validated);
+    $post->tags()->sync($validated['tags']);
+    event(new PostCreated($post));
+    return redirect()->route('posts.show', $post);
+}
+```
+
+Correct:
+```php
+public function store(StorePostRequest $request, CreatePostAction $create)
+{
+    $post = $create->execute($request->validated());
+
+    return redirect()->route('posts.show', $post);
+}
+```
+
+## Type-Hint Form Requests
+
+Type-hinting Form Requests triggers automatic validation and authorization before the method executes.
+
+Incorrect:
+```php
+public function store(Request $request): RedirectResponse
+{
+    $validated = $request->validate([
+        'title' => ['required', 'max:255'],
+        'body' => ['required'],
+    ]);
+
+    Post::create($validated);
+
+    return redirect()->route('posts.index');
+}
+```
+
+Correct:
+```php
+public function store(StorePostRequest $request): RedirectResponse
+{
+    Post::create($request->validated());
+
+    return redirect()->route('posts.index');
+}
+```

--- a/.agents/skills/laravel-best-practices/rules/scheduling.md
+++ b/.agents/skills/laravel-best-practices/rules/scheduling.md
@@ -1,0 +1,39 @@
+# Task Scheduling Best Practices
+
+## Use `withoutOverlapping()` on Variable-Duration Tasks
+
+Without it, a long-running task spawns a second instance on the next tick, causing double-processing or resource exhaustion.
+
+## Use `onOneServer()` on Multi-Server Deployments
+
+Without it, every server runs the same task simultaneously. Requires a shared cache driver (Redis, database, Memcached).
+
+## Use `runInBackground()` for Concurrent Long Tasks
+
+By default, tasks at the same tick run sequentially. A slow first task delays all subsequent ones. `runInBackground()` runs them as separate processes.
+
+## Use `environments()` to Restrict Tasks
+
+Prevent accidental execution of production-only tasks (billing, reporting) on staging.
+
+```php
+Schedule::command('billing:charge')->monthly()->environments(['production']);
+```
+
+## Use `takeUntilTimeout()` for Time-Bounded Processing
+
+A task running every 15 minutes that processes an unbounded cursor can overlap with the next run. Bound execution time.
+
+## Use Schedule Groups for Shared Configuration
+
+Avoid repeating `->onOneServer()->timezone('America/New_York')` across many tasks.
+
+```php
+Schedule::daily()
+    ->onOneServer()
+    ->timezone('America/New_York')
+    ->group(function () {
+        Schedule::command('emails:send --force');
+        Schedule::command('emails:prune');
+    });
+```

--- a/.agents/skills/laravel-best-practices/rules/security.md
+++ b/.agents/skills/laravel-best-practices/rules/security.md
@@ -1,0 +1,198 @@
+# Security Best Practices
+
+## Mass Assignment Protection
+
+Every model must define `$fillable` (whitelist) or `$guarded` (blacklist).
+
+Incorrect:
+```php
+class User extends Model
+{
+    protected $guarded = []; // All fields are mass assignable
+}
+```
+
+Correct:
+```php
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}
+```
+
+Never use `$guarded = []` on models that accept user input.
+
+## Authorize Every Action
+
+Use policies or gates in controllers. Never skip authorization.
+
+Incorrect:
+```php
+public function update(UpdatePostRequest $request, Post $post)
+{
+    $post->update($request->validated());
+}
+```
+
+Correct:
+```php
+public function update(UpdatePostRequest $request, Post $post)
+{
+    Gate::authorize('update', $post);
+
+    $post->update($request->validated());
+}
+```
+
+Or via Form Request:
+
+```php
+public function authorize(): bool
+{
+    return $this->user()->can('update', $this->route('post'));
+}
+```
+
+## Prevent SQL Injection
+
+Always use parameter binding. Never interpolate user input into queries.
+
+Incorrect:
+```php
+DB::select("SELECT * FROM users WHERE name = '{$request->name}'");
+```
+
+Correct:
+```php
+User::where('name', $request->name)->get();
+
+// Raw expressions with bindings
+User::whereRaw('LOWER(name) = ?', [strtolower($request->name)])->get();
+```
+
+## Escape Output to Prevent XSS
+
+Use `{{ }}` for HTML escaping. Only use `{!! !!}` for trusted, pre-sanitized content.
+
+Incorrect:
+```blade
+{!! $user->bio !!}
+```
+
+Correct:
+```blade
+{{ $user->bio }}
+```
+
+## CSRF Protection
+
+Include `@csrf` in all POST/PUT/PATCH/DELETE Blade forms. Inertia doesn't use `@csrf`; its HTTP client sends the `XSRF-TOKEN` cookie back as the `X-XSRF-TOKEN` header, which Laravel accepts in place of the `_token` field.
+
+Incorrect:
+```blade
+<form method="POST" action="/posts">
+    <input type="text" name="title">
+</form>
+```
+
+Correct:
+```blade
+<form method="POST" action="/posts">
+    @csrf
+    <input type="text" name="title">
+</form>
+```
+
+## Rate Limit Auth and API Routes
+
+Apply `throttle` middleware to authentication and API routes.
+
+```php
+RateLimiter::for('login', function (Request $request) {
+    return Limit::perMinute(5)->by($request->ip());
+});
+
+Route::post('/login', LoginController::class)->middleware('throttle:login');
+```
+
+## Validate File Uploads
+
+Validate MIME type and size. Both `mimes` and `mimetypes` read the file's contents to guess its MIME type; `mimes` just expresses the allow-list as extensions. The `extensions` rule checks only the client-supplied filename, so never rely on it alone. Never trust client-provided filenames.
+
+```php
+public function rules(): array
+{
+    return [
+        'avatar' => ['required', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
+    ];
+}
+```
+
+Store with generated filenames:
+
+```php
+$path = $request->file('avatar')->store('avatars', 'public');
+```
+
+## Keep Secrets Out of Code
+
+Never commit `.env`. Access secrets via `config()` only.
+
+Incorrect:
+```php
+$key = env('API_KEY');
+```
+
+Correct:
+```php
+// config/services.php
+'api_key' => env('API_KEY'),
+
+// In application code
+$key = config('services.api_key');
+```
+
+## Audit Dependencies
+
+Run `composer audit` periodically to check for known vulnerabilities in dependencies. Automate this in CI to catch issues before deployment.
+
+```bash
+composer audit
+```
+
+## Encrypt Sensitive Database Fields
+
+Use `encrypted` cast for API keys/tokens and mark the attribute as `hidden`.
+
+Incorrect:
+```php
+class Integration extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'api_key' => 'string',
+        ];
+    }
+}
+```
+
+Correct:
+```php
+class Integration extends Model
+{
+    protected $hidden = ['api_key', 'api_secret'];
+
+    protected function casts(): array
+    {
+        return [
+            'api_key' => 'encrypted',
+            'api_secret' => 'encrypted',
+        ];
+    }
+}
+```

--- a/.agents/skills/laravel-best-practices/rules/style.md
+++ b/.agents/skills/laravel-best-practices/rules/style.md
@@ -1,0 +1,125 @@
+# Conventions & Style
+
+## Follow Laravel Naming Conventions
+
+| What | Convention | Good | Bad |
+|------|-----------|------|-----|
+| Controller | singular | `ArticleController` | `ArticlesController` |
+| Model | singular | `User` | `Users` |
+| Table | plural, snake_case | `article_comments` | `articleComments` |
+| Pivot table | singular alphabetical | `article_user` | `user_article` |
+| Column | snake_case, no model name | `meta_title` | `article_meta_title` |
+| Foreign key | singular model + `_id` | `article_id` | `articles_id` |
+| Route | plural | `articles/1` | `article/1` |
+| Route name | snake_case with dots | `users.show_active` | `users.show-active` |
+| Method | camelCase | `getAll` | `get_all` |
+| Variable | camelCase | `$articlesWithAuthor` | `$articles_with_author` |
+| Collection | descriptive, plural | `$activeUsers` | `$data` |
+| Object | descriptive, singular | `$activeUser` | `$users` |
+| View | kebab-case | `show-filtered.blade.php` | `showFiltered.blade.php` |
+| Config | snake_case | `google_calendar.php` | `googleCalendar.php` |
+| Enum | singular | `UserType` | `UserTypes` |
+
+## Prefer Shorter Readable Syntax
+
+| Verbose | Shorter |
+|---------|---------|
+| `Session::get('cart')` | `session('cart')` |
+| `$request->session()->get('cart')` | `session('cart')` |
+| `$request->input('name')` | `$request->name` |
+| `return Redirect::back()` | `return back()` |
+| `Carbon::now()` | `now()` |
+| `App::make('Class')` | `app('Class')` |
+| `->where('column', '=', 1)` | `->where('column', 1)` |
+| `->orderBy('created_at', 'desc')` | `->latest()` |
+| `->orderBy('created_at', 'asc')` | `->oldest()` |
+| `->first()->name` | `->value('name')` |
+
+## Use Laravel String & Array Helpers
+
+Laravel provides `Str`, `Arr`, `Number`, and `Uri` helper classes that are more readable, chainable, and UTF-8 safe than raw PHP functions. Always prefer them.
+
+Strings — use `Str` and fluent `Str::of()` over raw PHP:
+```php
+// Incorrect
+$slug = strtolower(str_replace(' ', '-', $title));
+$short = substr($text, 0, 100) . '...';
+$class = substr(strrchr('App\Models\User', '\\'), 1);
+
+// Correct
+$slug = Str::slug($title);
+$short = Str::limit($text, 100);
+$class = class_basename('App\Models\User');
+```
+
+Fluent strings — chain operations for complex transformations:
+```php
+// Incorrect
+$result = strtolower(trim(str_replace('_', '-', $input)));
+
+// Correct
+$result = Str::of($input)->trim()->replace('_', '-')->lower();
+```
+
+Key `Str` methods to prefer: `Str::slug()`, `Str::limit()`, `Str::contains()`, `Str::before()`, `Str::after()`, `Str::between()`, `Str::camel()`, `Str::snake()`, `Str::kebab()`, `Str::headline()`, `Str::squish()`, `Str::mask()`, `Str::uuid()`, `Str::ulid()`, `Str::random()`, `Str::is()`.
+
+Arrays — use `Arr` over raw PHP:
+```php
+// Incorrect
+$name = isset($array['user']['name']) ? $array['user']['name'] : 'default';
+
+// Correct
+$name = Arr::get($array, 'user.name', 'default');
+```
+
+Key `Arr` methods: `Arr::get()`, `Arr::has()`, `Arr::only()`, `Arr::except()`, `Arr::first()`, `Arr::flatten()`, `Arr::pluck()`, `Arr::where()`, `Arr::wrap()`.
+
+Numbers — use `Number` for display formatting:
+```php
+Number::format(1000000);          // "1,000,000"
+Number::currency(1500, 'USD');    // "$1,500.00"
+Number::abbreviate(1000000);      // "1M"
+Number::fileSize(1024 * 1024);    // "1 MB"
+Number::percentage(75.5);         // "75.5%"
+```
+
+URIs — use `Uri` for URL manipulation:
+```php
+$uri = Uri::of('https://example.com/search')
+    ->withQuery(['q' => 'laravel', 'page' => 1]);
+```
+
+Use `$request->string('name')` to get a fluent `Stringable` directly from request input for immediate chaining.
+
+Use `search-docs` for the full list of available methods — these helpers are extensive.
+
+## No Inline JS/CSS in Blade
+
+Do not put JS or CSS in Blade templates. Do not put HTML in PHP classes.
+
+Incorrect:
+```blade
+let article = `{{ json_encode($article) }}`;
+```
+
+Correct:
+```blade
+<button class="js-fav-article" data-article='@json($article)'>{{ $article->name }}</button>
+```
+
+Pass data to JS via data attributes or use a dedicated PHP-to-JS package.
+
+## No Unnecessary Comments
+
+Code should be readable on its own. Use descriptive method and variable names instead of comments. The only exception is config files, where descriptive comments are expected.
+
+Incorrect:
+```php
+// Check if there are any joins
+if (count((array) $builder->getQuery()->joins) > 0)
+```
+
+Correct:
+```php
+if ($this->hasJoins())
+```

--- a/.agents/skills/laravel-best-practices/rules/validation.md
+++ b/.agents/skills/laravel-best-practices/rules/validation.md
@@ -1,0 +1,75 @@
+# Validation & Forms Best Practices
+
+## Use Form Request Classes
+
+Extract validation from controllers into dedicated Form Request classes.
+
+Incorrect:
+```php
+public function store(Request $request)
+{
+    $request->validate([
+        'title' => 'required|max:255',
+        'body' => 'required',
+    ]);
+}
+```
+
+Correct:
+```php
+public function store(StorePostRequest $request)
+{
+    Post::create($request->validated());
+}
+```
+
+## Array vs. String Notation for Rules
+
+Array syntax is more readable and composes cleanly with `Rule::` objects. Prefer it in new code, but check existing Form Requests first and match whatever notation the project already uses.
+
+```php
+// Preferred for new code
+'email' => ['required', 'email', Rule::unique('users')],
+
+// Follow existing convention if the project uses string notation
+'email' => 'required|email|unique:users',
+```
+
+## Always Use `validated()`
+
+Get only validated data. Never use `$request->all()` for mass operations.
+
+Incorrect:
+```php
+Post::create($request->all());
+```
+
+Correct:
+```php
+Post::create($request->validated());
+```
+
+## Use `Rule::when()` for Conditional Validation
+
+```php
+'company_name' => [
+    Rule::when($this->account_type === 'business', ['required', 'string', 'max:255']),
+],
+```
+
+## Use the `after()` Method for Custom Validation
+
+Use `after()` instead of `withValidator()` for custom validation logic that depends on multiple fields.
+
+```php
+public function after(): array
+{
+    return [
+        function (Validator $validator) {
+            if ($this->quantity > Product::find($this->product_id)?->stock) {
+                $validator->errors()->add('quantity', 'Not enough stock.');
+            }
+        },
+    ];
+}
+```

--- a/.agents/skills/mcp-development/SKILL.md
+++ b/.agents/skills/mcp-development/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: mcp-development
+description: "Use this skill for Cachet's Laravel MCP server. Trigger when creating or editing MCP tools, resources, prompts, server registration, schemas, annotations, authentication, authorization, visibility, or MCP tests. Do not use for non-Laravel MCP projects or generic AI features without MCP."
+license: MIT
+metadata:
+  author: laravel
+---
+# MCP Development
+
+## Documentation First
+
+**CRITICAL**: Always use `search-docs` BEFORE writing MCP code. The documentation is version-specific, comprehensive, and always up-to-date.
+
+```bash
+# Example searches
+search-docs(['mcp tools', 'mcp resources', 'mcp validation'])
+```
+
+## Core Package Conventions
+
+- Keep the server and primitives under `src/Mcp` in the `Cachet\\Mcp` namespace.
+- Register the web server through `CachetCoreServiceProvider`; do not create `routes/ai.php` or modify a host application.
+- Do not use `make:mcp-*` generators for final code. They target Testbench's host skeleton. Follow sibling tools and create the package file in `src/Mcp`.
+- Keep server availability, authentication, rate limiting, token abilities, and record visibility aligned with `config/cachet.php`, the MCP middleware, and existing concerns.
+- Every write tool must guard the matching Sanctum ability in both `handle()` and `shouldRegister()`.
+- Use the Laravel MCP annotation matching the side effect, including `#[IsReadOnly]`, `#[IsIdempotent]`, and `#[IsDestructive]` where applicable.
+- Put feature coverage under `tests/Feature/Mcp` and architecture coverage under `tests/Architecture/McpTest.php`.
+
+## Quick Reference
+
+### Package Layout
+
+Inspect the closest tool and its feature test before adding a primitive. Reuse `GuardsMcpAbilities`, `PresentsResources`, visibility scopes, pagination, and domain actions instead of duplicating those mechanics.
+
+### Basic Tool Implementation
+
+```php
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class MyTool extends Tool
+{
+    protected string $description = 'Tool description for LLM';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'param' => $schema->string()->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        return Response::text($request->get('param'));
+    }
+}
+```
+
+### Basic Resource Implementation
+
+```php
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Resource;
+
+class MyResource extends Resource
+{
+    protected string $description = 'Resource description';
+    protected string $uri = 'file://path/to/resource';
+    protected string $mimeType = 'text/markdown';
+
+    public function handle(): Response
+    {
+        return Response::text($content);
+    }
+}
+```
+
+### Response Methods
+
+```php
+Response::text('Text content');
+Response::error('Error message');
+Response::structured(['key' => 'value']);
+```
+
+## Testing MCP Primitives
+
+Test tools, resources, and prompts directly on their server:
+
+```php
+// Test a tool
+$response = CachetServer::tool(MyTool::class, ['param' => 'value']);
+$response->assertOk()->assertSee('Expected text');
+
+// Test as an authenticated user with the matching token ability
+Sanctum::actingAs($user, ['resource.manage']);
+$response = CachetServer::tool(MyTool::class, [...]);
+
+// Available assertions
+$response->assertOk();
+$response->assertSee('text');
+$response->assertHasErrors();
+$response->assertHasNoErrors();
+$response->assertName('tool-name');
+$response->assertSentNotification('event/type', ['data' => 'value']);
+```
+
+For write tools, also assert the database change, side effects, missing ability, and whether the tool is hidden from callers without that ability. Test status-page visibility whenever the tool reads a scoped record.
+
+### MCP Inspector
+
+Test interactively using the inspector:
+
+```bash
+vendor/bin/testbench route:list --name=cachet.mcp
+vendor/bin/testbench mcp:inspector mcp
+```
+
+The inspector is interactive and may install frontend tooling. Run it only when interactive debugging is needed.
+
+## Available Features
+
+The following features exist—**use `search-docs` for implementation details**:
+
+- **Tools**: `schema()`, validation, annotations (`#[IsReadOnly]`, `#[IsDestructive]`, etc.)
+- **Resources**: URI templates (`HasUriTemplate`), Dynamic resources
+- **Prompts**: Arguments, multi-message responses
+- **All primitives**: Dependency injection, `shouldRegister()`, validation
+- **Responses**: Text, error, structured, streaming, metadata
+- **Server registration**: Web routes, local routes, OAuth
+
+## Critical Imports
+
+```php
+use Laravel\Mcp\Request;           // NOT Laravel\Mcp\Server\Request
+use Laravel\Mcp\Response;          // NOT Laravel\Mcp\Server\Response
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Prompt;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+```
+
+## Common Pitfalls
+
+- **Not using `search-docs` before implementation**
+- Wrong imports: `Laravel\Mcp\Server\Request` (wrong) vs `Laravel\Mcp\Request` (correct)
+- Forgetting `schema()` method for tools with parameters
+- Missing required properties: `$description`, `$uri`, `$mimeType`
+- Wrong response pattern: `new Response()` instead of `Response::text()`
+- Generating final package code into Testbench's application skeleton
+- Registering a second server in `routes/ai.php` instead of extending `CachetServer`
+- Exposing a write tool without the matching Sanctum ability and registration guard
+- Returning records without Cachet's visibility scope
+- Running `mcp:start` command locally (hangs waiting for stdin)

--- a/.agents/skills/psalm-security-analysis/SKILL.md
+++ b/.agents/skills/psalm-security-analysis/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: psalm-security-analysis
+description: >
+  Runs and interprets Psalm security (taint) analysis on a Laravel project. Use when the user asks
+  to find security vulnerabilities, run a security scan, check for SQL injection or XSS, audit code
+  for taint issues, or fix Psalm taint errors. Also use when investigating data flow from user input
+  to sensitive operations, even if the user doesn't explicitly mention Psalm or taint analysis.
+  Requires psalm-plugin-laravel installed.
+metadata:
+  author: alies-dev
+  version: '1.1'
+---
+
+# Psalm Security Analysis for Laravel
+
+## Core Package Scope
+
+- Use the repository's `psalm.xml`. It enables taint analysis for `src/`, `database/factories`, `database/seeders`, and `config/`.
+- Core currently has no `psalm-baseline.xml`, so use a full run unless a baseline is deliberately added later.
+- Treat public status-page, API, webhook, and MCP inputs as package entry points. Account for the host application's middleware without assuming it makes package code safe.
+- Review Blade output separately because `resources/views` is outside Psalm's configured project files.
+- Use paths under `src/`, not application-oriented `app/` examples.
+- Report findings before changing code. Do not add a baseline or suppression without explaining the specific false positive.
+
+## Running the analysis
+
+Determine which mode to use from the user's prompt before running anything:
+
+- **Incremental** ("any new issues?", "check for regressions", "did I break anything?") → baseline run
+- **Full audit** ("find vulnerabilities", "full scan", "audit security", "show all" or `psalm-baseline.xml` file is not available in the project) → full run
+
+`--output-format` and `--report` are independent simultaneous channels. One run produces both a text stdout summary and a structured JSON report with full taint traces, covering all triage needs.
+
+**Do not pipe the command output** (e.g. `| grep` or `| head`). Psalm writes the `--report` file at the very end of execution; piping to a command that exits early sends SIGPIPE and kills Psalm before the file is written. The Bash tool captures all stdout automatically, so this is only a risk if you write a piped command explicitly.
+
+**Baseline run** respects `psalm-baseline.xml`, reports only *new* findings since it was created:
+
+```bash
+./vendor/bin/psalm --taint-analysis --no-cache --no-progress --no-suggestions \
+  --output-format=text \
+  --report=/tmp/psalm_taint.json
+```
+
+Exit 0 with no text output = no new issues.
+
+**Full run** ignores baseline, surfaces all findings:
+
+```bash
+./vendor/bin/psalm --taint-analysis --no-cache --no-progress --no-suggestions \
+  --ignore-baseline \
+  --output-format=text \
+  --report=/tmp/psalm_taint.json
+```
+
+- stdout — text output with `ERROR_CODE - message` format, visible immediately in the tool result without reading any file
+- `/tmp/psalm_taint.json` — structured report with full source→sink taint trace chains; use `jq` to pull individual findings without reading the whole file (`txt` format is redundant with stdout and lacks trace data)
+
+## Triage
+
+Use the text stdout output to assess the scope. For individual findings, query the JSON — this avoids reading the entire report:
+
+```bash
+# All taint issue types found
+jq -r '[.issues[].type] | unique[]' /tmp/psalm_taint.json | grep Tainted
+
+# Full trace for a specific issue type
+jq '.issues[] | select(.type == "TaintedSql")' /tmp/psalm_taint.json
+
+# Issues in a specific directory
+jq '.issues[] | select(.file_path | contains("src/Http"))' /tmp/psalm_taint.json
+
+# Affected files (unique)
+jq -r '.issues[] | select(.type | startswith("Tainted")) | .file_name' /tmp/psalm_taint.json | sort -u
+```
+
+### Triage each finding
+
+Use the taint trace from the JSON report as your primary source. For each finding, answer three questions:
+
+1. **Is there a real path from user input to the sink?** (or is the tainted value from a model/service that doesn't actually accept user data?)
+2. **Is there any sanitization/validation between source and sink?** (allowlist check, `in_array`, cast to int, `e()`, parameterized query?)
+3. **What's the access level?** (public endpoint vs admin-only, affects real-world exploitability)
+
+If the answer to #1 is yes and #2 is no → **real issue**. Document it with file, line, sink type, and severity.
+
+If the taint trace is insufficient, fall back to manually opening the file and reading ~20 lines of context around the flagged line.
+
+### Trace cross-file taint flows manually (when needed)
+
+When Psalm flags a method inside a service class and the trace doesn't surface the origin, grep for usages:
+
+```bash
+rg -n -- "->methodName\\(" src/
+```
+
+Then read the caller to see how arguments are passed, whether they originate from `$request->input()` or from trusted internal sources.
+
+### Report
+
+Group findings by type (SQL injection, open redirect, SSRF, etc.) and severity. For each:
+- Confirmed real: document file, line, input source, sink, fix
+- False positive: document why (allowlist protection, admin-only, model-generated value, etc.) and whether to suppress inline with `@psalm-suppress`
+
+## How taint analysis works
+
+Psalm tracks data from **sources** (user input) through the code to **sinks** (dangerous operations). Unsanitized taint reaching a sink triggers an issue.
+
+**Sources**, including but not limited to:
+
+- `$request->input()`, `$request->query()`, `$request->all()`, `$request->post()`, `$request->cookie()`, `$request->header()`, `$request->json()`, `$request->only()`, `$request->except()`
+- `$request->ip()`, `$request->userAgent()`, `$request->url()`, `$request->fullUrl()`, `$request->path()`, `$request->getContent()`
+- Route parameters via `$request->route()->parameter('id')` or `$request->route('id')`
+- `Session::get()`, `Session::pull()`, `Session::all()`, `session()` values
+- Validator `validated()`, `safe()` output, `ValidatedInput` methods
+- `UploadedFile::getClientOriginalName()`, `getClientOriginalExtension()`, `getClientMimeType()`
+- `request()` and `old()` helper functions
+- `Http\Client\Response` methods: `->body()`, `->json()`, `->object()`, `->collect()` (HTTP client responses are taint sources; in SSRF chains, the response body may carry user-influenced data)
+
+**Sinks**, including but not limited to:
+
+- SQL: `DB::statement()`, `DB::unprepared()`, `DB::select()`, `DB::insert()`, `DB::update()`, `DB::delete()`, `whereRaw()`, `selectRaw()`, `orderByRaw()`, `groupByRaw()`, `havingRaw()`, and other raw query methods
+- Shell: `Process::run()`, `Process::start()`, `Process::command()`
+- HTML/XSS: `Response::make()`, `response()`, `View::share()`, `HtmlString`, `Mailable::html()`, `MailMessage::line()`, `MailMessage::subject()` (includes `TaintedHtml` for raw output and `TaintedTextWithQuotes` for attribute injection via quote chars)
+- SSRF: `PendingRequest::get()`, `PendingRequest::post()`, `PendingRequest::put()`, `PendingRequest::send()` and other HTTP client methods (note: `Http::get()` facade calls may not propagate taint due to a known `__callStatic` limitation; call the underlying class directly for reliable detection)
+- File: `Storage::get()`, `Storage::put()`, `Storage::delete()`, `File::get()`, `File::delete()`, and related filesystem methods
+- Redirect: `redirect()->to()`, `Redirect::away()`, `Redirect::guest()`, `Redirect::intended()`
+- Mail headers: `Mailable::to()`, `Mailable::cc()`, `Mailable::bcc()`, `Mailable::subject()`, `MailMessage::cc()`, `MailMessage::subject()`
+- Cookie: `CookieJar::make()`, `CookieJar::forever()`, `cookie()` helper; `$path` and `$domain` parameters on `Cookie`/`CookieJar` methods (including `expire()`, `forget()`) are header-injection sinks
+- Redis: `Redis::eval()`, `Redis::executeRaw()` (Lua script injection sinks; note facade calls may not propagate taint due to the `__callStatic` limitation; the stubs target `PhpRedisConnection` directly)
+- Secret leaking: `TaintedUserSecret` and `TaintedSystemSecret` fire when encrypted or hashed values (marked as secrets by `bcrypt()`, `encrypt()`, etc.) reach HTML output
+
+**Escapes** (what removes taint):
+
+- HTML: `e()` helper, `Js::from()`, `Js::encode()` (remove `html` taint)
+- SQL: `DB::escape()`, `Connection::escape()` (remove `sql` taint)
+- Crypto: `encrypt()` helper, `bcrypt()` helper, `Encrypter::encrypt()`, `HashManager::make()` (remove `user_secret`/`system_secret` taint; facade calls like `Crypt::encrypt()` may not propagate due to `__callStatic` limitation)
+- Parameterized queries (`DB::select('...?', [$value])`) are safe. Only string interpolation into raw SQL is flagged.
+
+> **Note**: `Str::of($input)` and `str($input)` propagate input taint to the returned `Stringable` but do not escape it. Psalm cannot track taint through subsequent chain calls (`->upper()`, `->slug()`) due to a `$this` flow limitation.
+
+## Severity Classification
+
+Use this when reporting findings:
+
+- **HIGH**: public endpoint, direct exploitation, data exfiltration or code execution possible
+- **MEDIUM**: public endpoint but requires specific conditions, or significant impact (open redirect, SSRF with format validation only)
+- **LOW**: admin/authenticated-only endpoints; reduces blast radius but still warrants fixing
+- **FALSE**: false positive
+
+Open redirect in an auth flow (post-login redirect) is always HIGH. It enables phishing with a legitimate domain URL.
+
+## Fixing taint issues
+
+### TaintedSql
+
+```php
+// BAD — string interpolation
+DB::statement("DELETE FROM users WHERE id = " . $request->input('id'));
+
+// GOOD — parameterized
+DB::statement("DELETE FROM users WHERE id = ?", [$request->input('id')]);
+
+// GOOD — Eloquent (always parameterized)
+User::where('id', $request->input('id'))->delete();
+```
+
+**Subtle case — `orderBy()` column injection**: Unlike value parameters, column names passed to `orderBy()` are NOT parameterized by Eloquent.
+They go directly into the SQL as identifiers. This is a very common real vulnerability in sort/filter API endpoints.
+
+```php
+// BAD — real SQL injection: column name is not parameterized
+$col = $request->query('col', 'id');
+$dir = $request->query('dir', 'desc');
+User::orderBy($col, $dir)->get();
+
+// GOOD — validate against an allowlist before use
+$allowedCols = ['id', 'username', 'created_at'];
+$allowedDirs = ['asc', 'desc'];
+$col = in_array($request->query('col'), $allowedCols) ? $request->query('col') : 'id';
+$dir = in_array($request->query('dir'), $allowedDirs) ? $request->query('dir') : 'asc';
+User::orderBy($col, $dir)->get();
+```
+
+### TaintedShell
+
+```php
+// BAD — tainted
+Process::run('grep ' . $request->input('pattern') . ' /var/log/app.log');
+
+// GOOD — array syntax avoids shell interpolation
+Process::run(['grep', $request->input('pattern'), '/var/log/app.log']);
+```
+
+### TaintedHtml / TaintedTextWithQuotes
+
+`TaintedHtml` fires when user input reaches raw HTML output. `TaintedTextWithQuotes` is a stricter variant that flags content that could break HTML attributes via quote characters.
+
+```php
+// BAD — tainted
+return response()->make('<h1>' . $request->input('name') . '</h1>');
+
+// GOOD — escape output (removes both html and text-with-quotes taint)
+return response()->make('<h1>' . e($request->input('name')) . '</h1>');
+
+// GOOD — Blade auto-escapes with {{ }}
+return view('greeting', ['name' => $request->input('name')]);
+```
+
+**Also watch for**: unescaped user data in mail notifications and API-fetched content echoed directly:
+
+```php
+// BAD — password in notification email is unescaped user data
+(new MailMessage)->line('Password: ' . $server->authentication['pass']);
+
+// GOOD — escape it (or better: don't send passwords in emails at all)
+(new MailMessage)->line('Password: ' . e($server->authentication['pass']));
+
+// BAD — SSRF → XSS chain: HTTP response body echoed directly
+$response = Http::get($url)->throw();
+echo $response->body(); // TaintedHtml — response may contain attacker-controlled content
+
+// GOOD — only safe if $url is hardcoded or from a trusted source; otherwise escape
+echo e($response->body());
+```
+
+### TaintedSSRF
+
+```php
+// BAD — tainted
+Http::get($request->input('callback_url'));
+
+// GOOD — derive endpoint from validated input, never use the URL directly
+$endpoint = match ($request->input('service')) {
+    'users' => 'https://api.example.com/users',
+    'orders' => 'https://api.example.com/orders',
+    default => abort(422, 'Invalid service'),
+};
+Http::get($endpoint);
+```
+
+### TaintedFile
+
+```php
+// BAD — tainted
+Storage::get($request->input('path'));
+
+// GOOD — map user input to a known path
+$allowedFiles = ['report' => 'reports/q1.pdf', 'invoice' => 'invoices/latest.pdf'];
+$path = $allowedFiles[$request->input('file')] ?? abort(404);
+Storage::get($path);
+```
+
+### TaintedHeader
+
+```php
+// BAD — tainted (open redirect)
+return redirect($request->input('next'));
+
+// GOOD — named route or allowlist
+return redirect()->route('dashboard');
+
+$redirects = ['profile' => '/profile', 'settings' => '/settings'];
+return redirect($redirects[$request->input('next')] ?? '/');
+```
+
+**Subtle case — Referer header redirect**: The `Referer` header is fully user-controlled and redirecting to it is an open redirect. Use `back()` instead:
+
+```php
+// BAD — real open redirect: Referer header is user-controlled
+return redirect(request()->header('Referer'));
+
+// GOOD — back() is safe (uses server-managed history, not the header)
+return back();
+```
+
+### TaintedCallable
+
+Fires when a user-controlled string is used to instantiate a class or call a function dynamically. Often appears in admin testing or notification preview controllers.
+
+```diff
+$class = $request->input('errorType');
+- if (!class_exists($class)) { abort(400); } / BAD — any existing PHP class can be instantiated, not just Throwable subclasses
++ if (!class_exists($class) || !is_subclass_of($class, \Throwable::class)) { abort(400, 'Unknown exception'); } // // GOOD — restrict to the expected type with is_subclass_of
+throw new $class(); // TaintedCallable
+```
+
+> Note: even with `class_exists()`, without a type check any instantiatable class can be constructed. `is_subclass_of()` is the correct guard.
+
+## Cross-function taint flows
+
+Taint flows across function/method boundaries:
+
+```php
+// BAD — taint flows: $request->input() → getQuery() → DB::select()
+class ReportService {
+    public function getQuery(string $filter): string {
+        return "SELECT * FROM reports WHERE status = '$filter'";
+    }
+}
+$results = DB::select($service->getQuery($request->input('status')));
+
+// GOOD — parameterize inside the service
+class ReportService {
+    public function getResults(string $filter): array {
+        return DB::select("SELECT * FROM reports WHERE status = ?", [$filter]);
+    }
+}
+```
+
+## Suppressing false positives
+
+For confirmed false positives, use `@psalm-suppress` inline — this is more precise than a blanket baseline entry and keeps the reason next to the code:
+
+```php
+/** @psalm-suppress TaintedHeader -- redirect target is constructed by the application, not user-controlled */
+return redirect($model->url());
+
+/** @psalm-suppress TaintedSSRF -- intentional federation fetch; domain is a validated fediverse handle */
+Http::get('https://' . $domain . '/api/v1/apps');
+
+/** @psalm-suppress TaintedUserSecret TaintedSystemSecret -- Alpine.js component state; Js::from() JSON-encodes safely */
+echo Js::from($componentState);
+```
+
+Do **not** add taint suppressions to `psalm-baseline.xml` — inline `@psalm-suppress` makes the decision visible and reviewable.
+
+## Common false positives
+
+- **Validated input**: `$request->validated()` and `$request->safe()` are marked as taint sources because validation rules don't guarantee safety against all sink types (a valid email is still dangerous in raw SQL). If the validated data is used safely (e.g., in Eloquent), use `@psalm-suppress TaintedSql`.
+- **Eloquent and Query Builder**: `User::where('col', $value)` is safe — Eloquent and Builder parameterized methods carry `@psalm-taint-escape sql`. Psalm should not flag these; if it does, use `@psalm-suppress` and report about false-positive.
+- **Blade view data**: Passing variables to Blade templates (`view('name', ['key' => $value])`) does **not** trigger `TaintedHtml`. Use `{{ $value }}` for auto-escaped output; `{!! $value !!}` only for explicitly trusted HTML.
+- **Integer casting**: `(int) $request->input('page')` should remove taint. If Psalm still flags it, use `@psalm-suppress TaintedSql`.
+- **Runtime validation**: Psalm cannot track runtime checks (URL allowlists, `basename()`, `str_starts_with()`) as taint escapes. After manually validating input, suppress with `@psalm-suppress`.
+- **Model-generated redirects**: `redirect($model->url())` is flagged as `TaintedHeader` because taint propagates from user input stored in the database through model properties. If the URL is constructed by your model (not passed through directly from user input), use `@psalm-suppress TaintedHeader`.
+- **Service provider / cloud API clients**: Apps that make authenticated HTTP calls to external APIs (Linode, Bitbucket, Stripe, fediverse/ActivityPub) will show `TaintedSSRF` for expected outgoing requests. Suppress with `@psalm-suppress TaintedSSRF` and a comment naming the target service.
+- **`Js::from()` with encrypted component state**: `TaintedUserSecret`/`TaintedSystemSecret` may fire when Filament (or similar) passes encrypted state to Alpine.js via `Js::from()`. `Js::from()` JSON-encodes the data safely but does not escape secret taint — this is a known plugin limitation. Suppress with `@psalm-suppress TaintedUserSecret TaintedSystemSecret`.
+
+- **Allowlist-protected file access**: `TaintedFile` is a false positive when user input is validated against an explicit allowlist (`in_array($path, $allowedPaths, true)`) before being passed to `Storage::get()` or similar. Read the surrounding code — if there's an allowlist check that aborts on mismatch, suppress it.
+- **Database-stored emails in mail headers**: `TaintedHeader` on `->cc($member->getEmail())` or similar notification methods is a false positive when the email is a database-stored model property, not a value passed through directly from a current request. The practical risk is near-zero for stored, validated emails.
+- **SSRF with `url` validation rule**: `TaintedSSRF` is a real issue even when `['url']` validation is applied — the rule only validates format, not destination. An internal-URL allowlist or private-IP block is required to make this safe.
+
+Potential low-risk taints:
+- **Cache**: considered as safe, but may contain user-controlled data. Plugin does not report about it to reduce noise.
+
+## Reporting false positives
+
+If you encounter a finding that looks like a plugin or Psalm bug — ask the user to open an issue at https://github.com/psalm/psalm-plugin-laravel/issues with a minimal reproduction.

--- a/.agents/skills/tailwindcss-development/SKILL.md
+++ b/.agents/skills/tailwindcss-development/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: tailwindcss-development
+description: "Use for Cachet Tailwind CSS and UI styling: Blade utility classes, public status-page components, Filament dashboard theme work, responsive layout, dark mode, spacing, typography, and Tailwind v4 source configuration. Skip for backend PHP logic, database queries, API routes, and JavaScript with no HTML or CSS change."
+license: MIT
+metadata:
+  author: laravel
+---
+# Tailwind CSS Development
+
+## Documentation
+
+Use `search-docs` for detailed Tailwind CSS v4 patterns and documentation.
+
+## Core Package Conventions
+
+- Core uses Tailwind CSS v4 only.
+- Public status-page styles enter through `resources/css/cachet.css` and package Blade views under `resources/views`.
+- Dashboard styles enter through `resources/css/dashboard/theme.css`. Prefer Filament components and supported theme hooks before adding selectors against Filament internals.
+- Preserve the existing CSS-first configuration, `@source` boundaries, plugins, theme variables, and `cachet::` Blade component namespace.
+- The public status page follows `prefers-color-scheme`; the Filament dashboard follows its `.dark` class. Match the convention of the surface being changed.
+- Source files live under `resources/`. Run `composer build` first when the Testbench host is absent, then run `npm run build` after CSS, Blade utility, or frontend JavaScript changes. Never edit Testbench's mirrored assets.
+- The Vite build produces the package's publishable assets and mirrors them into the Testbench skeleton for feature tests.
+
+## Basic Usage
+
+- Use Tailwind CSS classes to style HTML. Check and follow existing Tailwind conventions in the project before introducing new patterns.
+- Offer to extract repeated patterns into components that match the project's conventions (e.g., Blade, JSX, Vue).
+- Consider class placement, order, priority, and defaults. Remove redundant classes, add classes to parent or child elements carefully to reduce repetition, and group elements logically.
+
+## Tailwind CSS v4 Specifics
+
+- Always use Tailwind CSS v4 and avoid deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+
+### CSS-First Configuration
+
+In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed:
+
+<!-- CSS-First Config -->
+```css
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+```
+
+### Import Syntax
+
+In Tailwind v4, import Tailwind with a regular CSS `@import` statement instead of the `@tailwind` directives used in v3:
+
+<!-- v4 Import Syntax -->
+```diff
+- @tailwind base;
+- @tailwind components;
+- @tailwind utilities;
++ @import "tailwindcss";
+```
+
+### Replaced Utilities
+
+Tailwind v4 removed deprecated utilities. Use the replacements shown below. Opacity values remain numeric.
+
+| Deprecated | Replacement |
+|------------|-------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
+
+## Spacing
+
+Use `gap` utilities instead of margins for spacing between siblings:
+
+<!-- Gap Utilities -->
+```html
+<div class="flex gap-8">
+    <div>Item 1</div>
+    <div>Item 2</div>
+</div>
+```
+
+## Dark Mode
+
+If existing pages and components support dark mode, new pages and components must support it the same way, typically using the `dark:` variant:
+
+<!-- Dark Mode -->
+```html
+<div class="bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+    Content adapts to color scheme
+</div>
+```
+
+## Common Patterns
+
+### Flexbox Layout
+
+<!-- Flexbox Layout -->
+```html
+<div class="flex items-center justify-between gap-4">
+    <div>Left content</div>
+    <div>Right content</div>
+</div>
+```
+
+### Grid Layout
+
+<!-- Grid Layout -->
+```html
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div>Card 1</div>
+    <div>Card 2</div>
+    <div>Card 3</div>
+</div>
+```
+
+## Common Pitfalls
+
+- Using deprecated v3 utilities (bg-opacity-*, flex-shrink-*, etc.)
+- Using `@tailwind` directives instead of `@import "tailwindcss"`
+- Trying to use `tailwind.config.js` instead of CSS `@theme` directive
+- Using margins for spacing between siblings instead of gap utilities
+- Forgetting to add dark mode variants when the project uses dark mode

--- a/.agents/skills/testing-best-practices/SKILL.md
+++ b/.agents/skills/testing-best-practices/SKILL.md
@@ -11,6 +11,14 @@ metadata:
 This skill provides rules for designing Laravel tests. Each rule file explains what to do and why. Use `search-docs` for Laravel and Pest API syntax.
 This project uses Pest. Follow the corresponding guidance in each rule.
 
+## Core Package Conventions
+
+- All tests use `Cachet\\Tests\\TestCase`, Orchestra Testbench, `WithWorkbench`, and `RefreshDatabase`.
+- Treat `workbench/` as a host-application fixture. Keep package behavior in `src/` and add workbench code only when a realistic consumer integration needs it.
+- Exercise service-provider registration, namespaced resources, routes, migrations, configuration, and publishing through Testbench rather than assuming an application bootstrap file.
+- Run Artisan test commands through `vendor/bin/testbench`.
+- View tests need the package's compiled Vite assets. When the Testbench manifest is absent, run `composer build` before `npm run build` so the host exists before Vite mirrors assets into it. Use `withoutVite()` only when asset resolution is irrelevant to the behavior under test.
+
 ## Consistency First
 
 Read nearby tests before you choose syntax and organization.

--- a/.agents/skills/testing-best-practices/rules/naming.md
+++ b/.agents/skills/testing-best-practices/rules/naming.md
@@ -3,7 +3,7 @@
 ## File Layout
 
 - Name each test file `{ClassName}Test.php`.
-- Place each test file at the same relative path as the class under test. The class `app/Actions/DeleteTeam.php` gets the test `tests/Unit/Actions/DeleteTeamTest.php`.
+- Place each test file at the same relative path as the class under test. The package class `src/Actions/DeleteTeam.php` gets the test `tests/Unit/Actions/DeleteTeamTest.php`.
 - Follow the project's convention for fixture files. If none exists, put fixtures in `tests/Fixtures/` and load them by path.
 - Move large literal values out of the test body and into fixture files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,21 @@ Stick to the existing structure. Do not invent new top-level directories.
 - `database/`: Migrations, Factories, Seeders.
 - `workbench/`: Testbench application skeleton.
 
+### Package Boundaries
+
+- Core is installed into a host Laravel application. Treat `workbench/` and the
+  Testbench vendor skeleton as disposable hosts, not production source.
+- Run Artisan commands through `vendor/bin/testbench`. Generators may target the
+  host skeleton, so place final package code in the existing package directory.
+- Support the Laravel versions in `composer.json`. Use APIs shared by those
+  versions unless a tested compatibility branch is required.
+- Register integration through the package service providers. Do not edit or
+  assume control of a consumer application's bootstrap, routes, or configuration.
+- Treat config keys, route names, view namespaces, publish tags, migrations, and
+  public PHP APIs as consumer-facing compatibility contracts.
+- Keep source assets in `resources/` and generated distributable assets in
+  `public/`. Never edit Testbench's mirrored asset output directly.
+
 ## 6. Specific Rules (from CLAUDE.md)
 
 - **Laravel Boost Guidelines:**


### PR DESCRIPTION
## Summary

- publish Laravel best-practice rules, MCP development, Tailwind CSS, and Psalm security skills
- adapt the guidance for Orchestra Testbench, service-provider integration, package paths, supported Laravel versions, and consumer-facing contracts
- extend the testing skill and persistent project instructions with package-specific boundaries
- leave out convention inference and Livewire guidance because they duplicate project instructions or assume an application-owned structure

## Validation

- all five skill directories pass `quick_validate.py`
- `composer validate --strict`
- `composer test:lint`
- `composer build`
- `npm run build`
- 1,122 tests passed with 4,123 assertions and 2 todos