### PR TITLE
Correct resource mutation semantics

### DIFF
--- a/src/Actions/Schedule/UpdateSchedule.php
+++ b/src/Actions/Schedule/UpdateSchedule.php
@@ -23,7 +23,7 @@ class UpdateSchedule
             $schedule->syncTags($data->tags);
         }
 
-        if ($data->components) {
+        if ($data->components !== null) {
             $components = collect($data->components)
                 ->mapWithKeys(fn (ScheduleComponentRequestData $component) => [
                     $component->id => ['component_status' => $component->status],

--- a/src/Actions/Subscriber/CreateSubscriber.php
+++ b/src/Actions/Subscriber/CreateSubscriber.php
@@ -13,14 +13,21 @@ class CreateSubscriber
     public function handle(string $email, bool $global = true, array $components = [], bool $verified = false, ?array $meta = null): Subscriber
     {
         return DB::transaction(function () use ($email, $global, $components, $verified, $meta): Subscriber {
-            $subscriber = Subscriber::firstOrNew(['email' => $email]);
+            $subscriber = Subscriber::firstOrCreate(['email' => $email], [
+                'global' => $global,
+                'email_verified_at' => $verified ? now() : null,
+            ]);
+
             $subscriber->fill(['global' => $global]);
 
-            if ($verified && ! $subscriber->hasVerifiedEmail()) {
-                $subscriber->email_verified_at = now();
+            if ($subscriber->isDirty('global')) {
+                $subscriber->save();
             }
 
-            $subscriber->save();
+            if ($verified) {
+                $subscriber->verify();
+            }
+
             $subscriber->components()->syncWithoutDetaching($components);
 
             if ($meta !== null) {

--- a/src/Actions/Subscriber/CreateSubscriber.php
+++ b/src/Actions/Subscriber/CreateSubscriber.php
@@ -3,6 +3,7 @@
 namespace Cachet\Actions\Subscriber;
 
 use Cachet\Models\Subscriber;
+use Illuminate\Support\Facades\DB;
 
 class CreateSubscriber
 {
@@ -11,19 +12,22 @@ class CreateSubscriber
      */
     public function handle(string $email, bool $global = true, array $components = [], bool $verified = false, ?array $meta = null): Subscriber
     {
-        $subscriber = Subscriber::firstOrCreate([
-            'email' => $email,
-        ], [
-            'global' => $global,
-            'email_verified_at' => $verified ? now() : null,
-        ]);
+        return DB::transaction(function () use ($email, $global, $components, $verified, $meta): Subscriber {
+            $subscriber = Subscriber::firstOrNew(['email' => $email]);
+            $subscriber->fill(['global' => $global]);
 
-        $subscriber->components()->attach($components);
+            if ($verified && ! $subscriber->hasVerifiedEmail()) {
+                $subscriber->email_verified_at = now();
+            }
 
-        if ($meta !== null) {
-            $subscriber->syncMeta($meta);
-        }
+            $subscriber->save();
+            $subscriber->components()->syncWithoutDetaching($components);
 
-        return $subscriber;
+            if ($meta !== null) {
+                $subscriber->syncMeta($meta);
+            }
+
+            return $subscriber;
+        });
     }
 }

--- a/tests/Feature/Api/ScheduleTest.php
+++ b/tests/Feature/Api/ScheduleTest.php
@@ -532,6 +532,21 @@ it('can update a schedule with components', function () {
     ]);
 });
 
+it('can remove every component from a schedule', function () {
+    Sanctum::actingAs(User::factory()->create(), ['schedules.manage']);
+
+    $schedule = Schedule::factory()->create();
+    $schedule->components()->attach(Component::factory()->create(), [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
+
+    putJson('/status/api/schedules/'.$schedule->id, [
+        'components' => [],
+    ])->assertOk();
+
+    expect($schedule->fresh()->components)->toBeEmpty();
+});
+
 it('cannot delete a schedule if not authenticated', function () {
     $schedule = Schedule::factory()->create();
 

--- a/tests/Feature/Api/SubscriberTest.php
+++ b/tests/Feature/Api/SubscriberTest.php
@@ -238,6 +238,30 @@ it('can create a verified subscriber without sending a verification email', func
     Notification::assertNothingSent();
 });
 
+it('can verify and update an existing subscriber', function () {
+    Notification::fake();
+
+    Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
+
+    $subscriber = Subscriber::factory()->create([
+        'email' => 'james@alt-three.com',
+        'global' => true,
+    ]);
+
+    postJson('/status/api/subscribers', [
+        'email' => $subscriber->email,
+        'global' => false,
+        'verified' => true,
+    ])->assertOk();
+
+    $subscriber->refresh();
+
+    expect((bool) $subscriber->global)->toBeFalse();
+    expect($subscriber->hasVerifiedEmail())->toBeTrue();
+
+    Notification::assertNothingSent();
+});
+
 it('can create a subscriber with component subscriptions', function () {
     Notification::fake();
 

--- a/tests/Unit/Actions/Schedule/UpdateScheduleTest.php
+++ b/tests/Unit/Actions/Schedule/UpdateScheduleTest.php
@@ -45,3 +45,16 @@ it('can update a schedule with components', function () {
         'component_status' => ComponentStatusEnum::major_outage,
     ]);
 });
+
+it('can remove every component from a schedule', function () {
+    $schedule = Schedule::factory()->create();
+    $schedule->components()->attach(Component::factory()->create(), [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
+
+    $data = UpdateScheduleRequestData::from(['components' => []]);
+
+    app(UpdateSchedule::class)->handle($schedule, $data);
+
+    expect($schedule->fresh()->components)->toBeEmpty();
+});

--- a/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
+++ b/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
@@ -3,6 +3,7 @@
 use Cachet\Actions\Subscriber\CreateSubscriber;
 use Cachet\Events\Subscribers\SubscriberCreated;
 use Cachet\Models\Component;
+use Cachet\Models\Subscriber;
 use Illuminate\Support\Facades\Event;
 
 it('can create a subscriber', function () {
@@ -63,4 +64,34 @@ it('can create a subscriber with components', function () {
         ->components->toHaveCount(2);
 
     Event::assertDispatched(SubscriberCreated::class);
+});
+
+it('updates the global state of an existing subscriber without resetting verification', function () {
+    $existing = Subscriber::factory()->verified()->create([
+        'email' => 'james@alt-three.com',
+        'global' => true,
+    ]);
+
+    $subscriber = app(CreateSubscriber::class)->handle($existing->email, global: false);
+
+    expect($subscriber->global)->toBeFalse();
+    expect($subscriber->hasVerifiedEmail())->toBeTrue();
+});
+
+it('verifies an existing subscriber when requested', function () {
+    $existing = Subscriber::factory()->create(['email' => 'james@alt-three.com']);
+
+    $subscriber = app(CreateSubscriber::class)->handle($existing->email, verified: true);
+
+    expect($subscriber->hasVerifiedEmail())->toBeTrue();
+});
+
+it('does not duplicate an existing component subscription', function () {
+    $component = Component::factory()->create();
+
+    app(CreateSubscriber::class)->handle('james@alt-three.com', components: [$component->id]);
+    $subscriber = app(CreateSubscriber::class)->handle('james@alt-three.com', components: [$component->id]);
+
+    expect($subscriber->components)->toHaveCount(1);
+    $this->assertDatabaseCount('subscriptions', 1);
 });

--- a/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
+++ b/tests/Unit/Actions/Subscriber/CreateSubscriberTest.php
@@ -2,6 +2,7 @@
 
 use Cachet\Actions\Subscriber\CreateSubscriber;
 use Cachet\Events\Subscribers\SubscriberCreated;
+use Cachet\Events\Subscribers\SubscriberVerified;
 use Cachet\Models\Component;
 use Cachet\Models\Subscriber;
 use Illuminate\Support\Facades\Event;
@@ -81,9 +82,12 @@ it('updates the global state of an existing subscriber without resetting verific
 it('verifies an existing subscriber when requested', function () {
     $existing = Subscriber::factory()->create(['email' => 'james@alt-three.com']);
 
+    Event::fake([SubscriberVerified::class]);
+
     $subscriber = app(CreateSubscriber::class)->handle($existing->email, verified: true);
 
     expect($subscriber->hasVerifiedEmail())->toBeTrue();
+    Event::assertDispatched(SubscriberVerified::class);
 });
 
 it('does not duplicate an existing component subscription', function () {


### PR DESCRIPTION
Makes empty schedule component lists clear associations and makes repeated subscriber creation safely update existing records.

Tests: targeted Pest suite, PHPStan, Pint.