### PR TITLE
Protect restricted status data

### DIFF
--- a/src/Actions/Update/NotifyIncidentUpdateSubscribers.php
+++ b/src/Actions/Update/NotifyIncidentUpdateSubscribers.php
@@ -27,6 +27,10 @@ class NotifyIncidentUpdateSubscribers
             return;
         }
 
+        if (! $incident->isPublished()) {
+            return;
+        }
+
         if (! $this->mailSettings->allow_subscribers) {
             return;
         }

--- a/src/Actions/Update/NotifyScheduleUpdateSubscribers.php
+++ b/src/Actions/Update/NotifyScheduleUpdateSubscribers.php
@@ -26,6 +26,10 @@ class NotifyScheduleUpdateSubscribers
             return;
         }
 
+        if (! $schedule->isPublished()) {
+            return;
+        }
+
         if (! $this->mailSettings->allow_subscribers) {
             return;
         }

--- a/src/Http/Controllers/Api/ComponentController.php
+++ b/src/Http/Controllers/Api/ComponentController.php
@@ -16,7 +16,6 @@ use Cachet\Filters\MetaFilter;
 use Cachet\Filters\TagsFilter;
 use Cachet\Http\Resources\Component as ComponentResource;
 use Cachet\Models\Component;
-use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
@@ -94,15 +93,9 @@ class ComponentController extends Controller
      */
     protected function visibleComponents(): Builder
     {
-        $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
-
         return Component::query()
             ->with(['unresolvedIncidents', 'activeMaintenance'])
-            ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
-            ->where(function ($query) use ($visibleGroups): void {
-                $query->whereNull('component_group_id')
-                    ->orWhereIn('component_group_id', $visibleGroups);
-            });
+            ->visibleTo($this->isAuthenticated());
     }
 
     /**

--- a/src/Http/Controllers/Api/IncidentController.php
+++ b/src/Http/Controllers/Api/IncidentController.php
@@ -14,12 +14,11 @@ use Cachet\Filters\MetaFilter;
 use Cachet\Filters\TagsFilter;
 use Cachet\Http\Resources\Incident as IncidentResource;
 use Cachet\Models\Component;
-use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -46,11 +45,16 @@ class IncidentController extends Controller
     protected function allowedIncludes(): array
     {
         return [
-            'components',
-            AllowedInclude::callback('components.group', function (BelongsTo $query): void {
-                /** @var BelongsTo<ComponentGroup, Component> $query */
-                $query->visible($this->isAuthenticated());
+            AllowedInclude::callback('components', function (BelongsToMany $query): void {
+                /** @var BelongsToMany<Component, Incident> $query */
+                $query->visibleTo($this->isAuthenticated());
             }),
+            AllowedInclude::callback('components.group', function (BelongsToMany $query): void {
+                /** @var BelongsToMany<Component, Incident> $query */
+                $query
+                    ->visibleTo($this->isAuthenticated())
+                    ->with(['group' => fn ($query) => $query->visible($this->isAuthenticated())]);
+            }, 'components'),
             'updates',
             'user',
             'meta',

--- a/src/Http/Controllers/Api/ScheduleController.php
+++ b/src/Http/Controllers/Api/ScheduleController.php
@@ -16,12 +16,11 @@ use Cachet\Filters\ScheduleStatusFilter;
 use Cachet\Filters\TagsFilter;
 use Cachet\Http\Resources\Schedule as ScheduleResource;
 use Cachet\Models\Component;
-use Cachet\Models\ComponentGroup;
 use Cachet\Models\Schedule;
 use Cachet\QueryBuilders\ScheduleBuilder;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -48,11 +47,16 @@ class ScheduleController extends Controller
     protected function allowedIncludes(): array
     {
         return [
-            'components',
-            AllowedInclude::callback('components.group', function (BelongsTo $query): void {
-                /** @var BelongsTo<ComponentGroup, Component> $query */
-                $query->visible($this->isAuthenticated());
+            AllowedInclude::callback('components', function (BelongsToMany $query): void {
+                /** @var BelongsToMany<Component, Schedule> $query */
+                $query->visibleTo($this->isAuthenticated());
             }),
+            AllowedInclude::callback('components.group', function (BelongsToMany $query): void {
+                /** @var BelongsToMany<Component, Schedule> $query */
+                $query
+                    ->visibleTo($this->isAuthenticated())
+                    ->with(['group' => fn ($query) => $query->visible($this->isAuthenticated())]);
+            }, 'components'),
             'updates',
             'user',
             'meta',

--- a/src/Mcp/Concerns/ScopesComponentVisibility.php
+++ b/src/Mcp/Concerns/ScopesComponentVisibility.php
@@ -4,7 +4,6 @@ namespace Cachet\Mcp\Concerns;
 
 use Cachet\Concerns\ChecksApiAuthentication;
 use Cachet\Models\Component;
-use Cachet\Models\ComponentGroup;
 use Illuminate\Database\Eloquent\Builder;
 
 trait ScopesComponentVisibility
@@ -22,14 +21,8 @@ trait ScopesComponentVisibility
      */
     protected function visibleComponents(): Builder
     {
-        $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
-
         return Component::query()
             ->with(['unresolvedIncidents', 'activeMaintenance'])
-            ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
-            ->where(function ($query) use ($visibleGroups): void {
-                $query->whereNull('component_group_id')
-                    ->orWhereIn('component_group_id', $visibleGroups);
-            });
+            ->visibleTo($this->isAuthenticated());
     }
 }

--- a/src/Mcp/Tools/Incidents/GetIncident.php
+++ b/src/Mcp/Tools/Incidents/GetIncident.php
@@ -38,7 +38,10 @@ class GetIncident extends Tool
     {
         $incident = Incident::query()
             ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'))
-            ->with(['components', 'updates'])
+            ->with([
+                'components' => fn ($query) => $query->visibleTo($this->isAuthenticated()),
+                'updates',
+            ])
             ->find($id = $request->integer('id'));
 
         if ($incident === null) {

--- a/src/Mcp/Tools/Schedules/GetSchedule.php
+++ b/src/Mcp/Tools/Schedules/GetSchedule.php
@@ -2,6 +2,8 @@
 
 namespace Cachet\Mcp\Tools\Schedules;
 
+use Cachet\Concerns\ChecksApiAuthentication;
+use Cachet\Mcp\Concerns\GuardsMcpAbilities;
 use Cachet\Mcp\Concerns\PresentsResources;
 use Cachet\Models\Schedule;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -14,6 +16,8 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 #[IsReadOnly]
 class GetSchedule extends Tool
 {
+    use ChecksApiAuthentication;
+    use GuardsMcpAbilities;
     use PresentsResources;
 
     protected string $name = 'get_schedule';
@@ -32,7 +36,13 @@ class GetSchedule extends Tool
 
     public function handle(Request $request): Response|ResponseFactory
     {
-        $schedule = Schedule::query()->with(['components', 'updates'])->find($id = $request->integer('id'));
+        $schedule = Schedule::query()
+            ->when(! $this->tokenCan('schedules.manage'), fn ($query) => $query->published())
+            ->with([
+                'components' => fn ($query) => $query->visibleTo($this->isAuthenticated()),
+                'updates',
+            ])
+            ->find($id = $request->integer('id'));
 
         if ($schedule === null) {
             return Response::error("Schedule [{$id}] not found.");

--- a/src/Mcp/Tools/Schedules/ListSchedules.php
+++ b/src/Mcp/Tools/Schedules/ListSchedules.php
@@ -2,6 +2,7 @@
 
 namespace Cachet\Mcp\Tools\Schedules;
 
+use Cachet\Mcp\Concerns\GuardsMcpAbilities;
 use Cachet\Mcp\Concerns\InteractsWithPagination;
 use Cachet\Mcp\Concerns\PresentsResources;
 use Cachet\Models\Schedule;
@@ -15,6 +16,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 #[IsReadOnly]
 class ListSchedules extends Tool
 {
+    use GuardsMcpAbilities;
     use InteractsWithPagination;
     use PresentsResources;
 
@@ -39,6 +41,7 @@ class ListSchedules extends Tool
     {
         $schedules = Schedule::query()
             ->with('tags')
+            ->when(! $this->tokenCan('schedules.manage'), fn ($query) => $query->published())
             ->when($request->filled('name'), fn ($query) => $query->where('name', 'like', '%'.$request->get('name').'%'))
             ->when($request->filled('tags'), fn ($query) => $query->withAnyTags($request->array('tags')))
             ->orderByDesc('scheduled_at')

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -54,6 +54,7 @@ use Illuminate\Support\Str;
  * @method static Builder<static>|static enabled()
  * @method static Builder<static>|static outage()
  * @method static Builder<static>|static status(ComponentStatusEnum $status)
+ * @method static Builder<static>|static visibleTo(bool $authenticated)
  * @method static ComponentFactory factory($count = null, $state = [])
  */
 class Component extends Model implements Metable
@@ -240,6 +241,21 @@ class Component extends Model implements Metable
     public function scopeOutage(Builder $query): void
     {
         $query->whereIn('status', ComponentStatusEnum::outage());
+    }
+
+    /**
+     * Scope components to those visible to the current caller.
+     */
+    public function scopeVisibleTo(Builder $query, bool $authenticated): void
+    {
+        $visibleGroups = ComponentGroup::query()->visible($authenticated)->select('id');
+
+        $query
+            ->unless($authenticated, fn (Builder $query) => $query->where('enabled', true))
+            ->where(function (Builder $query) use ($visibleGroups): void {
+                $query->whereNull('component_group_id')
+                    ->orWhereIn('component_group_id', $visibleGroups);
+            });
     }
 
     /**

--- a/tests/Feature/Api/IncidentTest.php
+++ b/tests/Feature/Api/IncidentTest.php
@@ -590,7 +590,7 @@ it('shows an authenticated incident to authenticated users', function () {
     $response->assertJsonPath('data.attributes.id', $incident->id);
 });
 
-it('does not reveal component groups hidden from guests through incident includes', function () {
+it('does not reveal components in hidden groups through incident includes', function () {
     $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
     $component = Component::factory()->for($hiddenGroup, 'group')->create();
     $incident = Incident::factory()->create();
@@ -602,7 +602,7 @@ it('does not reveal component groups hidden from guests through incident include
 
     $included = collect($response->json('included'));
 
-    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+    expect($included->firstWhere('id', (string) $component->id))->toBeNull()
         ->and($included->firstWhere('type', 'componentGroups'))->toBeNull();
 });
 

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -563,7 +563,7 @@ it('can delete a schedule', function () {
     ]);
 });
 
-it('does not reveal component groups hidden from guests through schedule includes', function () {
+it('does not reveal components in hidden groups through schedule includes', function () {
     $hiddenGroup = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
     $component = Component::factory()->for($hiddenGroup, 'group')->create();
     $schedule = Schedule::factory()->create();
@@ -575,6 +575,6 @@ it('does not reveal component groups hidden from guests through schedule include
 
     $included = collect($response->json('included'));
 
-    expect($included->firstWhere('id', (string) $component->id))->not->toBeNull()
+    expect($included->firstWhere('id', (string) $component->id))->toBeNull()
         ->and($included->firstWhere('type', 'componentGroups'))->toBeNull();
 });

--- a/tests/Feature/Mcp/Tools/IncidentToolsTest.php
+++ b/tests/Feature/Mcp/Tools/IncidentToolsTest.php
@@ -18,6 +18,7 @@ use Cachet\Mcp\Tools\IncidentUpdates\DeleteIncidentUpdate;
 use Cachet\Mcp\Tools\IncidentUpdates\EditIncidentUpdate;
 use Cachet\Mcp\Tools\IncidentUpdates\RecordIncidentUpdate;
 use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Models\IncidentTemplate;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -303,6 +304,17 @@ it('reveals authenticated-only incidents by id to authenticated callers', functi
     CachetServer::tool(GetIncident::class, ['id' => $incident->id])
         ->assertOk()
         ->assertSee('Internal Incident');
+});
+
+it('does not reveal components in hidden groups through incidents', function () {
+    $group = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $component = Component::factory()->for($group, 'group')->create(['name' => 'Hidden Component']);
+    $incident = Incident::factory()->create();
+    $incident->components()->attach($component, ['component_status' => ComponentStatusEnum::major_outage]);
+
+    CachetServer::tool(GetIncident::class, ['id' => $incident->id])
+        ->assertOk()
+        ->assertDontSee('Hidden Component');
 });
 
 it('overlays the displayed component status while an incident is unresolved', function () {

--- a/tests/Feature/Mcp/Tools/ScheduleToolsTest.php
+++ b/tests/Feature/Mcp/Tools/ScheduleToolsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Enums\ResourceVisibilityEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Mcp\CachetServer;
 use Cachet\Mcp\Tools\Schedules\CreateSchedule;
@@ -10,6 +12,8 @@ use Cachet\Mcp\Tools\Schedules\UpdateSchedule;
 use Cachet\Mcp\Tools\ScheduleUpdates\DeleteScheduleUpdate;
 use Cachet\Mcp\Tools\ScheduleUpdates\EditScheduleUpdate;
 use Cachet\Mcp\Tools\ScheduleUpdates\RecordScheduleUpdate;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Schedule;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
@@ -25,12 +29,56 @@ it('lists schedules for guests', function () {
         ->assertStructuredContent(fn (AssertableJson $json) => $json->has('data', 2)->etc());
 });
 
+it('does not list unpublished schedules for guests', function () {
+    Schedule::factory()->create(['name' => 'Published Maintenance']);
+    Schedule::factory()->create([
+        'name' => 'Embargoed Maintenance',
+        'published_at' => now()->addDay(),
+    ]);
+
+    CachetServer::tool(ListSchedules::class)
+        ->assertOk()
+        ->assertSee('Published Maintenance')
+        ->assertDontSee('Embargoed Maintenance');
+});
+
 it('gets a schedule by id', function () {
     $schedule = Schedule::factory()->create(['name' => 'Database Upgrade']);
 
     CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
         ->assertOk()
         ->assertSee('Database Upgrade');
+});
+
+it('does not reveal an unpublished schedule to guests by id', function () {
+    $schedule = Schedule::factory()->create(['published_at' => now()->addDay()]);
+
+    CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
+        ->assertHasErrors(["Schedule [{$schedule->id}] not found."]);
+});
+
+it('reveals unpublished schedules to callers that can manage schedules', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $schedule = Schedule::factory()->create([
+        'name' => 'Embargoed Maintenance',
+        'published_at' => now()->addDay(),
+    ]);
+
+    CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
+        ->assertOk()
+        ->assertSee('Embargoed Maintenance');
+});
+
+it('does not reveal components in hidden groups through schedules', function () {
+    $group = ComponentGroup::factory()->create(['visible' => ResourceVisibilityEnum::hidden]);
+    $component = Component::factory()->for($group, 'group')->create(['name' => 'Hidden Component']);
+    $schedule = Schedule::factory()->create();
+    $schedule->components()->attach($component, ['component_status' => ComponentStatusEnum::under_maintenance]);
+
+    CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
+        ->assertOk()
+        ->assertDontSee('Hidden Component');
 });
 
 it('returns an error for an unknown schedule', function () {

--- a/tests/Feature/Publishing/SchedulePublishingTest.php
+++ b/tests/Feature/Publishing/SchedulePublishingTest.php
@@ -93,6 +93,8 @@ it('exposes unpublished schedules to the mcp server for dashboard management', f
     Schedule::factory()->create(['name' => 'Published now']);
     Schedule::factory()->scheduled()->create(['name' => 'Prescheduled']);
 
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
     CachetServer::tool(ListSchedules::class)
         ->assertOk()
         ->assertStructuredContent(fn (AssertableJson $json) => $json->has('data', 2)->etc());
@@ -100,6 +102,8 @@ it('exposes unpublished schedules to the mcp server for dashboard management', f
 
 it('exposes a single unpublished schedule to the mcp server', function () {
     $schedule = Schedule::factory()->scheduled()->create(['name' => 'Prescheduled']);
+
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
 
     CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
         ->assertOk()

--- a/tests/Unit/Actions/Update/NotifyIncidentUpdateSubscribersTest.php
+++ b/tests/Unit/Actions/Update/NotifyIncidentUpdateSubscribersTest.php
@@ -69,6 +69,23 @@ it('does not notify unverified subscribers', function () {
     Notification::assertNothingSent();
 });
 
+it('does not notify subscribers about unpublished incident updates', function () {
+    Subscriber::factory()->verified()->create(['global' => true]);
+
+    $incident = Incident::factory()->create([
+        'notifications' => true,
+        'visible' => ResourceVisibilityEnum::guest,
+        'published_at' => now()->addDay(),
+    ]);
+
+    app(CreateUpdate::class)->handle($incident, CreateIncidentUpdateRequestData::from([
+        'message' => 'Embargoed incident details.',
+        'status' => IncidentStatusEnum::identified,
+    ]));
+
+    Notification::assertNothingSent();
+});
+
 it('notifies subscribers about updates to notifiable schedules', function () {
     $subscriber = Subscriber::factory()->verified()->create(['global' => true]);
 
@@ -88,6 +105,21 @@ it('does not notify about updates to schedules that do not want notifications', 
 
     app(CreateUpdate::class)->handle($schedule, CreateScheduleUpdateRequestData::from([
         'message' => 'Maintenance is progressing.',
+    ]));
+
+    Notification::assertNothingSent();
+});
+
+it('does not notify subscribers about unpublished schedule updates', function () {
+    Subscriber::factory()->verified()->create(['global' => true]);
+
+    $schedule = Schedule::factory()->create([
+        'notifications' => true,
+        'published_at' => now()->addDay(),
+    ]);
+
+    app(CreateUpdate::class)->handle($schedule, CreateScheduleUpdateRequestData::from([
+        'message' => 'Embargoed maintenance details.',
     ]));
 
     Notification::assertNothingSent();


### PR DESCRIPTION
Prevents unpublished schedules, unpublished updates, and hidden component relationships from leaking through REST or MCP.

Tests: targeted Pest suite, PHPStan, Psalm taint, Pint.