### PR TITLE
Fix MCP updates and eager loading

### DIFF
--- a/src/Mcp/Concerns/PresentsResources.php
+++ b/src/Mcp/Concerns/PresentsResources.php
@@ -17,6 +17,22 @@ use UnitEnum;
 trait PresentsResources
 {
     /**
+     * Relationships required to present a component without lazy loading.
+     *
+     * @return list<string>
+     */
+    protected function componentRelations(string $prefix = ''): array
+    {
+        $prefix = $prefix === '' ? '' : $prefix.'.';
+
+        return [
+            $prefix.'tags',
+            $prefix.'unresolvedIncidents',
+            $prefix.'activeMaintenance',
+        ];
+    }
+
+    /**
      * @return array{value: int|string, name: string}|null
      */
     protected function presentEnum(?UnitEnum $enum): ?array

--- a/src/Mcp/Concerns/ScopesComponentVisibility.php
+++ b/src/Mcp/Concerns/ScopesComponentVisibility.php
@@ -25,7 +25,7 @@ trait ScopesComponentVisibility
         $visibleGroups = ComponentGroup::query()->visible($this->isAuthenticated())->select('id');
 
         return Component::query()
-            ->with(['unresolvedIncidents', 'activeMaintenance'])
+            ->with(['unresolvedIncidents', 'activeMaintenance', 'tags'])
             ->unless($this->isAuthenticated(), fn (Builder $query) => $query->enabled())
             ->where(function ($query) use ($visibleGroups): void {
                 $query->whereNull('component_group_id')

--- a/src/Mcp/Tools/ComponentGroups/ListComponentGroups.php
+++ b/src/Mcp/Tools/ComponentGroups/ListComponentGroups.php
@@ -44,7 +44,7 @@ class ListComponentGroups extends Tool
                 if (! $this->isAuthenticated()) {
                     $query->enabled();
                 }
-            }])
+            }, ...$this->componentRelations('components')])
             ->when($request->filled('name'), fn ($query) => $query->where('name', 'like', '%'.$request->get('name').'%'))
             ->orderBy('order')
             ->simplePaginate(perPage: $this->perPage($request), page: $this->page($request));

--- a/src/Mcp/Tools/Components/ListComponents.php
+++ b/src/Mcp/Tools/Components/ListComponents.php
@@ -46,7 +46,6 @@ class ListComponents extends Tool
     public function handle(Request $request): ResponseFactory
     {
         $components = $this->visibleComponents()
-            ->with('tags')
             ->when($request->filled('name'), fn ($query) => $query->where('name', 'like', '%'.$request->get('name').'%'))
             ->when($request->filled('status'), fn ($query) => $query->where('status', $request->integer('status')))
             ->where('enabled', $request->boolean('enabled', true))

--- a/src/Mcp/Tools/Components/UpdateComponent.php
+++ b/src/Mcp/Tools/Components/UpdateComponent.php
@@ -59,7 +59,7 @@ class UpdateComponent extends Tool
         }
 
         $data = UpdateComponentRequestData::validateAndCreate(
-            $request->only(['name', 'description', 'status', 'link', 'order', 'enabled', 'component_group_id'])
+            $request->only(['tags', 'name', 'description', 'status', 'link', 'order', 'enabled', 'component_group_id'])
         );
 
         return Response::structured([

--- a/src/Mcp/Tools/Incidents/GetIncident.php
+++ b/src/Mcp/Tools/Incidents/GetIncident.php
@@ -38,7 +38,11 @@ class GetIncident extends Tool
     {
         $incident = Incident::query()
             ->viewableBy($this->isAuthenticated(), $this->tokenCan('incidents.manage'))
-            ->with(['components', 'updates'])
+            ->with([
+                ...$this->componentRelations('components'),
+                'tags',
+                'updates',
+            ])
             ->find($id = $request->integer('id'));
 
         if ($incident === null) {

--- a/src/Mcp/Tools/Incidents/UpdateIncident.php
+++ b/src/Mcp/Tools/Incidents/UpdateIncident.php
@@ -59,7 +59,7 @@ class UpdateIncident extends Tool
         }
 
         $data = UpdateIncidentRequestData::validateAndCreate(
-            $request->only(['name', 'message', 'status', 'visible', 'stickied', 'notifications', 'occurred_at', 'published_at'])
+            $request->only(['tags', 'name', 'message', 'status', 'visible', 'stickied', 'notifications', 'occurred_at', 'published_at'])
         );
 
         return Response::structured(['data' => $this->presentIncident($action->handle($incident, $data))]);

--- a/src/Mcp/Tools/Metrics/GetMetric.php
+++ b/src/Mcp/Tools/Metrics/GetMetric.php
@@ -36,7 +36,10 @@ class GetMetric extends Tool
     {
         $metric = Metric::query()
             ->visible($this->isAuthenticated())
-            ->with(['metricPoints' => fn ($query) => $query->latest()->limit(50)])
+            ->with([
+                'metricPoints' => fn ($query) => $query->latest()->limit(50),
+                'tags',
+            ])
             ->find($id = $request->integer('id'));
 
         if ($metric === null) {

--- a/src/Mcp/Tools/Metrics/UpdateMetric.php
+++ b/src/Mcp/Tools/Metrics/UpdateMetric.php
@@ -53,7 +53,7 @@ class UpdateMetric extends Tool
         }
 
         $data = UpdateMetricRequestData::validateAndCreate(
-            $request->only(['name', 'suffix', 'description', 'default_value', 'threshold'])
+            $request->only(['tags', 'name', 'suffix', 'description', 'default_value', 'threshold'])
         );
 
         return Response::structured(['data' => $this->presentMetric($action->handle($metric, $data))]);

--- a/src/Mcp/Tools/Schedules/GetSchedule.php
+++ b/src/Mcp/Tools/Schedules/GetSchedule.php
@@ -32,7 +32,13 @@ class GetSchedule extends Tool
 
     public function handle(Request $request): Response|ResponseFactory
     {
-        $schedule = Schedule::query()->with(['components', 'updates'])->find($id = $request->integer('id'));
+        $schedule = Schedule::query()
+            ->with([
+                ...$this->componentRelations('components'),
+                'tags',
+                'updates',
+            ])
+            ->find($id = $request->integer('id'));
 
         if ($schedule === null) {
             return Response::error("Schedule [{$id}] not found.");

--- a/src/Mcp/Tools/Schedules/UpdateSchedule.php
+++ b/src/Mcp/Tools/Schedules/UpdateSchedule.php
@@ -63,7 +63,7 @@ class UpdateSchedule extends Tool
         }
 
         $data = UpdateScheduleRequestData::validateAndCreate(
-            $request->only(['name', 'message', 'scheduled_at', 'completed_at', 'published_at', 'components'])
+            $request->only(['tags', 'name', 'message', 'scheduled_at', 'completed_at', 'published_at', 'components'])
         );
 
         return Response::structured(['data' => $this->presentSchedule($action->handle($schedule, $data))]);

--- a/src/Mcp/Tools/Subscribers/ListSubscribers.php
+++ b/src/Mcp/Tools/Subscribers/ListSubscribers.php
@@ -44,7 +44,7 @@ class ListSubscribers extends Tool
         }
 
         $subscribers = Subscriber::query()
-            ->with('components')
+            ->with($this->componentRelations('components'))
             ->when($request->filled('email'), fn ($query) => $query->where('email', 'like', '%'.$request->get('email').'%'))
             ->when($request->filled('global'), fn ($query) => $query->where('global', $request->boolean('global')))
             ->simplePaginate(perPage: $this->perPage($request), page: $this->page($request));

--- a/tests/Feature/Mcp/Tools/ComponentToolsTest.php
+++ b/tests/Feature/Mcp/Tools/ComponentToolsTest.php
@@ -14,6 +14,7 @@ use Cachet\Mcp\Tools\Components\ListComponents;
 use Cachet\Mcp\Tools\Components\UpdateComponent;
 use Cachet\Models\Component;
 use Cachet\Models\ComponentGroup;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -85,9 +86,11 @@ it('updates a component', function () {
     CachetServer::tool(UpdateComponent::class, [
         'id' => $component->id,
         'status' => ComponentStatusEnum::partial_outage->value,
+        'tags' => ['Public API'],
     ])->assertOk();
 
     expect($component->fresh()->status)->toBe(ComponentStatusEnum::partial_outage);
+    expect($component->fresh()->tags->pluck('name')->all())->toBe(['Public API']);
 });
 
 it('deletes a component', function () {
@@ -104,11 +107,18 @@ it('deletes a component', function () {
 
 it('lists component groups with their components', function () {
     $group = ComponentGroup::factory()->create(['name' => 'Core Services']);
-    Component::factory()->create(['component_group_id' => $group->id]);
+    $components = Component::factory(2)->create(['component_group_id' => $group->id]);
+    $components->each->syncTags(['Core']);
 
-    CachetServer::tool(ListComponentGroups::class)
-        ->assertOk()
-        ->assertSee('Core Services');
+    Model::preventLazyLoading();
+
+    try {
+        CachetServer::tool(ListComponentGroups::class)
+            ->assertOk()
+            ->assertSee('Core Services');
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });
 
 it('creates a component group', function () {

--- a/tests/Feature/Mcp/Tools/IncidentToolsTest.php
+++ b/tests/Feature/Mcp/Tools/IncidentToolsTest.php
@@ -20,6 +20,7 @@ use Cachet\Mcp\Tools\IncidentUpdates\RecordIncidentUpdate;
 use Cachet\Models\Component;
 use Cachet\Models\Incident;
 use Cachet\Models\IncidentTemplate;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -45,12 +46,20 @@ it('filters incidents by status', function () {
 
 it('gets an incident with its updates and components', function () {
     $incident = Incident::factory()->create(['name' => 'Database Outage']);
+    $incident->syncTags(['Database']);
+    $incident->components()->attach(Component::factory(2)->create());
     $incident->updates()->create(['status' => IncidentStatusEnum::watching, 'message' => 'Monitoring the fix.']);
 
-    CachetServer::tool(GetIncident::class, ['id' => $incident->id])
-        ->assertOk()
-        ->assertSee('Database Outage')
-        ->assertSee('Monitoring the fix.');
+    Model::preventLazyLoading();
+
+    try {
+        CachetServer::tool(GetIncident::class, ['id' => $incident->id])
+            ->assertOk()
+            ->assertSee('Database Outage')
+            ->assertSee('Monitoring the fix.');
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });
 
 it('returns an error for an unknown incident', function () {
@@ -131,9 +140,11 @@ it('updates an incident', function () {
     CachetServer::tool(UpdateIncident::class, [
         'id' => $incident->id,
         'stickied' => true,
+        'tags' => ['Database'],
     ])->assertOk();
 
     expect($incident->fresh()->stickied)->toBeTrue();
+    expect($incident->fresh()->tags->pluck('name')->all())->toBe(['Database']);
 });
 
 it('deletes an incident', function () {

--- a/tests/Feature/Mcp/Tools/MetricToolsTest.php
+++ b/tests/Feature/Mcp/Tools/MetricToolsTest.php
@@ -10,6 +10,7 @@ use Cachet\Mcp\Tools\Metrics\GetMetric;
 use Cachet\Mcp\Tools\Metrics\ListMetrics;
 use Cachet\Mcp\Tools\Metrics\UpdateMetric;
 use Cachet\Models\Metric;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -26,11 +27,18 @@ it('lists metrics for guests', function () {
 
 it('gets a metric with recent points', function () {
     $metric = Metric::factory()->create(['name' => 'Response Time']);
+    $metric->syncTags(['Latency']);
     $metric->metricPoints()->create(['value' => 42.5]);
 
-    CachetServer::tool(GetMetric::class, ['id' => $metric->id])
-        ->assertOk()
-        ->assertSee('Response Time');
+    Model::preventLazyLoading();
+
+    try {
+        CachetServer::tool(GetMetric::class, ['id' => $metric->id])
+            ->assertOk()
+            ->assertSee('Response Time');
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });
 
 it('returns an error for an unknown metric', function () {
@@ -57,9 +65,11 @@ it('updates a metric', function () {
     CachetServer::tool(UpdateMetric::class, [
         'id' => $metric->id,
         'suffix' => 'seconds',
+        'tags' => ['Latency'],
     ])->assertOk();
 
     expect($metric->fresh()->suffix)->toBe('seconds');
+    expect($metric->fresh()->tags->pluck('name')->all())->toBe(['Latency']);
 });
 
 it('deletes a metric', function () {

--- a/tests/Feature/Mcp/Tools/ScheduleToolsTest.php
+++ b/tests/Feature/Mcp/Tools/ScheduleToolsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
 use Cachet\Mcp\CachetServer;
 use Cachet\Mcp\Tools\Schedules\CreateSchedule;
@@ -10,7 +11,9 @@ use Cachet\Mcp\Tools\Schedules\UpdateSchedule;
 use Cachet\Mcp\Tools\ScheduleUpdates\DeleteScheduleUpdate;
 use Cachet\Mcp\Tools\ScheduleUpdates\EditScheduleUpdate;
 use Cachet\Mcp\Tools\ScheduleUpdates\RecordScheduleUpdate;
+use Cachet\Models\Component;
 use Cachet\Models\Schedule;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
 use Workbench\App\User;
@@ -27,10 +30,20 @@ it('lists schedules for guests', function () {
 
 it('gets a schedule by id', function () {
     $schedule = Schedule::factory()->create(['name' => 'Database Upgrade']);
+    $schedule->syncTags(['Database']);
+    $schedule->components()->attach(Component::factory(2)->create(), [
+        'component_status' => ComponentStatusEnum::under_maintenance,
+    ]);
 
-    CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
-        ->assertOk()
-        ->assertSee('Database Upgrade');
+    Model::preventLazyLoading();
+
+    try {
+        CachetServer::tool(GetSchedule::class, ['id' => $schedule->id])
+            ->assertOk()
+            ->assertSee('Database Upgrade');
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });
 
 it('returns an error for an unknown schedule', function () {
@@ -66,9 +79,11 @@ it('updates a schedule', function () {
     CachetServer::tool(UpdateSchedule::class, [
         'id' => $schedule->id,
         'name' => 'New Name',
+        'tags' => ['Infrastructure'],
     ])->assertOk();
 
     expect($schedule->fresh()->name)->toBe('New Name');
+    expect($schedule->fresh()->tags->pluck('name')->all())->toBe(['Infrastructure']);
 });
 
 it('deletes a schedule', function () {

--- a/tests/Feature/Mcp/Tools/SubscriberToolsTest.php
+++ b/tests/Feature/Mcp/Tools/SubscriberToolsTest.php
@@ -5,8 +5,10 @@ use Cachet\Mcp\Tools\Subscribers\CreateSubscriber;
 use Cachet\Mcp\Tools\Subscribers\ListSubscribers;
 use Cachet\Mcp\Tools\Subscribers\UnsubscribeSubscriber;
 use Cachet\Mcp\Tools\Subscribers\UpdateSubscriber;
+use Cachet\Models\Component;
 use Cachet\Models\Subscriber;
 use Cachet\Notifications\VerifySubscriberEmail;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Sanctum\Sanctum;
@@ -31,11 +33,20 @@ it('hides the subscribers list from tokens without the ability', function () {
 it('lists subscribers with the ability', function () {
     Sanctum::actingAs(User::factory()->create(), ['subscribers.manage']);
 
-    Subscriber::factory(2)->create();
+    $components = Component::factory(2)->create();
+    $components->each->syncTags(['Public API']);
+    $subscriber = Subscriber::factory()->create();
+    $subscriber->components()->attach($components);
 
-    CachetServer::tool(ListSubscribers::class)
-        ->assertOk()
-        ->assertStructuredContent(fn (AssertableJson $json) => $json->has('data', 2)->etc());
+    Model::preventLazyLoading();
+
+    try {
+        CachetServer::tool(ListSubscribers::class)
+            ->assertOk()
+            ->assertStructuredContent(fn (AssertableJson $json) => $json->has('data', 1)->etc());
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });
 
 it('creates a subscriber and sends a verification email', function () {


### PR DESCRIPTION
Allows MCP update tools to persist tags and eager-loads structured response relationships to avoid N+1 queries.

Tests: MCP tool suite, PHPStan, Pint.