### PR TITLE
Replace select with toggle buttons for component status and fix the under maintenance icon color

### DIFF
--- a/resources/svg/component-under-maintenance.svg
+++ b/resources/svg/component-under-maintenance.svg
@@ -2,7 +2,7 @@
      width="20pt" height="20pt" viewBox="0 0 128.000000 128.000000"
      preserveAspectRatio="xMidYMid meet">
     <g transform="translate(0.000000,128.000000) scale(0.100000,-0.100000)"
-       fill="#000000" stroke="none">
+       fill="currentColor" stroke="none">
         <path d="M913 1250 c-66 -23 -109 -54 -127 -88 -7 -15 -19 -65 -25 -112 l-12
 -85 -77 -77 -77 -78 -67 67 c-65 65 -68 69 -68 116 0 27 -7 61 -16 76 -16 26
 -239 179 -277 189 -13 3 -36 -13 -78 -54 -32 -32 -59 -64 -59 -72 0 -7 38 -71

--- a/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
+++ b/src/Filament/Resources/Schedules/RelationManagers/ComponentsRelationManager.php
@@ -9,6 +9,7 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\ToggleButtons;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -57,10 +58,12 @@ class ComponentsRelationManager extends RelationManager
                             ->searchable()
                             ->multiple()
                             ->required(),
-                        Select::make('component_status')
+                        ToggleButtons::make('component_status')
                             ->options(ComponentStatusEnum::class)
                             ->default(ComponentStatusEnum::under_maintenance->value)
                             ->required()
+                            ->inline()
+                            ->columnSpanFull()
                             ->label(__('cachet::schedule.form.add_component.status_label')),
                     ]),
             ])

--- a/src/Filament/Resources/Schedules/ScheduleResource.php
+++ b/src/Filament/Resources/Schedules/ScheduleResource.php
@@ -27,6 +27,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\ToggleButtons;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
@@ -84,11 +85,12 @@ class ScheduleResource extends Resource
                                 ->required()
                                 ->options(fn (): array => ComponentOptions::forSelect())
                                 ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
-                            Select::make('component_status')
+                            ToggleButtons::make('component_status')
+                                ->label(__('cachet::schedule.form.add_component.status_label'))
+                                ->inline()
                                 ->options(ComponentStatusEnum::class)
                                 ->default(ComponentStatusEnum::under_maintenance->value)
-                                ->required()
-                                ->label(__('cachet::schedule.form.add_component.status_label')),
+                                ->required(),
                         ])
                         ->label(__('cachet::schedule.form.add_component.header'))
                         ->columnSpanFull(),


### PR DESCRIPTION
# Descriptions
- Replace Select with ToggleButtons for component_status in schedule create form and attach modal, matching the incident resource pattern
- Fix under-maintenance SVG icon always rendering black by changing hardcoded fill to currentColor. This issue is very noticeable on the dark mode
# Screenshots
- Under maintenance icon with this change:
<img width="653" height="114" alt="image" src="https://github.com/user-attachments/assets/4ca3a135-8dbe-4b3b-9781-7c5bdd55cd46" />

- Component status on the create schedule with this change:
<img width="765" height="280" alt="image" src="https://github.com/user-attachments/assets/32266777-78c7-49a5-9a71-c8875f4a2583" />

- Component status on the attach components modal on the edit schedule with this change:
<img width="677" height="363" alt="image" src="https://github.com/user-attachments/assets/6aea5fa6-fe39-4f1f-963f-ec1c1ea8d8e3" />
