### PR TITLE
Protect Testbench asset sources

### DIFF
--- a/tests/Unit/Commands/AssetsCommandTest.php
+++ b/tests/Unit/Commands/AssetsCommandTest.php
@@ -3,15 +3,23 @@
 use Illuminate\Support\Facades\File;
 
 it('publishes the assets', function () {
+    $originalPublicPath = public_path();
+    $testingPublicPath = storage_path('framework/testing/cachet-assets-'.getmypid());
+
+    $this->app->usePublicPath($testingPublicPath);
+
     $target = public_path('vendor/cachethq/cachet');
-    File::deleteDirectory($target);
 
-    $this->artisan('cachet:assets')
-        ->expectsOutput('Cachet assets published.')
-        ->assertExitCode(0);
+    try {
+        $this->artisan('cachet:assets')
+            ->expectsOutput('Cachet assets published.')
+            ->assertExitCode(0);
 
-    expect(File::isDirectory($target))->toBeTrue()
-        ->and(File::exists($target.'/favicon.ico'))->toBeTrue();
+        expect(File::isDirectory($target))->toBeTrue()
+            ->and(File::exists($target.'/favicon.ico'))->toBeTrue();
+    } finally {
+        $this->app->usePublicPath($originalPublicPath);
 
-    File::deleteDirectory($target);
+        File::deleteDirectory($testingPublicPath);
+    }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,39 +1,42 @@
-import { cpSync, existsSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, realpathSync, rmSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import laravel from 'laravel-vite-plugin'
-import tailwindcss from "@tailwindcss/vite"
+import tailwindcss from '@tailwindcss/vite'
 
 /**
  * Mirror the compiled assets into the Testbench skeleton after each build.
  */
 function syncTestbenchAssets() {
-  const source = 'public/build'
-  const target = 'vendor/orchestra/testbench-core/laravel/public/vendor/cachethq/cachet/build'
+    const sourceRoot = 'public'
+    const targetRoot = 'vendor/orchestra/testbench-core/laravel/public/vendor/cachethq/cachet'
+    const source = `${sourceRoot}/build`
+    const target = `${targetRoot}/build`
 
-  return {
-    name: 'cachet-sync-testbench-assets',
-    apply: 'build',
-    closeBundle() {
-      if (!existsSync(`${target}/..`)) {
-        return
-      }
+    return {
+        name: 'cachet-sync-testbench-assets',
+        apply: 'build',
+        closeBundle() {
+            if (!existsSync(targetRoot)) {
+                return
+            }
 
-      rmSync(target, { recursive: true, force: true })
-      cpSync(source, target, { recursive: true })
-    },
-  }
+            // Testbench may expose the package public directory through a symlink.
+            if (realpathSync(sourceRoot) === realpathSync(targetRoot)) {
+                return
+            }
+
+            rmSync(target, { recursive: true, force: true })
+            cpSync(source, target, { recursive: true })
+        },
+    }
 }
 
 export default defineConfig({
-  plugins: [
-    laravel({
-      input: [
-        'resources/css/cachet.css',
-        'resources/css/dashboard/theme.css',
-        'resources/js/cachet.js',
-      ],
-    }),
-    tailwindcss(),
-    syncTestbenchAssets(),
-  ],
+    plugins: [
+        laravel({
+            input: ['resources/css/cachet.css', 'resources/css/dashboard/theme.css', 'resources/js/cachet.js'],
+        }),
+        tailwindcss(),
+        syncTestbenchAssets(),
+    ],
 })


### PR DESCRIPTION
## Summary

- skip Testbench asset mirroring when the target resolves to the package public directory
- isolate the asset publishing test from Testbench symlinks and parallel workers

## Tests

- `npm run build`
- `composer test:lint`
- `vendor/bin/pest tests/Unit/Commands/AssetsCommandTest.php tests/Unit/Mail/TestMailTest.php --compact`
- `vendor/bin/pest --parallel --processes=10 --ci --compact --passthru-php="-d memory_limit=512M"` (1,122 passed; 2 todos)