### PR TITLE
Group components in the edit schedule attach components modal

### DIFF
--- a/src/Filament/Components/ComponentOptions.php
+++ b/src/Filament/Components/ComponentOptions.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Cachet\Filament\Components;
+
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
+use Illuminate\Database\Eloquent\Model;
+
+class ComponentOptions
+{
+    /**
+     * Get components grouped by their component group, for Filament Select dropdowns.
+     *
+     * Pass the parent record to exclude components already attached to it through
+     * the `components` BelongsToMany relationship.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public static function forSelect(?Model $excludeAttachedTo = null): array
+    {
+        $query = Component::query()
+            ->with('group')
+            ->leftJoin('component_groups', 'components.component_group_id', '=', 'component_groups.id')
+            ->orderByRaw('component_groups.id is null')
+            ->orderBy('component_groups.order')
+            ->orderBy('component_groups.name')
+            ->orderBy('components.order')
+            ->orderBy('components.name')
+            ->select('components.*');
+
+        if ($excludeAttachedTo && method_exists($excludeAttachedTo, 'components')) {
+            $query->whereNotIn('components.id', $excludeAttachedTo->components()->pluck('components.id'));
+        }
+
+        return $query
+            ->get()
+            ->groupBy(function (Component $component): string {
+                $group = $component->group;
+
+                return $group instanceof ComponentGroup
+                    ? $group->name
+                    : __('cachet::component.list.ungrouped');
+            })
+            ->map(fn ($components): array => $components->pluck('name', 'id')->all())
+            ->all();
+    }
+}

--- a/src/Filament/Resources/Incidents/IncidentResource.php
+++ b/src/Filament/Resources/Incidents/IncidentResource.php
@@ -8,13 +8,12 @@ use Cachet\Data\Requests\IncidentUpdate\CreateIncidentUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
+use Cachet\Filament\Components\ComponentOptions;
 use Cachet\Filament\Resources\Incidents\Pages\CreateIncident;
 use Cachet\Filament\Resources\Incidents\Pages\EditIncident;
 use Cachet\Filament\Resources\Incidents\Pages\ListIncidents;
 use Cachet\Filament\Resources\Incidents\RelationManagers\ComponentsRelationManager;
 use Cachet\Filament\Resources\Updates\RelationManagers\UpdatesRelationManager;
-use Cachet\Models\Component;
-use Cachet\Models\ComponentGroup;
 use Cachet\Models\Incident;
 use Cachet\Settings\MailSettings;
 use Cachet\Status;
@@ -95,7 +94,7 @@ class IncidentResource extends Resource
                                 ->label(__('cachet::incident.form.add_component.component_label'))
                                 ->preload()
                                 ->required()
-                                ->options(fn (): array => static::getComponentOptions())
+                                ->options(fn (): array => ComponentOptions::forSelect())
                                 ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
                             ToggleButtons::make('component_status')
                                 ->label(__('cachet::incident.form.add_component.status_label'))
@@ -148,40 +147,6 @@ class IncidentResource extends Resource
                 ])->columnSpanFull(),
             ])
             ->columns(4);
-    }
-
-    /**
-     * Get components grouped by their component group for incident selection.
-     *
-     * @return array<string, array<int, string>>
-     */
-    public static function getComponentOptions(?Incident $excludeAttachedTo = null): array
-    {
-        $query = Component::query()
-            ->with('group')
-            ->leftJoin('component_groups', 'components.component_group_id', '=', 'component_groups.id')
-            ->orderByRaw('component_groups.id is null')
-            ->orderBy('component_groups.order')
-            ->orderBy('component_groups.name')
-            ->orderBy('components.order')
-            ->orderBy('components.name')
-            ->select('components.*');
-
-        if ($excludeAttachedTo instanceof Incident) {
-            $query->whereNotIn('components.id', $excludeAttachedTo->components()->pluck('components.id'));
-        }
-
-        return $query
-            ->get()
-            ->groupBy(function (Component $component): string {
-                $group = $component->group;
-
-                return $group instanceof ComponentGroup
-                    ? $group->name
-                    : __('cachet::component.list.ungrouped');
-            })
-            ->map(fn ($components): array => $components->pluck('name', 'id')->all())
-            ->all();
     }
 
     public static function table(Table $table): Table

--- a/src/Filament/Resources/Incidents/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Incidents/RelationManagers/ComponentsRelationManager.php
@@ -3,8 +3,7 @@
 namespace Cachet\Filament\Resources\Incidents\RelationManagers;
 
 use Cachet\Enums\ComponentStatusEnum;
-use Cachet\Filament\Resources\Incidents\IncidentResource;
-use Cachet\Models\Incident;
+use Cachet\Filament\Components\ComponentOptions;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
@@ -66,11 +65,7 @@ class ComponentsRelationManager extends RelationManager
                         Select::make('recordId')
                             ->label(trans_choice('cachet::component.resource_label', 2))
                             ->placeholder(__('cachet::component.attach.placeholder'))
-                            ->options(function (): array {
-                                $owner = $this->getOwnerRecord();
-
-                                return IncidentResource::getComponentOptions($owner instanceof Incident ? $owner : null);
-                            })
+                            ->options(fn (): array => ComponentOptions::forSelect($this->getOwnerRecord()))
                             ->searchable()
                             ->multiple()
                             ->required(),

--- a/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
@@ -3,6 +3,7 @@
 namespace Cachet\Filament\Resources\Schedules\RelationManagers;
 
 use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Components\ComponentOptions;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
@@ -20,7 +21,7 @@ class ComponentsRelationManager extends RelationManager
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string
     {
-        return __('Components');
+        return trans_choice('cachet::component.resource_label', 2);
     }
 
     public function form(Schema $schema): Schema
@@ -35,24 +36,27 @@ class ComponentsRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('name')
-            ->modelLabel(__('Component'))
-            ->pluralModelLabel(__('Components'))
+            ->modelLabel(trans_choice('cachet::component.resource_label', 1))
+            ->pluralModelLabel(trans_choice('cachet::component.resource_label', 2))
             ->columns([
                 TextColumn::make('name')
-                    ->label(__('Name')),
+                    ->label(__('cachet::component.list.headers.name')),
             ])
             ->filters([
                 //
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->preloadRecordSelect()
-                    ->recordSelect(
-                        fn (Select $select) => $select->placeholder(__('Select a component')),
-                    )
+                    ->modalHeading(__('cachet::component.attach.heading'))
                     ->multiple()
-                    ->schema(fn (AttachAction $action): array => [
-                        $action->getRecordSelect(),
+                    ->form(fn (): array => [
+                        Select::make('recordId')
+                            ->label(trans_choice('cachet::component.resource_label', 2))
+                            ->placeholder(__('cachet::component.attach.placeholder'))
+                            ->options(fn (): array => ComponentOptions::forSelect($this->getOwnerRecord()))
+                            ->searchable()
+                            ->multiple()
+                            ->required(),
                         Select::make('component_status')
                             ->options(ComponentStatusEnum::class)
                             ->default(ComponentStatusEnum::under_maintenance->value)

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -7,6 +7,7 @@ use Cachet\Cachet;
 use Cachet\Data\Requests\ScheduleUpdate\CreateScheduleUpdateRequestData;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\ScheduleStatusEnum;
+use Cachet\Filament\Components\ComponentOptions;
 use Cachet\Filament\Resources\Schedules\Pages\CreateSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\EditSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\ListSchedules;
@@ -78,11 +79,11 @@ class ScheduleResource extends Resource
                         ->addActionLabel(__('cachet::schedule.form.add_component.action_label'))
                         ->schema([
                             Select::make('component_id')
+                                ->label(__('cachet::schedule.form.add_component.component_label'))
                                 ->preload()
                                 ->required()
-                                ->relationship('component', 'name')
-                                ->disableOptionsWhenSelectedInSiblingRepeaterItems()
-                                ->label(__('cachet::schedule.form.add_component.component_label')),
+                                ->options(fn (): array => ComponentOptions::forSelect())
+                                ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
                             Select::make('component_status')
                                 ->options(ComponentStatusEnum::class)
                                 ->default(ComponentStatusEnum::under_maintenance->value)

--- a/tests/Feature/Filament/Resources/IncidentResourceTest.php
+++ b/tests/Feature/Filament/Resources/IncidentResourceTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature\Filament\Resources;
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Enums\IncidentStatusEnum;
 use Cachet\Enums\ResourceVisibilityEnum;
-use Cachet\Filament\Resources\Incidents\IncidentResource;
+use Cachet\Filament\Components\ComponentOptions;
 use Cachet\Filament\Resources\Incidents\Pages\CreateIncident;
 use Cachet\Filament\Resources\Incidents\Pages\EditIncident;
 use Cachet\Filament\Resources\Incidents\Pages\ListIncidents;
@@ -147,7 +147,7 @@ it('excludes already attached components from the attach action options', functi
 
     $incident->components()->attach($attached->id, ['component_status' => ComponentStatusEnum::operational->value]);
 
-    $options = IncidentResource::getComponentOptions($incident);
+    $options = ComponentOptions::forSelect($incident);
 
     expect(collect($options)->flatten()->all())->not->toContain('Already Attached');
 });

--- a/tests/Feature/Filament/Resources/ScheduleResourceTest.php
+++ b/tests/Feature/Filament/Resources/ScheduleResourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Filament\Resources;
 
 use Cachet\Enums\ComponentStatusEnum;
 use Cachet\Filament\Components\ComponentOptions;
+use Cachet\Filament\Resources\Schedules\Pages\CreateSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\EditSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\ListSchedules;
 use Cachet\Models\Component;
@@ -74,4 +75,22 @@ it('groups schedule component options by component group', function () {
         ->toHaveKey(__('cachet::component.list.ungrouped'))
         ->and($options['API Services'])->toContain('API')
         ->and($options[__('cachet::component.list.ungrouped')])->toContain('Standalone Service');
+});
+
+it('groups component selections by component group when creating a schedule', function () {
+    $firstGroup = ComponentGroup::factory()->create(['name' => 'API Services', 'order' => 1]);
+    $secondGroup = ComponentGroup::factory()->create(['name' => 'Web Services', 'order' => 2]);
+
+    Component::factory()->for($firstGroup, 'group')->create(['name' => 'API']);
+    Component::factory()->for($secondGroup, 'group')->create(['name' => 'Web']);
+    Component::factory()->create(['name' => 'Standalone Service']);
+
+    livewire(CreateSchedule::class)
+        ->fillForm([
+            'scheduleComponents' => [['component_id' => null]],
+        ])
+        ->assertSeeInOrder(['API Services', 'Web Services', __('cachet::component.list.ungrouped')])
+        ->assertSee('API')
+        ->assertSee('Web')
+        ->assertSee('Standalone Service');
 });

--- a/tests/Feature/Filament/Resources/ScheduleResourceTest.php
+++ b/tests/Feature/Filament/Resources/ScheduleResourceTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Filament\Resources;
 
+use Cachet\Enums\ComponentStatusEnum;
+use Cachet\Filament\Components\ComponentOptions;
 use Cachet\Filament\Resources\Schedules\Pages\EditSchedule;
 use Cachet\Filament\Resources\Schedules\Pages\ListSchedules;
+use Cachet\Models\Component;
+use Cachet\Models\ComponentGroup;
 use Cachet\Models\Schedule;
 use Filament\Facades\Filament;
 use Workbench\App\User;
@@ -45,4 +49,29 @@ it('sorts schedules by their computed status', function () {
     livewire(ListSchedules::class)
         ->sortTable('status')
         ->assertCanSeeTableRecords([$upcoming, $inProgress, $complete], inOrder: true);
+});
+
+it('excludes already attached components from the schedule attach action options', function () {
+    $schedule = Schedule::factory()->create();
+    $attached = Component::factory()->create(['name' => 'Already Attached']);
+
+    $schedule->components()->attach($attached->id, ['component_status' => ComponentStatusEnum::operational->value]);
+
+    $options = ComponentOptions::forSelect($schedule);
+
+    expect(collect($options)->flatten()->all())->not->toContain('Already Attached');
+});
+
+it('groups schedule component options by component group', function () {
+    $firstGroup = ComponentGroup::factory()->create(['name' => 'API Services', 'order' => 1]);
+    Component::factory()->for($firstGroup, 'group')->create(['name' => 'API']);
+    Component::factory()->create(['name' => 'Standalone Service']);
+
+    $options = ComponentOptions::forSelect();
+
+    expect($options)
+        ->toHaveKey('API Services')
+        ->toHaveKey(__('cachet::component.list.ungrouped'))
+        ->and($options['API Services'])->toContain('API')
+        ->and($options[__('cachet::component.list.ungrouped')])->toContain('Standalone Service');
 });


### PR DESCRIPTION
# Descriptions
- Similar to #443, added components grouping to the edit schedule attach modal
- Refactor the component options into its own class, `ComponentOptions`, and reuse it across edit schedule and edit incident attach components modal
# Screenshots
<img width="960" height="532" alt="image" src="https://github.com/user-attachments/assets/7d7bd7eb-e583-4ffc-a4d9-0d42886180a2" />
